### PR TITLE
Fix opening lease

### DIFF
--- a/contracts/lease/src/contract/state/opening/transfer_out.rs
+++ b/contracts/lease/src/contract/state/opening/transfer_out.rs
@@ -1,7 +1,8 @@
-use cosmwasm_std::{Deps, DepsMut, Env, Timestamp};
+use cosmwasm_std::{Deps, DepsMut, Env, QuerierWrapper, Timestamp};
 use sdk::neutron_sdk::sudo::msg::SudoMsg;
 use serde::{Deserialize, Serialize};
 
+use finance::zero::Zero;
 use lpp::stub::lender::LppLenderRef;
 use oracle::stub::OracleRef;
 use platform::{batch::Batch, ica::HostAccount};
@@ -16,6 +17,8 @@ use crate::{
     error::ContractResult,
 };
 
+type TransfersNb = u8;
+
 #[derive(Serialize, Deserialize)]
 pub struct TransferOut {
     form: NewLeaseForm,
@@ -23,6 +26,7 @@ pub struct TransferOut {
     downpayment: DownpaymentCoin,
     loan: OpenLoanRespResult,
     deps: (LppLenderRef, OracleRef),
+    nb_completed: TransfersNb, // have to track the responses because each transfer is a separate msg
 }
 
 impl TransferOut {
@@ -39,26 +43,30 @@ impl TransferOut {
             downpayment,
             loan,
             deps,
+            nb_completed: TransfersNb::ZERO,
         }
     }
 
     //TODO define a State trait with `fn enter(&self, deps: &Deps)` and
     //simplify the TransferOut::on_success return type to `impl State`
     pub(super) fn enter_state(&self, now: Timestamp) -> ContractResult<Batch> {
+        debug_assert_eq!(self.nb_completed, TransfersNb::ZERO);
         let mut sender = self.dex_account.transfer_to(now);
         sender.send(&self.downpayment)?;
         sender.send(&self.loan.principal)?;
         Ok(sender.into())
     }
-}
 
-impl Controller for TransferOut {
-    fn sudo(self, deps: &mut DepsMut, _env: Env, msg: SudoMsg) -> ContractResult<Response> {
-        match msg {
-            SudoMsg::Response {
-                request: _,
-                data: _,
-            } => {
+    fn on_response(self, querier: &QuerierWrapper) -> ContractResult<Response> {
+        match self.nb_completed {
+            0 => {
+                let next_state = Self {
+                    nb_completed: self.nb_completed + 1,
+                    ..self
+                };
+                Ok(Response::from(Batch::default(), next_state))
+            }
+            1 => {
                 let next_state = BuyAsset::new(
                     self.form,
                     self.dex_account,
@@ -66,8 +74,23 @@ impl Controller for TransferOut {
                     self.loan,
                     self.deps,
                 );
-                let batch = next_state.enter_state(&deps.querier)?;
+                let batch = next_state.enter_state(querier)?;
                 Ok(Response::from(batch, next_state))
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Controller for TransferOut {
+    fn sudo(self, deps: &mut DepsMut, _env: Env, msg: SudoMsg) -> ContractResult<Response> {
+        match msg {
+            SudoMsg::Response { request: _, data } => {
+                deps.api.debug(&format!(
+                    "[Lease][TransferOut] receive ack '{}'",
+                    data.to_base64()
+                ));
+                self.on_response(&deps.querier)
             }
             SudoMsg::Timeout { request: _ } => todo!(),
             SudoMsg::Error {

--- a/packages/swap/src/trx.rs
+++ b/packages/swap/src/trx.rs
@@ -20,7 +20,6 @@ use crate::{
 };
 
 const REQUEST_MSG_TYPE: &str = "/osmosis.gamm.v1beta1.MsgSwapExactAmountIn";
-const RESPONSE_MSG_TYPE: &str = "/osmosis.gamm.v1beta1.MsgSwapExactAmountInResponse";
 
 pub fn exact_amount_in<G>(
     trx: &mut Transaction,
@@ -61,7 +60,7 @@ where
         .next()
         .ok_or_else(|| Error::MissingResponse("swap of exact amount request".into()))?;
     let amount =
-        trx::decode_msg_response::<_, MsgSwapExactAmountInResponse>(resp, RESPONSE_MSG_TYPE)?
+        trx::decode_msg_response::<_, MsgSwapExactAmountInResponse>(resp, REQUEST_MSG_TYPE)?
             .token_out_amount;
     Amount::from_str(&amount).map_err(|_| Error::InvalidAmount(amount))
 }
@@ -73,7 +72,7 @@ pub fn build_exact_amount_in_resp(amount_out: Amount) -> MsgData {
         token_out_amount: amount_out.to_string(),
     };
     MsgData {
-        msg_type: RESPONSE_MSG_TYPE.into(),
+        msg_type: REQUEST_MSG_TYPE.into(),
         data: resp.encode_to_vec(),
     }
 }

--- a/tests/src/common/lease_wrapper.rs
+++ b/tests/src/common/lease_wrapper.rs
@@ -263,6 +263,8 @@ pub fn complete_lease_initialization<Lpn>(
         Lpn::BANK_SYMBOL
     );
 
+    // TransferOut sends two IBC transfers so expect two requests
+    send_blank_response(mock_app, lease_addr);
     send_blank_response(mock_app, lease_addr);
 
     {


### PR DESCRIPTION
Address the following discrepancies in the open lease protocol:
- the transfer out is composed of two cosmos messages so have to expect two responses, not just one, even though they are sent together
- the swap trx response contains responses to each swap request pointed to by the request type, not as we thought, the response type