### PR TITLE
chore(oracle): Updated `oracle` contract's version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,7 +779,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "oracle"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "access-control",
  "cosmwasm-std",

--- a/contracts/oracle/Cargo.toml
+++ b/contracts/oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oracle"
-version = "0.4.4"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Missed in #98 