### PR TITLE
fix: Oracle dispatch error & minor macro refactor

### DIFF
--- a/contracts/oracle/src/contract/config.rs
+++ b/contracts/oracle/src/contract/config.rs
@@ -37,7 +37,7 @@ mod tests {
             Usdc::TICKER.to_string(),
             60,
             Percent::from_percent(50),
-            swap_tree!(Usdc::TICKER, (1, Cro::TICKER)),
+            swap_tree!({ base: Usdc::TICKER }, (1, Cro::TICKER)),
         );
         let (mut deps, _info) = setup_test(msg);
 
@@ -83,7 +83,7 @@ mod tests {
     fn config_supported_pairs() {
         let (mut deps, _info) = setup_test(dummy_default_instantiate_msg());
 
-        let test_tree = swap_tree!((1, Cro::TICKER), (2, Osmo::TICKER));
+        let test_tree = swap_tree!({ base: Usdc::TICKER }, (1, Cro::TICKER), (2, Osmo::TICKER));
 
         let res = sudo(
             deps.as_mut(),
@@ -127,7 +127,7 @@ mod tests {
     fn invalid_supported_pairs() {
         let (mut deps, _info) = setup_test(dummy_default_instantiate_msg());
 
-        let test_tree = swap_tree!((1, Cro::TICKER), (2, Cro::TICKER));
+        let test_tree = swap_tree!({ base: Usdc::TICKER }, (1, Cro::TICKER), (2, Cro::TICKER));
 
         let Response {
             messages,

--- a/contracts/oracle/src/contract/config.rs
+++ b/contracts/oracle/src/contract/config.rs
@@ -37,7 +37,7 @@ mod tests {
             Usdc::TICKER.to_string(),
             60,
             Percent::from_percent(50),
-            swap_tree!((1, Cro::TICKER)),
+            swap_tree!(Usdc::TICKER, (1, Cro::TICKER)),
         );
         let (mut deps, _info) = setup_test(msg);
 

--- a/contracts/oracle/src/contract/mod.rs
+++ b/contracts/oracle/src/contract/mod.rs
@@ -171,7 +171,7 @@ mod tests {
             Usdc::TICKER.to_string(),
             60,
             Percent::from_percent(50),
-            swap_tree!((1, Osmo::TICKER)),
+            swap_tree!(Usdc::TICKER, (1, Osmo::TICKER)),
         );
         let (deps, _info) = setup_test(msg);
 

--- a/contracts/oracle/src/contract/mod.rs
+++ b/contracts/oracle/src/contract/mod.rs
@@ -171,7 +171,7 @@ mod tests {
             Usdc::TICKER.to_string(),
             60,
             Percent::from_percent(50),
-            swap_tree!(Usdc::TICKER, (1, Osmo::TICKER)),
+            swap_tree!({ base: Usdc::TICKER }, (1, Osmo::TICKER)),
         );
         let (deps, _info) = setup_test(msg);
 

--- a/contracts/oracle/src/contract/oracle/mod.rs
+++ b/contracts/oracle/src/contract/oracle/mod.rs
@@ -257,10 +257,12 @@ mod tests {
             .store(storage)
             .unwrap();
 
-        SupportedPairs::<BaseCurrency>::new(swap_tree!(Usdc::TICKER, (1, Nls::TICKER)).into_tree())
-            .unwrap()
-            .save(storage)
-            .unwrap();
+        SupportedPairs::<BaseCurrency>::new(
+            swap_tree!({ base: Usdc::TICKER }, (1, Nls::TICKER)).into_tree(),
+        )
+        .unwrap()
+        .save(storage)
+        .unwrap();
     }
 
     #[track_caller]

--- a/contracts/oracle/src/contract/oracle/mod.rs
+++ b/contracts/oracle/src/contract/oracle/mod.rs
@@ -182,6 +182,9 @@ mod test_normalized_price_not_found {
 
     const NOW: Timestamp = Timestamp::from_seconds(1);
 
+    const PRICE_BASE: NlsCoin = Coin::new(1);
+    const PRICE_QUOTE: UsdcCoin = Coin::new(1);
+
     #[test]
     fn test() {
         let mut storage: MockStorage = MockStorage::new();
@@ -237,11 +240,8 @@ mod test_normalized_price_not_found {
             .try_add_price_alarm::<BaseCurrency>(
                 Addr::unchecked("1"),
                 Alarm::new(
-                    SpotPrice::new(NlsCoin::new(1).into(), UsdcCoin::new(1).into()),
-                    Some(SpotPrice::new(
-                        NlsCoin::new(1).into(),
-                        UsdcCoin::new(2).into(),
-                    )),
+                    SpotPrice::new(PRICE_BASE.into(), PRICE_QUOTE.into()),
+                    Some(SpotPrice::new(PRICE_BASE.into(), PRICE_QUOTE.into())),
                 ),
             )
             .unwrap();
@@ -254,7 +254,7 @@ mod test_normalized_price_not_found {
                 storage,
                 NOW,
                 &Addr::unchecked("feeder"),
-                &[price::total_of(NlsCoin::new(1)).is(UsdcCoin::new(2)).into()],
+                &[price::total_of(PRICE_BASE).is(PRICE_QUOTE).into()],
             )
             .unwrap();
     }

--- a/contracts/oracle/src/contract/oracle/mod.rs
+++ b/contracts/oracle/src/contract/oracle/mod.rs
@@ -257,12 +257,10 @@ mod tests {
             .store(storage)
             .unwrap();
 
-        SupportedPairs::<BaseCurrency>::new(
-            swap_tree!(Usdc::TICKER, (1, Nls::TICKER)).into_tree(),
-        )
-        .unwrap()
-        .save(storage)
-        .unwrap();
+        SupportedPairs::<BaseCurrency>::new(swap_tree!(Usdc::TICKER, (1, Nls::TICKER)).into_tree())
+            .unwrap()
+            .save(storage)
+            .unwrap();
     }
 
     #[track_caller]

--- a/contracts/oracle/src/contract/oracle/mod.rs
+++ b/contracts/oracle/src/contract/oracle/mod.rs
@@ -231,8 +231,6 @@ mod test_normalized_price_not_found {
 
     #[track_caller]
     fn add_alarm(storage: &mut dyn Storage) {
-        let storage: &mut dyn Storage = storage;
-
         let mut alarms: MarketAlarms<'_, &mut dyn Storage> = MarketAlarms::new(storage);
 
         alarms
@@ -273,8 +271,6 @@ mod test_normalized_price_not_found {
 
     #[track_caller]
     fn deliver(storage: &mut dyn Storage, count: u32) {
-        let storage: &mut dyn Storage = storage;
-
         let mut alarms: MarketAlarms<'_, &mut dyn Storage> = MarketAlarms::new(storage);
 
         for _ in 0..count {

--- a/contracts/oracle/src/contract/oracle/mod.rs
+++ b/contracts/oracle/src/contract/oracle/mod.rs
@@ -258,7 +258,7 @@ mod tests {
             .unwrap();
 
         SupportedPairs::<BaseCurrency>::new(
-            swap_tree!((1, Nls::TICKER)).into_tree(),
+            swap_tree!(Usdc::TICKER, (1, Nls::TICKER)).into_tree(),
         )
         .unwrap()
         .save(storage)

--- a/contracts/oracle/src/macros.rs
+++ b/contracts/oracle/src/macros.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! swap_tree {
-    ($base_currency: expr, $(($id: literal, $currency: expr $(,)?)),+ $(,)?) => {
+    ({base: $base_currency: expr}, $(($id: literal, $currency: expr $(,)?)),+ $(,)?) => {
         serde_json_wasm::from_str::<::tree::HumanReadableTree<::swap::SwapTarget>>(&::tree::tree_json! {
             value: format!("[0, {:?}]", $base_currency),
             children: [

--- a/contracts/oracle/src/macros.rs
+++ b/contracts/oracle/src/macros.rs
@@ -1,8 +1,8 @@
 #[macro_export]
 macro_rules! swap_tree {
-    ($(($id: literal, $currency: expr $(,)?)),+ $(,)?) => {
+    ($base_currency: expr, $(($id: literal, $currency: expr $(,)?)),+ $(,)?) => {
         serde_json_wasm::from_str::<::tree::HumanReadableTree<::swap::SwapTarget>>(&::tree::tree_json! {
-            value: format!("[0, {:?}]", Usdc::TICKER),
+            value: format!("[0, {:?}]", $base_currency),
             children: [
                 $({ value: format!("[{}, {:?}]", $id, $currency) }),+
             ],

--- a/contracts/oracle/src/macros.rs
+++ b/contracts/oracle/src/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! swap_tree {
     ($(($id: literal, $currency: expr $(,)?)),+ $(,)?) => {
-        serde_json_wasm::from_str(&tree::tree_json! {
+        serde_json_wasm::from_str::<::tree::HumanReadableTree<::swap::SwapTarget>>(&::tree::tree_json! {
             value: format!("[0, {:?}]", Usdc::TICKER),
             children: [
                 $({ value: format!("[{}, {:?}]", $id, $currency) }),+

--- a/packages/finance/src/coin/mod.rs
+++ b/packages/finance/src/coin/mod.rs
@@ -88,11 +88,11 @@ where
         debug_assert!(gcd > 0);
 
         debug_assert!(
-            self.amount % gcd != 0,
+            self.amount % gcd == 0,
             "LHS-value's amount is not divisible by the GCD!"
         );
         debug_assert!(
-            other.amount % gcd != 0,
+            other.amount % gcd == 0,
             "RHS-value's amount is not divisible by the GCD!"
         );
 

--- a/packages/finance/src/coin/mod.rs
+++ b/packages/finance/src/coin/mod.rs
@@ -43,10 +43,6 @@ where
         self.amount == Zero::ZERO
     }
 
-    pub const fn into_amount(self) -> Amount {
-        self.amount
-    }
-
     #[track_caller]
     pub fn checked_add(self, rhs: Self) -> Option<Self> {
         let may_amount = self.amount.checked_add(rhs.amount);

--- a/packages/finance/src/coin/mod.rs
+++ b/packages/finance/src/coin/mod.rs
@@ -53,8 +53,8 @@ where
     }
 
     #[track_caller]
-    pub const fn saturating_sub(self, rhs: Self) -> Self {
-        Self::new(self.amount.saturating_sub(rhs.amount))
+    pub fn saturating_sub(self, rhs: Self) -> Self {
+        self.amount.saturating_sub(rhs.amount).into()
     }
 
     #[track_caller]

--- a/packages/finance/src/coin/mod.rs
+++ b/packages/finance/src/coin/mod.rs
@@ -80,16 +80,21 @@ where
     where
         OtherC: Currency,
     {
-        debug_assert!(!self.is_zero() && !other.is_zero());
+        debug_assert!(!self.is_zero(), "LHS-value's amount is zero!");
+        debug_assert!(!other.is_zero(), "RHS-value's amount is zero!");
+
         let gcd: Amount = gcd::binary_u128(self.amount, other.amount);
+
         debug_assert!(gcd > 0);
 
-        #[cfg(debug_assertions)]
-        if self.amount % gcd != 0 {
-            panic!("LHS-value's amount is not divisible by the GCD!");
-        } else if other.amount % gcd != 0 {
-            panic!("RHS-value's amount is not divisible by the GCD!");
-        }
+        debug_assert!(
+            self.amount % gcd != 0,
+            "LHS-value's amount is not divisible by the GCD!"
+        );
+        debug_assert!(
+            other.amount % gcd != 0,
+            "RHS-value's amount is not divisible by the GCD!"
+        );
 
         (
             Self::new(self.amount / gcd),

--- a/packages/finance/src/price/base.rs
+++ b/packages/finance/src/price/base.rs
@@ -1,9 +1,11 @@
-use super::{dto::PriceDTO, Price};
+use currency::{Currency, Group, Symbol};
+
 use crate::{
     coin::{Coin, CoinDTO},
     error::Error,
 };
-use currency::{Currency, Group, Symbol};
+
+use super::{dto::PriceDTO, Price};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct BasePrice<BaseG, QuoteC>

--- a/packages/finance/src/price/mod.rs
+++ b/packages/finance/src/price/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 pub mod base;
 pub mod dto;
 
-pub fn total_of<C>(amount: Coin<C>) -> PriceBuilder<C>
+pub const fn total_of<C>(amount: Coin<C>) -> PriceBuilder<C>
 where
     C: Currency,
 {
@@ -66,27 +66,17 @@ where
 {
     #[track_caller]
     fn new(amount: Coin<C>, amount_quote: Coin<QuoteC>) -> Self {
-        let res: Self = Self::new_inner(amount, amount_quote);
-
-        #[cfg(debug_assertions)]
-        res.invariant_held().unwrap();
-
-        res
-    }
-
-    #[cfg(feature = "testing")]
-    pub const fn unchecked(amount: Coin<C>, amount_quote: Coin<QuoteC>) -> Self {
-        Self::new_inner(amount, amount_quote)
-    }
-
-    const fn new_inner(amount: Coin<C>, amount_quote: Coin<QuoteC>) -> Self {
         let (amount_normalized, amount_quote_normalized): (Coin<C>, Coin<QuoteC>) =
             amount.into_coprime_with(amount_quote);
 
-        Self {
+        let res: Self = Self {
             amount: amount_normalized,
             amount_quote: amount_quote_normalized,
-        }
+        };
+
+        debug_assert_eq!(Ok(()), res.invariant_held());
+
+        res
     }
 
     /// Returns a new [`Price`] which represents identity mapped, one to one, currency pair.

--- a/packages/finance/src/price/mod.rs
+++ b/packages/finance/src/price/mod.rs
@@ -97,14 +97,6 @@ where
         }
     }
 
-    pub const fn base_amount(&self) -> Coin<C> {
-        self.amount
-    }
-
-    pub const fn quote_amount(&self) -> Coin<QuoteC> {
-        self.amount_quote
-    }
-
     /// Price(amount, amount_quote) * Ratio(nominator / denominator) = Price(amount * denominator, amount_quote * nominator)
     /// where the pairs (amount, nominator) and (amount_quote, denominator) are transformed into co-prime numbers.
     /// Please note that Price(amount, amount_quote) is like Ratio(amount_quote / amount).

--- a/packages/marketprice/src/alarms/mod.rs
+++ b/packages/marketprice/src/alarms/mod.rs
@@ -235,7 +235,7 @@ where
             .may_load(self.storage.deref(), subscriber.clone())?;
 
         if let Some(above) = &above {
-            self.alarms_below.replace(
+            self.alarms_above_or_equal.replace(
                 self.storage.deref_mut(),
                 subscriber.clone(),
                 None,

--- a/packages/marketprice/src/alarms/mod.rs
+++ b/packages/marketprice/src/alarms/mod.rs
@@ -401,11 +401,7 @@ pub mod tests {
         type PriceBaseQuote = Price<BaseCurrency, QuoteCurrency>;
 
         const PRICE: PriceBaseQuote = Price::unchecked(Coin::new(1), Coin::new(2));
-
-        const LOWER_PRICE: PriceBaseQuote = Price::unchecked(
-            PRICE.base_amount(),
-            Coin::new(PRICE.quote_amount().into_amount() - 1),
-        );
+        const LOWER_PRICE: PriceBaseQuote = Price::identity();
 
         fn expect_no_alarms<'storage>(
             alarms: &PriceAlarms<'storage, &mut (dyn Storage + 'storage)>,

--- a/tests/src/common/oracle.rs
+++ b/tests/src/common/oracle.rs
@@ -60,7 +60,12 @@ impl Instantiator {
                     Percent::from_percent(75),
                 ),
             },
-            swap_tree: oracle::swap_tree!((1, Osmo::TICKER), (3, Cro::TICKER), (13, Atom::TICKER)),
+            swap_tree: oracle::swap_tree!(
+                { base: Usdc::TICKER },
+                (1, Osmo::TICKER),
+                (3, Cro::TICKER),
+                (13, Atom::TICKER)
+            ),
         };
 
         app.instantiate(


### PR DESCRIPTION
Addition: Minor refactor to `oracle` macro to add the base currency as a parameter.