### PR TITLE
refactor: Cleanup unnecessary impls and bounds

### DIFF
--- a/platform/packages/currency/src/from_symbol_any.rs
+++ b/platform/packages/currency/src/from_symbol_any.rs
@@ -1,5 +1,3 @@
-use serde::{de::DeserializeOwned, Serialize};
-
 use crate::{error::Error, Matcher, MaybeAnyVisitResult, SymbolSlice};
 
 use super::{matcher::Tickers, Currency, Group};
@@ -16,7 +14,7 @@ pub trait AnyVisitor {
 
     fn on<C>(self) -> AnyVisitorResult<Self>
     where
-        C: Currency + Serialize + DeserializeOwned;
+        C: Currency;
 }
 pub trait AnyVisitorPair {
     type Output;
@@ -24,8 +22,8 @@ pub trait AnyVisitorPair {
 
     fn on<C1, C2>(self) -> AnyVisitorPairResult<Self>
     where
-        C1: Currency + Serialize + DeserializeOwned,
-        C2: Currency + Serialize + DeserializeOwned;
+        C1: Currency,
+        C2: Currency;
 }
 
 pub trait GroupVisit: Matcher {
@@ -66,8 +64,6 @@ where
 mod impl_any_tickers {
     use std::marker::PhantomData;
 
-    use serde::{de::DeserializeOwned, Serialize};
-
     use crate::{error::Error, matcher::Tickers, Currency, Group, SymbolSlice};
 
     use super::{AnyVisitor, AnyVisitorPair, AnyVisitorResult, GroupVisit};
@@ -105,7 +101,7 @@ mod impl_any_tickers {
 
         fn on<C1>(self) -> AnyVisitorResult<Self>
         where
-            C1: Currency + Serialize + DeserializeOwned,
+            C1: Currency,
         {
             Tickers.visit_any::<G2, _>(
                 self.ticker2,
@@ -127,7 +123,7 @@ mod impl_any_tickers {
     }
     impl<C1, V> AnyVisitor for SecondTickerVisitor<C1, V>
     where
-        C1: Currency + Serialize + DeserializeOwned,
+        C1: Currency,
         V: AnyVisitorPair,
     {
         type Output = <V as AnyVisitorPair>::Output;
@@ -135,7 +131,7 @@ mod impl_any_tickers {
 
         fn on<C2>(self) -> AnyVisitorResult<Self>
         where
-            C2: Currency + Serialize + DeserializeOwned,
+            C2: Currency,
         {
             self.visitor.on::<C1, C2>()
         }
@@ -202,8 +198,8 @@ mod test {
     where
         G1: Group,
         G2: Group,
-        C1: 'static + Currency,
-        C2: 'static + Currency,
+        C1: Currency,
+        C2: Currency,
     {
         let v_c1_c2 = ExpectPair::<C1, C2>::default();
         assert_eq!(
@@ -216,8 +212,8 @@ mod test {
     where
         G1: Group,
         G2: Group,
-        C1: 'static + Currency,
-        C2: 'static + Currency,
+        C1: Currency,
+        C2: Currency,
     {
         let v_c1_c2 = ExpectPair::<C1, C2>::default();
         assert!(super::visit_any_on_tickers::<G1, G2, _>(C1::TICKER, C2::TICKER, v_c1_c2).is_err());

--- a/platform/packages/currency/src/from_symbol_any.rs
+++ b/platform/packages/currency/src/from_symbol_any.rs
@@ -16,6 +16,7 @@ pub trait AnyVisitor {
     where
         C: Currency;
 }
+
 pub trait AnyVisitorPair {
     type Output;
     type Error;
@@ -45,6 +46,7 @@ pub trait GroupVisit: Matcher {
         G::maybe_visit(self, ticker, visitor)
     }
 }
+
 impl<M> GroupVisit for M where M: Matcher {}
 
 pub fn visit_any_on_tickers<G1, G2, V>(
@@ -77,6 +79,7 @@ mod impl_any_tickers {
         group2: PhantomData<G2>,
         visitor: V,
     }
+
     impl<'a, G2, V> FirstTickerVisitor<'a, G2, V>
     where
         G2: Group,
@@ -90,14 +93,15 @@ mod impl_any_tickers {
             }
         }
     }
+
     impl<'a, G2, V> AnyVisitor for FirstTickerVisitor<'a, G2, V>
     where
         G2: Group,
         V: AnyVisitorPair,
         Error: Into<V::Error>,
     {
-        type Output = <V as AnyVisitorPair>::Output;
-        type Error = <V as AnyVisitorPair>::Error;
+        type Output = V::Output;
+        type Error = V::Error;
 
         fn on<C1>(self) -> AnyVisitorResult<Self>
         where
@@ -121,13 +125,14 @@ mod impl_any_tickers {
         currency1: PhantomData<C1>,
         visitor: V,
     }
+
     impl<C1, V> AnyVisitor for SecondTickerVisitor<C1, V>
     where
         C1: Currency,
         V: AnyVisitorPair,
     {
-        type Output = <V as AnyVisitorPair>::Output;
-        type Error = <V as AnyVisitorPair>::Error;
+        type Output = V::Output;
+        type Error = V::Error;
 
         fn on<C2>(self) -> AnyVisitorResult<Self>
         where

--- a/platform/packages/currency/src/group.rs
+++ b/platform/packages/currency/src/group.rs
@@ -1,8 +1,12 @@
+use std::fmt::Debug;
+
+use sdk::schemars::JsonSchema;
+
 use crate::SymbolSlice;
 
 use super::{matcher::Matcher, AnyVisitor, AnyVisitorResult};
 
-pub trait Group: PartialEq {
+pub trait Group: Debug + Copy + Eq + JsonSchema + 'static {
     const DESCR: &'static str;
 
     fn maybe_visit<M, V>(matcher: &M, symbol: &SymbolSlice, visitor: V) -> MaybeAnyVisitResult<V>

--- a/platform/packages/currency/src/lib.rs
+++ b/platform/packages/currency/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{any::TypeId, fmt::Debug};
 
-use serde::{de::DeserializeOwned, Serialize};
+use sdk::schemars::JsonSchema;
 
 use crate::error::{Error, Result};
 
@@ -31,7 +31,7 @@ pub type SymbolOwned = String;
 // Not extending Serialize + DeserializeOwbed since the serde derive implementations fail to
 // satisfy trait bounds with regards of the lifetimes
 // Foe example, https://stackoverflow.com/questions/70774093/generic-type-that-implements-deserializeowned
-pub trait Currency: Copy + Ord + Default + Debug + 'static {
+pub trait Currency: Debug + Copy + Ord + JsonSchema + Sized + 'static {
     /// Identifier of the currency
     const TICKER: SymbolStatic;
 
@@ -83,7 +83,7 @@ pub fn maybe_visit_any<M, C, V>(
 ) -> MaybeAnyVisitResult<V>
 where
     M: Matcher + ?Sized,
-    C: Currency + Serialize + DeserializeOwned,
+    C: Currency,
     V: AnyVisitor,
 {
     if matcher.match_::<C>(symbol) {

--- a/platform/packages/currency/src/nls.rs
+++ b/platform/packages/currency/src/nls.rs
@@ -8,7 +8,7 @@ use crate::{AnyVisitor, Currency, Group, Matcher, MaybeAnyVisitResult, SymbolSli
 /// - LP rewards
 /// - Relayers' tips
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, JsonSchema)]
-pub struct NlsPlatform;
+pub enum NlsPlatform {}
 impl Currency for NlsPlatform {
     const TICKER: SymbolStatic = "NLS";
     const BANK_SYMBOL: SymbolStatic = "unls";
@@ -18,7 +18,7 @@ impl Currency for NlsPlatform {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
-pub struct Native {}
+pub enum Native {}
 impl Group for Native {
     const DESCR: &'static str = "native";
 

--- a/platform/packages/currency/src/nls.rs
+++ b/platform/packages/currency/src/nls.rs
@@ -1,17 +1,13 @@
-use serde::{Deserialize, Serialize};
-
 use sdk::schemars::{self, JsonSchema};
 
 use crate::{AnyVisitor, Currency, Group, Matcher, MaybeAnyVisitResult, SymbolSlice, SymbolStatic};
 
-#[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize, JsonSchema,
-)]
 /// A 'local'-only 'dex-independent' representation of Nls.
 ///
 /// Intended to be used *only* until the TODO below gets done, and *only* in dex-independent usecases:
 /// - LP rewards
 /// - Relayers' tips
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, JsonSchema)]
 pub struct NlsPlatform;
 impl Currency for NlsPlatform {
     const TICKER: SymbolStatic = "NLS";
@@ -21,8 +17,7 @@ impl Currency for NlsPlatform {
     const DEX_SYMBOL: SymbolStatic = "N/A_N/A_N/A";
 }
 
-#[derive(Deserialize, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Debug))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub struct Native {}
 impl Group for Native {
     const DESCR: &'static str = "native";

--- a/platform/packages/currency/src/nls.rs
+++ b/platform/packages/currency/src/nls.rs
@@ -9,6 +9,7 @@ use crate::{AnyVisitor, Currency, Group, Matcher, MaybeAnyVisitResult, SymbolSli
 /// - Relayers' tips
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, JsonSchema)]
 pub enum NlsPlatform {}
+
 impl Currency for NlsPlatform {
     const TICKER: SymbolStatic = "NLS";
     const BANK_SYMBOL: SymbolStatic = "unls";
@@ -19,6 +20,7 @@ impl Currency for NlsPlatform {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub enum Native {}
+
 impl Group for Native {
     const DESCR: &'static str = "native";
 

--- a/platform/packages/currency/src/test/group.rs
+++ b/platform/packages/currency/src/test/group.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use sdk::schemars::{self, JsonSchema};
 
 use crate::{AnyVisitor, Group, Matcher, MaybeAnyVisitResult, SymbolSlice};
 
@@ -6,7 +6,7 @@ pub type SuperGroupTestC1 = impl_::TestC1;
 pub type SuperGroupTestC2 = impl_::TestC2;
 pub type SubGroupTestC1 = impl_::TestC3;
 
-#[derive(Debug, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub struct SuperGroup {}
 impl Group for SuperGroup {
     const DESCR: &'static str = "super_group";
@@ -22,7 +22,7 @@ impl Group for SuperGroup {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub struct SubGroup {}
 impl Group for SubGroup {
     const DESCR: &'static str = "sub_group";
@@ -39,13 +39,11 @@ impl Group for SubGroup {
 }
 
 mod impl_ {
-    use serde::{Deserialize, Serialize};
+    use sdk::schemars::{self, JsonSchema};
 
     use crate::{Currency, SymbolStatic};
 
-    #[derive(
-        Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize,
-    )]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
     pub struct TestC1;
     impl Currency for TestC1 {
         const TICKER: SymbolStatic = "ticker#1";
@@ -53,9 +51,7 @@ mod impl_ {
         const DEX_SYMBOL: SymbolStatic = "ibc/dex_ticker#1";
     }
 
-    #[derive(
-        Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize,
-    )]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
     pub struct TestC2;
     impl Currency for TestC2 {
         const TICKER: SymbolStatic = "ticker#2";
@@ -63,9 +59,7 @@ mod impl_ {
         const DEX_SYMBOL: SymbolStatic = "ibc/dex_ticker#2";
     }
 
-    #[derive(
-        Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize,
-    )]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
     pub struct TestC3;
     impl Currency for TestC3 {
         const TICKER: SymbolStatic = "ticker#3";

--- a/platform/packages/currency/src/test/group.rs
+++ b/platform/packages/currency/src/test/group.rs
@@ -8,6 +8,7 @@ pub type SubGroupTestC1 = impl_::TestC3;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub enum SuperGroup {}
+
 impl Group for SuperGroup {
     const DESCR: &'static str = "super_group";
 
@@ -24,6 +25,7 @@ impl Group for SuperGroup {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub enum SubGroup {}
+
 impl Group for SubGroup {
     const DESCR: &'static str = "sub_group";
 
@@ -45,6 +47,7 @@ mod impl_ {
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
     pub enum TestC1 {}
+
     impl Currency for TestC1 {
         const TICKER: SymbolStatic = "ticker#1";
         const BANK_SYMBOL: SymbolStatic = "ibc/bank_ticker#1";
@@ -53,6 +56,7 @@ mod impl_ {
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
     pub enum TestC2 {}
+
     impl Currency for TestC2 {
         const TICKER: SymbolStatic = "ticker#2";
         const BANK_SYMBOL: SymbolStatic = "ibc/bank_ticker#2";
@@ -61,6 +65,7 @@ mod impl_ {
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
     pub enum TestC3 {}
+
     impl Currency for TestC3 {
         const TICKER: SymbolStatic = "ticker#3";
         const BANK_SYMBOL: SymbolStatic = "ibc/bank_ticker#3";

--- a/platform/packages/currency/src/test/group.rs
+++ b/platform/packages/currency/src/test/group.rs
@@ -7,7 +7,7 @@ pub type SuperGroupTestC2 = impl_::TestC2;
 pub type SubGroupTestC1 = impl_::TestC3;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
-pub struct SuperGroup {}
+pub enum SuperGroup {}
 impl Group for SuperGroup {
     const DESCR: &'static str = "super_group";
 
@@ -23,7 +23,7 @@ impl Group for SuperGroup {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
-pub struct SubGroup {}
+pub enum SubGroup {}
 impl Group for SubGroup {
     const DESCR: &'static str = "sub_group";
 
@@ -44,7 +44,7 @@ mod impl_ {
     use crate::{Currency, SymbolStatic};
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
-    pub struct TestC1;
+    pub enum TestC1 {}
     impl Currency for TestC1 {
         const TICKER: SymbolStatic = "ticker#1";
         const BANK_SYMBOL: SymbolStatic = "ibc/bank_ticker#1";
@@ -52,7 +52,7 @@ mod impl_ {
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
-    pub struct TestC2;
+    pub enum TestC2 {}
     impl Currency for TestC2 {
         const TICKER: SymbolStatic = "ticker#2";
         const BANK_SYMBOL: SymbolStatic = "ibc/bank_ticker#2";
@@ -60,7 +60,7 @@ mod impl_ {
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
-    pub struct TestC3;
+    pub enum TestC3 {}
     impl Currency for TestC3 {
         const TICKER: SymbolStatic = "ticker#3";
         const BANK_SYMBOL: SymbolStatic = "ibc/bank_ticker#3";

--- a/platform/packages/currency/src/test/mod.rs
+++ b/platform/packages/currency/src/test/mod.rs
@@ -13,6 +13,7 @@ impl<C> Default for Expect<C> {
         Self(PhantomData)
     }
 }
+
 impl<C> AnyVisitor for Expect<C>
 where
     C: 'static,
@@ -27,6 +28,7 @@ where
         Ok(crate::equal::<C, Cin>())
     }
 }
+
 impl<C> SingleVisitor<C> for Expect<C> {
     type Output = bool;
     type Error = Error;
@@ -37,6 +39,7 @@ impl<C> SingleVisitor<C> for Expect<C> {
 }
 
 pub struct ExpectUnknownCurrency;
+
 impl AnyVisitor for ExpectUnknownCurrency {
     type Output = bool;
     type Error = Error;
@@ -72,6 +75,7 @@ where
         Self(PhantomData, PhantomData)
     }
 }
+
 impl<C1, C2> AnyVisitorPair for ExpectPair<C1, C2>
 where
     C1: Currency,

--- a/platform/packages/currency/src/test/mod.rs
+++ b/platform/packages/currency/src/test/mod.rs
@@ -10,7 +10,7 @@ pub struct Expect<C>(PhantomData<C>);
 
 impl<C> Default for Expect<C> {
     fn default() -> Self {
-        Self(Default::default())
+        Self(PhantomData)
     }
 }
 impl<C> AnyVisitor for Expect<C>
@@ -58,16 +58,24 @@ impl<C> SingleVisitor<C> for ExpectUnknownCurrency {
     }
 }
 
-pub struct ExpectPair<C1, C2>(PhantomData<C1>, PhantomData<C2>);
-impl<C1, C2> Default for ExpectPair<C1, C2> {
+pub struct ExpectPair<C1, C2>(PhantomData<C1>, PhantomData<C2>)
+where
+    C1: Currency,
+    C2: Currency;
+
+impl<C1, C2> Default for ExpectPair<C1, C2>
+where
+    C1: Currency,
+    C2: Currency,
+{
     fn default() -> Self {
-        Self(Default::default(), Default::default())
+        Self(PhantomData, PhantomData)
     }
 }
 impl<C1, C2> AnyVisitorPair for ExpectPair<C1, C2>
 where
-    C1: 'static,
-    C2: 'static,
+    C1: Currency,
+    C2: Currency,
 {
     type Output = bool;
     type Error = Error;

--- a/platform/packages/finance/src/coin/dto/mod.rs
+++ b/platform/packages/finance/src/coin/dto/mod.rs
@@ -254,7 +254,7 @@ mod test {
     };
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
-    struct MyTestCurrency;
+    enum MyTestCurrency {}
     impl Currency for MyTestCurrency {
         const TICKER: SymbolStatic = "qwerty";
         const BANK_SYMBOL: SymbolStatic = "ibc/1";
@@ -262,7 +262,7 @@ mod test {
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
-    struct MyTestGroup {}
+    enum MyTestGroup {}
     impl Group for MyTestGroup {
         const DESCR: &'static str = "My Test Group";
 

--- a/platform/packages/finance/src/coin/dto/mod.rs
+++ b/platform/packages/finance/src/coin/dto/mod.rs
@@ -255,6 +255,7 @@ mod test {
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
     enum MyTestCurrency {}
+
     impl Currency for MyTestCurrency {
         const TICKER: SymbolStatic = "qwerty";
         const BANK_SYMBOL: SymbolStatic = "ibc/1";
@@ -263,6 +264,7 @@ mod test {
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
     enum MyTestGroup {}
+
     impl Group for MyTestGroup {
         const DESCR: &'static str = "My Test Group";
 

--- a/platform/packages/finance/src/coin/mod.rs
+++ b/platform/packages/finance/src/coin/mod.rs
@@ -20,9 +20,12 @@ mod serde;
 pub type Amount = u128;
 
 #[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize, JsonSchema,
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
 )]
-pub struct Coin<C> {
+pub struct Coin<C>
+where
+    C: Currency,
+{
     amount: Amount,
     #[serde(skip)]
     ticker: PhantomData<C>,
@@ -100,6 +103,15 @@ where
             Self::new(self.amount / gcd),
             Coin::<OtherC>::new(other.amount / gcd),
         )
+    }
+}
+
+impl<C> Default for Coin<C>
+where
+    C: Currency,
+{
+    fn default() -> Self {
+        Self::ZERO
     }
 }
 
@@ -234,7 +246,10 @@ where
     }
 }
 
-impl<C> AsRef<Self> for Coin<C> {
+impl<C> AsRef<Self> for Coin<C>
+where
+    C: Currency,
+{
     fn as_ref(&self) -> &Self {
         self
     }

--- a/platform/packages/finance/src/coin/serde.rs
+++ b/platform/packages/finance/src/coin/serde.rs
@@ -4,12 +4,13 @@ mod test {
 
     use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-    use crate::coin::Coin;
     use currency::{
         test::{SuperGroupTestC1, SuperGroupTestC2},
         Currency,
     };
     use sdk::cosmwasm_std::{from_json, to_json_vec};
+
+    use crate::coin::Coin;
 
     #[test]
     fn serialize_deserialize() {
@@ -50,6 +51,7 @@ mod test {
     #[test]
     fn serialize_deserialize_as_field() {
         #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        #[serde(bound(serialize = "", deserialize = ""))]
         struct CoinContainer<C>
         where
             C: Currency,

--- a/platform/packages/finance/src/fractionable/duration.rs
+++ b/platform/packages/finance/src/fractionable/duration.rs
@@ -15,7 +15,7 @@ where
 
 impl<C> Fractionable<Coin<C>> for Duration
 where
-    C: Currency + PartialEq + Default + Copy,
+    C: Currency,
 {
     #[track_caller]
     fn safe_mul<F>(self, fraction: &F) -> Self

--- a/platform/packages/finance/src/fractionable/percent.rs
+++ b/platform/packages/finance/src/fractionable/percent.rs
@@ -1,9 +1,10 @@
+use currency::Currency;
+
 use crate::{
     coin::Coin,
     percent::{Percent, Units},
     ratio::Ratio,
 };
-use currency::Currency;
 
 use super::{Fractionable, HigherRank};
 
@@ -27,7 +28,7 @@ impl Fractionable<Units> for Percent {
 
 impl<C> Fractionable<Coin<C>> for Percent
 where
-    C: Currency + PartialEq + Default + Copy,
+    C: Currency,
 {
     #[track_caller]
     fn safe_mul<F>(self, fraction: &F) -> Self

--- a/platform/packages/finance/src/percent/mod.rs
+++ b/platform/packages/finance/src/percent/mod.rs
@@ -45,8 +45,8 @@ impl Percent {
 
     pub fn from_ratio<FractionUnit>(nominator: FractionUnit, denominator: FractionUnit) -> Self
     where
-        FractionUnit: Zero + Debug + Copy + PartialEq,
         Self: Fractionable<FractionUnit>,
+        FractionUnit: Zero + Debug + Copy + PartialEq,
     {
         Rational::new(nominator, denominator).of(Percent::HUNDRED)
     }

--- a/platform/packages/finance/src/price/dto/unchecked.rs
+++ b/platform/packages/finance/src/price/dto/unchecked.rs
@@ -1,13 +1,18 @@
 use serde::Deserialize;
 
-use crate::{coin::CoinDTO, error::Error};
 use currency::Group;
+
+use crate::{coin::CoinDTO, error::Error};
 
 use super::PriceDTO as ValidatedDTO;
 
 /// Brings invariant checking as a step in deserializing a PriceDTO
 #[derive(Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(
+    deny_unknown_fields,
+    rename_all = "snake_case",
+    bound(serialize = "", deserialize = "")
+)]
 pub(super) struct PriceDTO<G, QuoteG>
 where
     G: Group,

--- a/platform/packages/finance/src/price/dto/unchecked.rs
+++ b/platform/packages/finance/src/price/dto/unchecked.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use currency::Group;
+use currency::{visit_any_on_tickers, AnyVisitorPair, AnyVisitorPairResult, Group};
 
 use crate::{coin::CoinDTO, error::Error};
 
@@ -30,11 +30,31 @@ where
     type Error = Error;
 
     fn try_from(dto: PriceDTO<G, QuoteG>) -> Result<Self, Self::Error> {
+        visit_any_on_tickers::<G, QuoteG, _>(
+            dto.amount.ticker(),
+            dto.amount_quote.ticker(),
+            VisitorImpl,
+        )?;
+
         let res = Self {
             amount: dto.amount,
             amount_quote: dto.amount_quote,
         };
+
         res.invariant_held()?;
+
         Ok(res)
+    }
+}
+
+struct VisitorImpl;
+
+impl AnyVisitorPair for VisitorImpl {
+    type Output = ();
+
+    type Error = Error;
+
+    fn on<C1, C2>(self) -> AnyVisitorPairResult<Self> {
+        Ok(())
     }
 }

--- a/platform/packages/finance/src/price/dto/with_price.rs
+++ b/platform/packages/finance/src/price/dto/with_price.rs
@@ -1,5 +1,3 @@
-use serde::{de::DeserializeOwned, Serialize};
-
 use currency::{error::CmdError, AnyVisitorPair, Currency, Group};
 
 use crate::error::Error;
@@ -46,8 +44,8 @@ where
 
     fn on<C1, C2>(self) -> Result<Self::Output, Self::Error>
     where
-        C1: Currency + Serialize + DeserializeOwned,
-        C2: Currency + Serialize + DeserializeOwned,
+        C1: Currency,
+        C2: Currency,
     {
         self.price
             .try_into()

--- a/platform/packages/lpp/src/nlpn.rs
+++ b/platform/packages/lpp/src/nlpn.rs
@@ -1,11 +1,7 @@
-use serde::{Deserialize, Serialize};
-
 use currency::{Currency, SymbolStatic};
 use sdk::schemars::{self, JsonSchema};
 
-#[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize, JsonSchema,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
 pub struct NLpn;
 impl Currency for NLpn {
     // should not be visible

--- a/platform/packages/lpp/src/nlpn.rs
+++ b/platform/packages/lpp/src/nlpn.rs
@@ -2,7 +2,7 @@ use currency::{Currency, SymbolStatic};
 use sdk::schemars::{self, JsonSchema};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
-pub struct NLpn;
+pub enum NLpn {}
 impl Currency for NLpn {
     // should not be visible
     const TICKER: SymbolStatic = "NLpn";

--- a/platform/packages/lpp/src/nlpn.rs
+++ b/platform/packages/lpp/src/nlpn.rs
@@ -3,6 +3,7 @@ use sdk::schemars::{self, JsonSchema};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
 pub enum NLpn {}
+
 impl Currency for NLpn {
     // should not be visible
     const TICKER: SymbolStatic = "NLpn";

--- a/platform/packages/lpp/src/usd.rs
+++ b/platform/packages/lpp/src/usd.rs
@@ -10,6 +10,7 @@ use sdk::schemars::{self, JsonSchema};
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
 )]
 pub enum Usd {}
+
 impl Currency for Usd {
     // should not be visible
     const TICKER: SymbolStatic = "USD";
@@ -21,6 +22,7 @@ pub type CoinUsd = Coin<Usd>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub enum UsdGroup {}
+
 impl Group for UsdGroup {
     const DESCR: &'static str = "usd group";
 

--- a/platform/packages/lpp/src/usd.rs
+++ b/platform/packages/lpp/src/usd.rs
@@ -7,7 +7,7 @@ use currency::{
 use sdk::schemars::{self, JsonSchema};
 
 #[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize, JsonSchema,
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
 )]
 pub struct Usd;
 impl Currency for Usd {
@@ -19,7 +19,7 @@ impl Currency for Usd {
 
 pub type CoinUsd = Coin<Usd>;
 
-#[derive(PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub struct UsdGroup;
 impl Group for UsdGroup {
     const DESCR: &'static str = "usd group";

--- a/platform/packages/lpp/src/usd.rs
+++ b/platform/packages/lpp/src/usd.rs
@@ -9,7 +9,7 @@ use sdk::schemars::{self, JsonSchema};
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
 )]
-pub struct Usd;
+pub enum Usd {}
 impl Currency for Usd {
     // should not be visible
     const TICKER: SymbolStatic = "USD";
@@ -20,7 +20,7 @@ impl Currency for Usd {
 pub type CoinUsd = Coin<Usd>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
-pub struct UsdGroup;
+pub enum UsdGroup {}
 impl Group for UsdGroup {
     const DESCR: &'static str = "usd group";
 

--- a/platform/packages/oracle/src/convert.rs
+++ b/platform/packages/oracle/src/convert.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use serde::Deserialize;
-
 use currency::{Currency, Group};
 use finance::{coin::Coin, price};
 use sdk::cosmwasm_std::QuerierWrapper;
@@ -18,9 +16,9 @@ pub fn to_base<BaseC, BaseG, InC, InG>(
 ) -> Result<Coin<BaseC>, Error>
 where
     BaseC: Currency,
-    BaseG: Group + for<'de> Deserialize<'de>,
+    BaseG: Group,
     InC: Currency,
-    InG: Group + for<'de> Deserialize<'de>,
+    InG: Group,
 {
     struct PriceConvert<BaseC, InC, InG>
     where
@@ -37,7 +35,7 @@ where
     where
         BaseC: Currency,
         InC: Currency,
-        InG: Group + for<'de> Deserialize<'de>,
+        InG: Group,
     {
         type Output = Coin<BaseC>;
         type Error = Error;
@@ -68,18 +66,16 @@ pub fn from_base<BaseC, BaseG, OracleS, OutC, OutG>(
 ) -> Result<Coin<OutC>, Error>
 where
     BaseC: Currency,
-    BaseG: Group + for<'de> Deserialize<'de>,
+    BaseG: Group,
     OracleS: Oracle<BaseC>,
     OutC: Currency,
-    OutG: Group + for<'de> Deserialize<'de>,
+    OutG: Group,
 {
     from_base::PriceConvert::<_, _, OutG>::new(in_amount).do_convert(oracle)
 }
 
 mod from_base {
     use std::marker::PhantomData;
-
-    use serde::Deserialize;
 
     use currency::{Currency, Group};
     use finance::{coin::Coin, price};
@@ -101,7 +97,7 @@ mod from_base {
     where
         BaseC: Currency,
         OutC: Currency,
-        OutG: Group + for<'a> Deserialize<'a>,
+        OutG: Group,
     {
         pub(super) fn new(in_amount: Coin<BaseC>) -> Self {
             Self {

--- a/platform/packages/oracle/src/stub/impl_.rs
+++ b/platform/packages/oracle/src/stub/impl_.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use serde::Deserialize;
-
 use currency::{Currency, Group};
 use finance::price::{dto::PriceDTO, Price};
 use sdk::cosmwasm_std::{Addr, QuerierWrapper};
@@ -90,13 +88,13 @@ impl<'a, OracleBase, OracleBaseG, PriceConverterT> Oracle<OracleBase>
     for OracleStub<'a, OracleBase, OracleBaseG, PriceConverterT>
 where
     OracleBase: Currency,
-    OracleBaseG: Group + for<'de> Deserialize<'de>,
+    OracleBaseG: Group,
     PriceConverterT: PriceConverter,
 {
     fn price_of<C, G>(&self) -> Result<Price<C, OracleBase>>
     where
         C: Currency,
-        G: Group + for<'de> Deserialize<'de>,
+        G: Group,
     {
         if currency::equal::<C, OracleBase>() {
             return Ok(Price::identity());

--- a/platform/packages/oracle/src/stub/mod.rs
+++ b/platform/packages/oracle/src/stub/mod.rs
@@ -16,13 +16,13 @@ use self::impl_::{CheckedConverter, OracleStub};
 mod impl_;
 
 #[cfg(feature = "unchecked-base-currency")]
-pub fn new_unchecked_base_currency_stub<'a, OracleBase, OracleBaseG>(
+pub fn new_unchecked_base_currency_stub<OracleBase, OracleBaseG>(
     oracle: Addr,
-    querier: QuerierWrapper<'a>,
-) -> impl Oracle<OracleBase> + 'a
+    querier: QuerierWrapper<'_>,
+) -> impl Oracle<OracleBase> + '_
 where
     OracleBase: Currency,
-    OracleBaseG: Group + for<'de> Deserialize<'de> + 'a,
+    OracleBaseG: Group,
 {
     use self::impl_::BaseCUncheckedConverter;
 
@@ -40,7 +40,7 @@ where
     fn price_of<C, G>(&self) -> Result<Price<C, OracleBase>>
     where
         C: Currency,
-        G: Group + for<'de> Deserialize<'de>;
+        G: Group;
 }
 
 pub trait WithOracle<OracleBase>
@@ -91,7 +91,7 @@ impl OracleRef {
     ) -> StdResult<V::Output, V::Error>
     where
         OracleBase: Currency,
-        OracleBaseG: Group + for<'de> Deserialize<'de>,
+        OracleBaseG: Group,
         V: WithOracle<OracleBase>,
         Error: Into<V::Error>,
     {

--- a/platform/packages/oracle/src/test.rs
+++ b/platform/packages/oracle/src/test.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "testing")]
 
-use serde::Deserialize;
-
 use currency::{test::SuperGroupTestC1, Currency, Group};
 use finance::{
     coin::Amount,
@@ -32,7 +30,7 @@ where
     fn price_of<C, G>(&self) -> Result<Price<C, BaseC>>
     where
         C: Currency,
-        G: Group + for<'de> Deserialize<'de>,
+        G: Group,
     {
         self.0
             .map(|price| price::total_of(1.into()).is(price.into()))

--- a/platform/packages/platform/src/bank.rs
+++ b/platform/packages/platform/src/bank.rs
@@ -366,6 +366,7 @@ mod test {
     use sdk::{
         cosmwasm_std::{coin as cw_coin, Addr, Coin as CwCoin, Empty, QuerierWrapper},
         cw_multi_test::BasicApp,
+        schemars::{self, JsonSchema},
     };
 
     use crate::{coin_legacy, error::Error};
@@ -468,7 +469,7 @@ mod test {
         let coin = Coin::<ExtraCurrency>::new(AMOUNT);
         let in_coin_1 = coin_legacy::to_cosmwasm(coin);
 
-        #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
         struct MyNiceCurrency {}
         impl Currency for MyNiceCurrency {
             const BANK_SYMBOL: SymbolStatic = "wdd";

--- a/platform/packages/platform/src/bank.rs
+++ b/platform/packages/platform/src/bank.rs
@@ -471,11 +471,13 @@ mod test {
 
         #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
         enum MyNiceCurrency {}
+
         impl Currency for MyNiceCurrency {
             const BANK_SYMBOL: SymbolStatic = "wdd";
             const DEX_SYMBOL: SymbolStatic = "dex3rdf";
             const TICKER: SymbolStatic = "ticedc";
         }
+
         let in_coin_2 = coin_legacy::to_cosmwasm(Coin::<MyNiceCurrency>::new(AMOUNT));
 
         assert_eq!(

--- a/platform/packages/platform/src/bank.rs
+++ b/platform/packages/platform/src/bank.rs
@@ -470,7 +470,7 @@ mod test {
         let in_coin_1 = coin_legacy::to_cosmwasm(coin);
 
         #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
-        struct MyNiceCurrency {}
+        enum MyNiceCurrency {}
         impl Currency for MyNiceCurrency {
             const BANK_SYMBOL: SymbolStatic = "wdd";
             const DEX_SYMBOL: SymbolStatic = "dex3rdf";

--- a/protocol/contracts/lease/src/lease/mod.rs
+++ b/protocol/contracts/lease/src/lease/mod.rs
@@ -29,7 +29,11 @@ pub(crate) mod with_lease_paid;
 // the others could be provided on demand when certain operation is being performed
 // then review the methods that take `&mut self` whether could be transformed into `&self`
 // and those that take `self` into `&mut self` or `&self`
-pub struct Lease<Lpn, Asset, Lpp, Oracle> {
+pub struct Lease<Lpn, Asset, Lpp, Oracle>
+where
+    Lpn: Currency,
+    Asset: Currency,
+{
     addr: Addr,
     customer: Addr,
     position: Position<Asset, Lpn>,
@@ -43,7 +47,11 @@ pub struct IntoDTOResult {
     pub batch: Batch,
 }
 
-impl<Lpn, Asset, LppLoan, Oracle> Lease<Lpn, Asset, LppLoan, Oracle> {
+impl<Lpn, Asset, LppLoan, Oracle> Lease<Lpn, Asset, LppLoan, Oracle>
+where
+    Lpn: Currency,
+    Asset: Currency,
+{
     pub(crate) fn addr(&self) -> &Addr {
         &self.addr
     }

--- a/protocol/contracts/lease/src/lease/paid.rs
+++ b/protocol/contracts/lease/src/lease/paid.rs
@@ -9,7 +9,11 @@ use crate::error::ContractResult;
 
 use super::LeaseDTO;
 
-pub struct Lease<Asset, Lpn> {
+pub struct Lease<Asset, Lpn>
+where
+    Asset: Currency,
+    Lpn: Currency,
+{
     customer: Addr,
     amount: Coin<Asset>,
     lpn: PhantomData<Lpn>,

--- a/protocol/contracts/lease/src/lease/with_lease_deps.rs
+++ b/protocol/contracts/lease/src/lease/with_lease_deps.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use serde::de::DeserializeOwned;
-
 use currencies::{LeaseGroup, Lpns};
 use currency::{self, AnyVisitor, AnyVisitorResult, Currency, GroupVisit, SymbolSlice, Tickers};
 use lpp::stub::{
@@ -73,7 +71,7 @@ where
 
     fn on<C>(self) -> AnyVisitorResult<Self>
     where
-        C: 'static + Currency + DeserializeOwned,
+        C: Currency,
     {
         self.lpp.execute_loan(
             FactoryStage2 {

--- a/protocol/contracts/lease/src/loan/repay.rs
+++ b/protocol/contracts/lease/src/loan/repay.rs
@@ -1,7 +1,7 @@
 use currency::Currency;
 use finance::coin::Coin;
 
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub(crate) struct Receipt<C>
 where
     C: Currency,
@@ -94,6 +94,23 @@ where
         debug_assert_eq!(self.change, Coin::default());
 
         self.change = change;
+    }
+}
+
+impl<C> Default for Receipt<C>
+where
+    C: Currency,
+{
+    fn default() -> Self {
+        Self {
+            previous_margin_paid: Default::default(),
+            current_margin_paid: Default::default(),
+            previous_interest_paid: Default::default(),
+            current_interest_paid: Default::default(),
+            principal_paid: Default::default(),
+            change: Default::default(),
+            close: Default::default(),
+        }
     }
 }
 

--- a/protocol/contracts/lease/src/position/mod.rs
+++ b/protocol/contracts/lease/src/position/mod.rs
@@ -15,7 +15,11 @@ mod spec;
 mod status;
 
 #[cfg_attr(test, derive(Debug))]
-pub struct Position<Asset, Lpn> {
+pub struct Position<Asset, Lpn>
+where
+    Asset: Currency,
+    Lpn: Currency,
+{
     amount: Coin<Asset>,
     spec: Spec<Lpn>,
 }

--- a/protocol/contracts/lease/src/position/spec/mod.rs
+++ b/protocol/contracts/lease/src/position/spec/mod.rs
@@ -16,7 +16,10 @@ use crate::{
 mod dto;
 
 #[cfg_attr(test, derive(Debug))]
-pub struct Spec<Lpn> {
+pub struct Spec<Lpn>
+where
+    Lpn: Currency,
+{
     liability: Liability,
     min_asset: Coin<Lpn>,
     min_transaction: Coin<Lpn>,

--- a/protocol/contracts/leaser/src/cmd/quote.rs
+++ b/protocol/contracts/leaser/src/cmd/quote.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use serde::{de::DeserializeOwned, Serialize};
-
 use currencies::{LeaseGroup, Lpns, PaymentGroup};
 use currency::{AnyVisitor, AnyVisitorResult, Currency, GroupVisit, SymbolOwned, Tickers};
 use finance::{coin::Coin, liability::Liability, percent::Percent, price::total};
@@ -165,7 +163,7 @@ where
 
     fn on<C>(self) -> AnyVisitorResult<Self>
     where
-        C: 'static + Currency + Serialize + DeserializeOwned,
+        C: Currency,
     {
         Tickers
             .maybe_visit_any::<LeaseGroup, _>(
@@ -214,7 +212,7 @@ where
 
     fn on<Asset>(self) -> AnyVisitorResult<Self>
     where
-        Asset: 'static + Currency + DeserializeOwned,
+        Asset: Currency,
     {
         let downpayment_lpn = total(
             self.downpayment,

--- a/protocol/contracts/lpp/src/contract/borrow.rs
+++ b/protocol/contracts/lpp/src/contract/borrow.rs
@@ -1,5 +1,3 @@
-use serde::{de::DeserializeOwned, Serialize};
-
 use currency::Currency;
 use finance::coin::Coin;
 use platform::{
@@ -23,7 +21,7 @@ pub(super) fn try_open_loan<Lpn>(
     amount: Coin<Lpn>,
 ) -> Result<(LoanResponse<Lpn>, MessageResponse)>
 where
-    Lpn: 'static + Currency + Serialize + DeserializeOwned,
+    Lpn: Currency,
 {
     let lease_addr = info.sender;
     let mut lpp = LiquidityPool::<Lpn>::load(deps.storage)?;
@@ -45,7 +43,7 @@ pub(super) fn try_repay_loan<Lpn>(
     info: MessageInfo,
 ) -> Result<(Coin<Lpn>, MessageResponse)>
 where
-    Lpn: 'static + Currency + Serialize + DeserializeOwned,
+    Lpn: Currency,
 {
     let lease_addr = info.sender;
     let repay_amount = bank::received_one(info.funds)?;
@@ -70,7 +68,7 @@ pub(super) fn query_quote<Lpn>(
     quote: Coin<Lpn>,
 ) -> Result<QueryQuoteResponse>
 where
-    Lpn: 'static + Currency + Serialize + DeserializeOwned,
+    Lpn: Currency,
 {
     let lpp = LiquidityPool::<Lpn>::load(deps.storage)?;
 
@@ -82,7 +80,7 @@ where
 
 pub fn query_loan<Lpn>(storage: &dyn Storage, lease_addr: Addr) -> Result<QueryLoanResponse<Lpn>>
 where
-    Lpn: 'static + Currency + Serialize + DeserializeOwned,
+    Lpn: Currency,
 {
     Loan::query(storage, lease_addr)
 }

--- a/protocol/contracts/lpp/src/contract/lender.rs
+++ b/protocol/contracts/lpp/src/contract/lender.rs
@@ -1,5 +1,3 @@
-use serde::{de::DeserializeOwned, Serialize};
-
 use currency::Currency;
 use finance::{coin::Coin, zero::Zero};
 use lpp_platform::NLpn;
@@ -24,7 +22,7 @@ pub(super) fn try_deposit<Lpn>(
     info: MessageInfo,
 ) -> Result<MessageResponse>
 where
-    Lpn: 'static + Currency + DeserializeOwned + Serialize,
+    Lpn: Currency,
 {
     let lender_addr = info.sender;
     let pending_deposit = bank::received_one(info.funds)?;
@@ -52,7 +50,7 @@ where
 
 pub(super) fn deposit_capacity<Lpn>(deps: Deps<'_>, env: Env) -> Result<Option<Coin<Lpn>>>
 where
-    Lpn: 'static + Currency + DeserializeOwned + Serialize,
+    Lpn: Currency,
 {
     LiquidityPool::<Lpn>::load(deps.storage)
         .and_then(|lpp: LiquidityPool<Lpn>| lpp.deposit_capacity(deps.querier, &env, Coin::ZERO))
@@ -65,7 +63,7 @@ pub(super) fn try_withdraw<Lpn>(
     amount_nlpn: Uint128,
 ) -> Result<MessageResponse>
 where
-    Lpn: 'static + Currency + DeserializeOwned + Serialize,
+    Lpn: Currency,
 {
     if amount_nlpn.is_zero() {
         return Err(ContractError::ZeroWithdrawFunds);
@@ -105,7 +103,7 @@ where
 
 pub fn query_ntoken_price<Lpn>(deps: Deps<'_>, env: Env) -> Result<PriceResponse<Lpn>>
 where
-    Lpn: Currency + DeserializeOwned + Serialize,
+    Lpn: Currency,
 {
     LiquidityPool::load(deps.storage).and_then(|lpp| {
         lpp.calculate_price(&deps, &env, Coin::default())

--- a/protocol/contracts/lpp/src/contract/mod.rs
+++ b/protocol/contracts/lpp/src/contract/mod.rs
@@ -1,7 +1,5 @@
 use std::ops::DerefMut as _;
 
-use serde::{de::DeserializeOwned, Serialize};
-
 use access_control::SingleUserAccess;
 use currencies::Lpns;
 use currency::{AnyVisitor, AnyVisitorResult, Currency, GroupVisit, Tickers};
@@ -42,7 +40,7 @@ impl<'a> InstantiateWithLpn<'a> {
     // could be moved directly to on<LPN>()
     fn do_work<Lpn>(mut self) -> Result<()>
     where
-        Lpn: 'static + Currency + Serialize + DeserializeOwned,
+        Lpn: Currency,
     {
         versioning::initialize(self.deps.storage, CONTRACT_VERSION)?;
 
@@ -68,7 +66,7 @@ impl<'a> AnyVisitor for InstantiateWithLpn<'a> {
 
     fn on<Lpn>(self) -> AnyVisitorResult<Self>
     where
-        Lpn: 'static + Currency + DeserializeOwned + Serialize,
+        Lpn: Currency,
     {
         self.do_work::<Lpn>()
     }
@@ -124,7 +122,7 @@ struct ExecuteWithLpn<'a> {
 impl<'a> ExecuteWithLpn<'a> {
     fn do_work<Lpn>(self) -> Result<CwResponse>
     where
-        Lpn: 'static + Currency + Serialize + DeserializeOwned,
+        Lpn: Currency,
     {
         // currency context variants
         match self.msg {
@@ -186,7 +184,7 @@ impl<'a> AnyVisitor for ExecuteWithLpn<'a> {
 
     fn on<Lpn>(self) -> AnyVisitorResult<Self>
     where
-        Lpn: 'static + Currency + DeserializeOwned + Serialize,
+        Lpn: Currency,
     {
         self.do_work::<Lpn>()
     }
@@ -247,7 +245,7 @@ struct QueryWithLpn<'a> {
 impl<'a> QueryWithLpn<'a> {
     fn do_work<Lpn>(self) -> Result<Binary>
     where
-        Lpn: 'static + Currency + Serialize + DeserializeOwned,
+        Lpn: Currency,
     {
         // currency context variants
         let res = match self.msg {
@@ -289,7 +287,7 @@ impl<'a> AnyVisitor for QueryWithLpn<'a> {
 
     fn on<Lpn>(self) -> AnyVisitorResult<Self>
     where
-        Lpn: 'static + Currency + DeserializeOwned + Serialize,
+        Lpn: Currency,
     {
         self.do_work::<Lpn>()
     }

--- a/protocol/contracts/lpp/src/contract/rewards.rs
+++ b/protocol/contracts/lpp/src/contract/rewards.rs
@@ -1,5 +1,3 @@
-use serde::{de::DeserializeOwned, Serialize};
-
 use currency::Currency;
 use lpp_platform::msg::LppBalanceResponse;
 use platform::{
@@ -55,7 +53,7 @@ pub(super) fn try_claim_rewards(
 
 pub(super) fn query_lpp_balance<Lpn>(deps: Deps<'_>, env: Env) -> Result<LppBalanceResponse>
 where
-    Lpn: 'static + Currency + DeserializeOwned + Serialize,
+    Lpn: Currency,
 {
     LiquidityPool::<Lpn>::load(deps.storage).and_then(|lpp| lpp.query_lpp_balance(&deps, &env))
 }

--- a/protocol/contracts/lpp/src/lpp.rs
+++ b/protocol/contracts/lpp/src/lpp.rs
@@ -1,6 +1,4 @@
 use currencies::Lpns;
-use serde::{de::DeserializeOwned, Serialize};
-
 use currency::Currency;
 use finance::{
     coin::Coin,
@@ -26,14 +24,14 @@ use crate::{
 // Deposit and Loan which in turn may use LiquidityPool.
 pub struct NTokenPrice<Lpn>
 where
-    Lpn: 'static + Currency + Serialize + DeserializeOwned,
+    Lpn: Currency,
 {
     price: Price<NLpn, Lpn>,
 }
 
 impl<Lpn> NTokenPrice<Lpn>
 where
-    Lpn: Currency + Serialize + DeserializeOwned,
+    Lpn: Currency,
 {
     pub fn get(&self) -> Price<NLpn, Lpn> {
         self.price
@@ -49,7 +47,7 @@ where
 
 impl<Lpn> From<NTokenPrice<Lpn>> for PriceResponse<Lpn>
 where
-    Lpn: Currency + Serialize + DeserializeOwned,
+    Lpn: Currency,
 {
     fn from(nprice: NTokenPrice<Lpn>) -> Self {
         PriceResponse(nprice.price)
@@ -66,7 +64,7 @@ where
 
 impl<Lpn> LiquidityPool<Lpn>
 where
-    Lpn: 'static + Currency + Serialize + DeserializeOwned,
+    Lpn: Currency,
 {
     pub fn store(storage: &mut dyn Storage, config: Config) -> Result<()> {
         config

--- a/protocol/contracts/lpp/src/msg.rs
+++ b/protocol/contracts/lpp/src/msg.rs
@@ -127,10 +127,14 @@ pub struct BalanceResponse {
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
 #[cfg_attr(any(test, feature = "testing"), derive(Debug))]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(
+    deny_unknown_fields,
+    rename_all = "snake_case",
+    bound(serialize = "", deserialize = "")
+)]
 pub struct PriceResponse<Lpn>(pub Price<NLpn, Lpn>)
 where
-    Lpn: 'static + Currency;
+    Lpn: Currency;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
 #[cfg_attr(any(test, feature = "testing"), derive(Debug))]

--- a/protocol/contracts/lpp/src/state/config.rs
+++ b/protocol/contracts/lpp/src/state/config.rs
@@ -1,4 +1,4 @@
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use currency::Currency;
 use finance::{percent::bound::BoundToHundredPercent, price::Price};
@@ -62,7 +62,7 @@ impl Config {
 
     pub fn initial_derivative_price<Lpn>() -> Price<NLpn, Lpn>
     where
-        Lpn: Currency + Serialize + DeserializeOwned,
+        Lpn: Currency,
     {
         Price::identity()
     }

--- a/protocol/contracts/lpp/src/state/deposit.rs
+++ b/protocol/contracts/lpp/src/state/deposit.rs
@@ -1,4 +1,4 @@
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use currency::{Currency, NlsPlatform};
 use finance::{
@@ -66,7 +66,7 @@ impl Deposit {
         price: NTokenPrice<Lpn>,
     ) -> Result<Coin<NLpn>>
     where
-        Lpn: Currency + Serialize + DeserializeOwned,
+        Lpn: Currency,
     {
         if amount_lpn.is_zero() {
             return Err(ContractError::ZeroDepositFunds);

--- a/protocol/contracts/lpp/src/state/total.rs
+++ b/protocol/contracts/lpp/src/state/total.rs
@@ -1,4 +1,4 @@
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use currency::Currency;
 use finance::{
@@ -19,6 +19,7 @@ use sdk::{
 use crate::error::ContractError;
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(bound(serialize = "", deserialize = ""))]
 pub struct Total<Lpn>
 where
     Lpn: Currency,
@@ -31,7 +32,7 @@ where
 
 impl<Lpn> Default for Total<Lpn>
 where
-    Lpn: Currency + Serialize + DeserializeOwned,
+    Lpn: Currency,
 {
     fn default() -> Self {
         Self::new()
@@ -40,7 +41,7 @@ where
 
 impl<Lpn> Total<Lpn>
 where
-    Lpn: Currency + Serialize + DeserializeOwned,
+    Lpn: Currency,
 {
     const STORAGE: Item<'static, Total<Lpn>> = Item::new("total");
 

--- a/protocol/contracts/lpp/src/stub/lender.rs
+++ b/protocol/contracts/lpp/src/stub/lender.rs
@@ -1,7 +1,5 @@
 use std::{marker::PhantomData, result::Result as StdResult};
 
-use serde::de::DeserializeOwned;
-
 use currency::Currency;
 use finance::coin::Coin;
 use platform::{
@@ -67,7 +65,7 @@ where
 
 impl<'a, Lpn> LppLender<Lpn> for LppLenderStub<'a, Lpn>
 where
-    Lpn: Currency + DeserializeOwned,
+    Lpn: Currency,
 {
     fn open_loan_req(&mut self, amount: Coin<Lpn>) -> Result<()> {
         self.batch

--- a/protocol/contracts/lpp/src/stub/loan.rs
+++ b/protocol/contracts/lpp/src/stub/loan.rs
@@ -1,7 +1,5 @@
 use std::{marker::PhantomData, result::Result as StdResult};
 
-use serde::de::DeserializeOwned;
-
 use currency::Currency;
 use finance::{coin::Coin, percent::Percent};
 use platform::batch::Batch;
@@ -53,7 +51,7 @@ where
 
 impl<Lpn> LppLoanImpl<Lpn>
 where
-    Lpn: Currency + DeserializeOwned,
+    Lpn: Currency,
 {
     pub(super) fn new(lpp_ref: LppRef, loan: Loan<Lpn>) -> Self {
         Self {

--- a/protocol/contracts/lpp/src/stub/mod.rs
+++ b/protocol/contracts/lpp/src/stub/mod.rs
@@ -1,6 +1,6 @@
 use std::result::Result as StdResult;
 
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use currencies::Lpns;
 use currency::{
@@ -76,7 +76,7 @@ impl LppRef {
 
             fn on<C>(self) -> AnyVisitorResult<Self>
             where
-                C: Currency + Serialize + DeserializeOwned,
+                C: Currency,
             {
                 self.lpp_ref
                     .into_loan::<C>(self.lease, self.querier)
@@ -124,7 +124,7 @@ impl LppRef {
 
             fn on<C>(self) -> AnyVisitorResult<Self>
             where
-                C: Currency + Serialize + DeserializeOwned,
+                C: Currency,
             {
                 self.cmd
                     .exec(self.lpp_ref.into_lender::<C>(self.querier))
@@ -150,7 +150,7 @@ impl LppRef {
         querier: QuerierWrapper<'_>,
     ) -> Result<LppLoanImpl<Lpn>>
     where
-        Lpn: Currency + DeserializeOwned,
+        Lpn: Currency,
     {
         querier
             .query_wasm_smart(

--- a/protocol/contracts/oracle/src/contract/alarms/iter.rs
+++ b/protocol/contracts/oracle/src/contract/alarms/iter.rs
@@ -1,7 +1,5 @@
 use std::{iter, ops::Deref};
 
-use serde::{de::DeserializeOwned, Serialize};
-
 use currency::{AnyVisitor, AnyVisitorResult, Currency, GroupVisit, Tickers};
 use finance::price::{base::BasePrice, Price};
 use marketprice::alarms::{errors::AlarmError, AlarmsIterator, PriceAlarms};
@@ -117,7 +115,7 @@ where
 
     fn on<C>(self) -> AnyVisitorResult<Self>
     where
-        C: Currency + Serialize + DeserializeOwned,
+        C: Currency,
     {
         Price::<C, BaseC>::try_from(self.price)
             .map(|price: Price<C, BaseC>| {

--- a/protocol/contracts/oracle/src/contract/exec.rs
+++ b/protocol/contracts/oracle/src/contract/exec.rs
@@ -1,5 +1,3 @@
-use serde::de::DeserializeOwned;
-
 use currencies::Lpns;
 use currency::{AnyVisitor, AnyVisitorResult, Currency, GroupVisit, Tickers};
 use marketprice::SpotPrice;
@@ -51,7 +49,7 @@ impl<'a> AnyVisitor for ExecWithOracleBase<'a> {
 
     fn on<OracleBase>(self) -> AnyVisitorResult<Self>
     where
-        OracleBase: Currency + DeserializeOwned,
+        OracleBase: Currency,
     {
         match self.msg {
             ExecuteMsg::FeedPrices { prices } => {
@@ -94,7 +92,7 @@ fn try_feed_prices<OracleBase>(
     prices: Vec<SpotPrice>,
 ) -> ContractResult<()>
 where
-    OracleBase: Currency + DeserializeOwned,
+    OracleBase: Currency,
 {
     let config = Config::load(storage).map_err(ContractError::LoadConfig)?;
     let oracle = Feeds::<OracleBase>::with(config.price_config);

--- a/protocol/contracts/oracle/src/contract/oracle/feed/leg_cmd.rs
+++ b/protocol/contracts/oracle/src/contract/oracle/feed/leg_cmd.rs
@@ -1,5 +1,3 @@
-use serde::de::DeserializeOwned;
-
 use currency::{AnyVisitorPair, Currency};
 use finance::price::{base::BasePrice, Price};
 use swap::SwapGroup;
@@ -32,7 +30,7 @@ where
 
 impl<OracleBase, Querier> AnyVisitorPair for &mut LegCmd<OracleBase, Querier>
 where
-    OracleBase: Currency + DeserializeOwned,
+    OracleBase: Currency,
     Querier: PriceQuerier,
 {
     type Output = Option<BasePrice<SwapGroup, OracleBase>>;
@@ -40,8 +38,8 @@ where
 
     fn on<B, Q>(self) -> Result<Self::Output, Self::Error>
     where
-        B: Currency + DeserializeOwned,
-        Q: Currency + DeserializeOwned,
+        B: Currency,
+        Q: Currency,
     {
         // tries to find price for non empty stack (in a branch of the tree)
         // covers both normal flow and NoPrice cases

--- a/protocol/contracts/oracle/src/contract/oracle/feed/mod.rs
+++ b/protocol/contracts/oracle/src/contract/oracle/feed/mod.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use serde::de::DeserializeOwned;
-
 use currency::{Currency, SymbolOwned};
 use finance::price::base::BasePrice;
 use marketprice::{config::Config, market_price::PriceFeeds, SpotPrice};
@@ -27,7 +25,7 @@ pub struct Feeds<OracleBase> {
 
 impl<OracleBase> Feeds<OracleBase>
 where
-    OracleBase: Currency + DeserializeOwned,
+    OracleBase: Currency,
 {
     pub(crate) fn with(config: Config) -> Self {
         Self {
@@ -148,8 +146,8 @@ mod test {
     impl PriceQuerier for TestFeeds {
         fn price<B, Q>(&self) -> Result<Option<Price<B, Q>>, ContractError>
         where
-            B: Currency + DeserializeOwned,
-            Q: Currency + DeserializeOwned,
+            B: Currency,
+            Q: Currency,
         {
             Ok(self
                 .0

--- a/protocol/contracts/oracle/src/contract/oracle/feed/price_querier.rs
+++ b/protocol/contracts/oracle/src/contract/oracle/feed/price_querier.rs
@@ -1,5 +1,3 @@
-use serde::de::DeserializeOwned;
-
 use currency::Currency;
 use finance::price::Price;
 use marketprice::{error::PriceFeedsError, market_price::PriceFeeds};
@@ -33,15 +31,15 @@ impl<'a> FedPrices<'a> {
 pub trait PriceQuerier {
     fn price<B, Q>(&self) -> Result<Option<Price<B, Q>>, ContractError>
     where
-        B: Currency + DeserializeOwned,
-        Q: Currency + DeserializeOwned;
+        B: Currency,
+        Q: Currency;
 }
 
 impl<'a> PriceQuerier for FedPrices<'a> {
     fn price<B, Q>(&self) -> Result<Option<Price<B, Q>>, ContractError>
     where
-        B: Currency + DeserializeOwned,
-        Q: Currency + DeserializeOwned,
+        B: Currency,
+        Q: Currency,
     {
         let price = self
             .feeds

--- a/protocol/contracts/oracle/src/contract/oracle/mod.rs
+++ b/protocol/contracts/oracle/src/contract/oracle/mod.rs
@@ -1,7 +1,5 @@
 use std::ops::{Deref, DerefMut};
 
-use serde::de::DeserializeOwned;
-
 use currency::{Currency, SymbolOwned};
 use finance::price::base::BasePrice;
 use marketprice::SpotPrice;
@@ -33,7 +31,7 @@ pub(crate) type CalculateAllPricesIterItem<OracleBase> = AllPricesIterItem<Oracl
 pub(crate) struct Oracle<'storage, S, OracleBase>
 where
     S: Deref<Target = dyn Storage + 'storage>,
-    OracleBase: Currency + DeserializeOwned,
+    OracleBase: Currency,
 {
     storage: S,
     tree: SupportedPairs<OracleBase>,
@@ -44,7 +42,7 @@ where
 impl<'storage, S, OracleBase> Oracle<'storage, S, OracleBase>
 where
     S: Deref<Target = dyn Storage + 'storage>,
-    OracleBase: Currency + DeserializeOwned,
+    OracleBase: Currency,
 {
     pub fn load(storage: S) -> Result<Self, ContractError> {
         let tree = SupportedPairs::load(storage.deref())?;
@@ -112,7 +110,7 @@ where
 impl<'storage, S, OracleBase> Oracle<'storage, S, OracleBase>
 where
     S: Deref<Target = dyn Storage + 'storage> + DerefMut,
-    OracleBase: Currency + DeserializeOwned,
+    OracleBase: Currency,
 {
     const REPLY_ID: Id = 0;
     const EVENT_TYPE: &'static str = "pricealarm";

--- a/protocol/contracts/oracle/src/contract/query.rs
+++ b/protocol/contracts/oracle/src/contract/query.rs
@@ -1,5 +1,3 @@
-use serde::{de::DeserializeOwned, Serialize};
-
 use currencies::Lpns;
 use currency::{AnyVisitor, AnyVisitorResult, Currency, GroupVisit, Tickers};
 use sdk::cosmwasm_std::{to_json_binary, Binary, Deps, Env};
@@ -33,7 +31,7 @@ impl<'a> AnyVisitor for QueryWithOracleBase<'a> {
 
     fn on<OracleBase>(self) -> AnyVisitorResult<Self>
     where
-        OracleBase: 'static + Currency + DeserializeOwned + Serialize,
+        OracleBase: Currency,
     {
         match self.msg {
             QueryMsg::SupportedCurrencyPairs {} => to_json_binary(

--- a/protocol/contracts/oracle/src/contract/sudo.rs
+++ b/protocol/contracts/oracle/src/contract/sudo.rs
@@ -1,5 +1,3 @@
-use serde::de::DeserializeOwned;
-
 use currencies::Lpns;
 use currency::{AnyVisitor, AnyVisitorResult, Currency, GroupVisit, Tickers};
 use sdk::cosmwasm_std::DepsMut;
@@ -32,7 +30,7 @@ impl<'a> AnyVisitor for SudoWithOracleBase<'a> {
 
     fn on<OracleBase>(self) -> AnyVisitorResult<Self>
     where
-        OracleBase: Currency + DeserializeOwned,
+        OracleBase: Currency,
     {
         match self.msg {
             SudoMsg::SwapTree { tree } => SupportedPairs::<OracleBase>::new(tree.into_tree())?

--- a/protocol/contracts/oracle/src/state/supported_pairs.rs
+++ b/protocol/contracts/oracle/src/state/supported_pairs.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, marker::PhantomData};
 
-use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use currencies::PaymentGroup;
 use currency::{
@@ -94,7 +94,7 @@ where
 
             fn on<C>(self) -> AnyVisitorResult<Self>
             where
-                C: Currency + Serialize + DeserializeOwned + 'static,
+                C: Currency,
             {
                 Ok(())
             }

--- a/protocol/packages/currencies/src/currency_macro.rs
+++ b/protocol/packages/currencies/src/currency_macro.rs
@@ -18,7 +18,6 @@ macro_rules! define_currency {
             Eq,
             PartialOrd,
             Ord,
-            Default,
             $crate::currency_macro::Serialize,
             $crate::currency_macro::Deserialize,
             $crate::currency_macro::JsonSchema,

--- a/protocol/packages/currencies/src/currency_macro.rs
+++ b/protocol/packages/currencies/src/currency_macro.rs
@@ -23,7 +23,7 @@ macro_rules! define_currency {
             $crate::currency_macro::JsonSchema,
         )]
         #[serde(deny_unknown_fields, rename_all = "snake_case")]
-        pub struct $ident {}
+        pub enum $ident {}
 
         impl $crate::currency_macro::Currency for $ident {
             const TICKER: $crate::currency_macro::SymbolStatic = ::core::stringify!($ticker);

--- a/protocol/packages/currencies/src/lease/mod.rs
+++ b/protocol/packages/currencies/src/lease/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod astroport;
 pub(crate) mod osmosis;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
-pub struct LeaseGroup {}
+pub enum LeaseGroup {}
 
 impl Group for LeaseGroup {
     const DESCR: &'static str = "lease";

--- a/protocol/packages/currencies/src/lease/mod.rs
+++ b/protocol/packages/currencies/src/lease/mod.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use currency::{AnyVisitor, Group, Matcher, MaybeAnyVisitResult, SymbolSlice};
 use sdk::schemars::{self, JsonSchema};
 
@@ -13,9 +11,7 @@ pub(crate) mod astroport;
 #[cfg(feature = "osmosis")]
 pub(crate) mod osmosis;
 
-#[derive(Clone, PartialEq, Eq, JsonSchema, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "testing"), derive(Debug))]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub struct LeaseGroup {}
 
 impl Group for LeaseGroup {

--- a/protocol/packages/currencies/src/lpn/mod.rs
+++ b/protocol/packages/currencies/src/lpn/mod.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use currency::{AnyVisitor, Group, Matcher, MaybeAnyVisitResult, SymbolSlice};
 use sdk::schemars::{self, JsonSchema};
 
@@ -13,8 +11,7 @@ pub(crate) mod astroport;
 #[cfg(feature = "osmosis")]
 pub(crate) mod osmosis;
 
-#[derive(Clone, Debug, PartialEq, Eq, JsonSchema, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub struct Lpns {}
 
 impl Group for Lpns {

--- a/protocol/packages/currencies/src/lpn/mod.rs
+++ b/protocol/packages/currencies/src/lpn/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod astroport;
 pub(crate) mod osmosis;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
-pub struct Lpns {}
+pub enum Lpns {}
 
 impl Group for Lpns {
     const DESCR: &'static str = "lpns";

--- a/protocol/packages/currencies/src/native/mod.rs
+++ b/protocol/packages/currencies/src/native/mod.rs
@@ -15,6 +15,7 @@ pub type Nls = impl_mod::Nls;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub enum Native {}
+
 impl Group for Native {
     const DESCR: &'static str = "native";
 

--- a/protocol/packages/currencies/src/native/mod.rs
+++ b/protocol/packages/currencies/src/native/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod osmosis;
 pub type Nls = impl_mod::Nls;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
-pub struct Native {}
+pub enum Native {}
 impl Group for Native {
     const DESCR: &'static str = "native";
 

--- a/protocol/packages/currencies/src/native/mod.rs
+++ b/protocol/packages/currencies/src/native/mod.rs
@@ -1,4 +1,5 @@
 use currency::{AnyVisitor, Group, Matcher, MaybeAnyVisitResult, SymbolSlice};
+use sdk::schemars::{self, JsonSchema};
 
 #[cfg(feature = "astroport")]
 use self::astroport as impl_mod;
@@ -12,8 +13,7 @@ pub(crate) mod osmosis;
 
 pub type Nls = impl_mod::Nls;
 
-#[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Debug))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub struct Native {}
 impl Group for Native {
     const DESCR: &'static str = "native";

--- a/protocol/packages/currencies/src/payment/mod.rs
+++ b/protocol/packages/currencies/src/payment/mod.rs
@@ -6,7 +6,7 @@ use super::{lease::LeaseGroup, lpn::Lpns, native::Native};
 mod osmosis_tests;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
-pub struct PaymentGroup {}
+pub enum PaymentGroup {}
 
 impl Group for PaymentGroup {
     const DESCR: &'static str = "payment";

--- a/protocol/packages/currencies/src/payment/mod.rs
+++ b/protocol/packages/currencies/src/payment/mod.rs
@@ -1,15 +1,11 @@
-use serde::{Deserialize, Serialize};
-
-use sdk::schemars::{self, JsonSchema};
-
 use currency::{AnyVisitor, Group, Matcher, MaybeAnyVisitResult, SymbolSlice};
+use sdk::schemars::{self, JsonSchema};
 
 use super::{lease::LeaseGroup, lpn::Lpns, native::Native};
 
 mod osmosis_tests;
 
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub struct PaymentGroup {}
 
 impl Group for PaymentGroup {

--- a/protocol/packages/currencies/src/symbols_macro.rs
+++ b/protocol/packages/currencies/src/symbols_macro.rs
@@ -18,7 +18,7 @@ macro_rules! define_symbol {
                 { CurrencySymbols { $($body)* } }
             )+
             #[cfg(all($($(not(net = $net)),+),+))]
-            { compile_error!(concat!("No symbols defined for network with name \"", env!("NET"), "\"!")) }
+            compile_error!(concat!("No symbols defined for network with name \"", env!("NET"), "\"!"))
         };
     };
 }

--- a/protocol/packages/marketprice/src/feed/mod.rs
+++ b/protocol/packages/marketprice/src/feed/mod.rs
@@ -13,7 +13,12 @@ use self::observation::Observation;
 mod observation;
 mod sample;
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize)]
+#[serde(
+    rename_all = "snake_case",
+    deny_unknown_fields,
+    bound(serialize = "", deserialize = "")
+)]
 pub struct PriceFeed<C, QuoteC>
 where
     C: Currency,
@@ -101,6 +106,16 @@ where
         self.observations
             .iter()
             .filter(move |&o| valid_observations(o))
+    }
+}
+
+impl<C, QuoteC> Default for PriceFeed<C, QuoteC>
+where
+    C: Currency,
+    QuoteC: Currency,
+{
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/protocol/packages/marketprice/src/feed/mod.rs
+++ b/protocol/packages/marketprice/src/feed/mod.rs
@@ -32,8 +32,10 @@ where
     C: Currency,
     QuoteC: Currency,
 {
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            observations: Vec::new(),
+        }
     }
 
     pub fn add_observation(

--- a/protocol/packages/marketprice/src/feed/observation.rs
+++ b/protocol/packages/marketprice/src/feed/observation.rs
@@ -6,6 +6,11 @@ use sdk::cosmwasm_std::{Addr, Timestamp};
 
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(test, derive(Debug))]
+#[serde(
+    rename_all = "snake_case",
+    deny_unknown_fields,
+    bound(serialize = "", deserialize = "")
+)]
 pub struct Observation<C, QuoteC>
 where
     C: Currency,

--- a/protocol/packages/marketprice/src/feed/sample.rs
+++ b/protocol/packages/marketprice/src/feed/sample.rs
@@ -25,7 +25,7 @@ where
     SampleBuilder::from(observations, start_from, sample_span)
 }
 
-#[derive(Default, Copy, Clone)]
+#[derive(Clone, Copy)]
 #[cfg_attr(test, derive(PartialEq, Eq, Debug))]
 pub struct Sample<C, QuoteC>
 where
@@ -44,6 +44,18 @@ where
 {
     pub fn into_maybe_price(self) -> Option<Price<C, QuoteC>> {
         self.price
+    }
+}
+
+impl<C, QuoteC> Default for Sample<C, QuoteC>
+where
+    C: Currency,
+    QuoteC: Currency,
+{
+    fn default() -> Self {
+        Self {
+            price: Default::default(),
+        }
     }
 }
 

--- a/protocol/packages/marketprice/src/market_price.rs
+++ b/protocol/packages/marketprice/src/market_price.rs
@@ -1,5 +1,3 @@
-use serde::{de::DeserializeOwned, Serialize};
-
 use currency::{
     self, AnyVisitor, AnyVisitorResult, Currency, GroupVisit, SymbolOwned, SymbolSlice, Tickers,
 };
@@ -66,8 +64,8 @@ impl<'m> PriceFeeds<'m> {
     ) -> Result<SpotPrice, PriceFeedsError>
     where
         'm: 'a,
-        QuoteC: Currency + DeserializeOwned,
-        Iter: Iterator<Item = &'a SymbolSlice> + DoubleEndedIterator,
+        QuoteC: Currency,
+        Iter: DoubleEndedIterator<Item = &'a SymbolSlice>,
     {
         let mut root_to_leaf = leaf_to_root.rev();
         let _root = root_to_leaf.next();
@@ -89,8 +87,8 @@ impl<'m> PriceFeeds<'m> {
         total_feeders: usize,
     ) -> Result<Price<C, QuoteC>, PriceFeedsError>
     where
-        C: Currency + DeserializeOwned,
-        QuoteC: Currency + DeserializeOwned,
+        C: Currency,
+        QuoteC: Currency,
     {
         let feed_bin = self
             .storage
@@ -103,8 +101,8 @@ fn load_feed<BaseC, QuoteC>(
     feed_bin: Option<PriceFeedBin>,
 ) -> Result<PriceFeed<BaseC, QuoteC>, PriceFeedsError>
 where
-    BaseC: Currency + DeserializeOwned,
-    QuoteC: Currency + DeserializeOwned,
+    BaseC: Currency,
+    QuoteC: Currency,
 {
     feed_bin.map_or_else(
         || Ok(PriceFeed::<BaseC, QuoteC>::default()),
@@ -127,7 +125,7 @@ where
 impl<'a, Iter, BaseC, QuoteC> PriceCollect<'a, Iter, BaseC, QuoteC>
 where
     Iter: Iterator<Item = &'a SymbolSlice>,
-    BaseC: Currency + DeserializeOwned,
+    BaseC: Currency,
     QuoteC: Currency,
 {
     fn do_collect(
@@ -156,7 +154,7 @@ where
 impl<'a, Iter, QuoteC, QuoteQuoteC> AnyVisitor for PriceCollect<'a, Iter, QuoteC, QuoteQuoteC>
 where
     Iter: Iterator<Item = &'a SymbolSlice>,
-    QuoteC: Currency + DeserializeOwned,
+    QuoteC: Currency,
     QuoteQuoteC: Currency,
 {
     type Output = SpotPrice;
@@ -164,7 +162,7 @@ where
 
     fn on<C>(self) -> AnyVisitorResult<Self>
     where
-        C: Currency + Serialize + DeserializeOwned,
+        C: Currency,
     {
         let next_price =
             self.feeds
@@ -202,8 +200,8 @@ fn add_observation(
 
         fn exec<C, QuoteC>(self, price: Price<C, QuoteC>) -> Result<Self::Output, Self::Error>
         where
-            C: Currency + Serialize + DeserializeOwned,
-            QuoteC: Currency + Serialize + DeserializeOwned,
+            C: Currency,
+            QuoteC: Currency,
         {
             load_feed(self.feed_bin).and_then(|feed| {
                 let feed =


### PR DESCRIPTION
In addition to cleanup, a check on PriceDTO is added to ensure both currencies belong to their groups.