### PR TITLE
refactor!: Merge `cosmwasm-bindings` and `contract` features

### DIFF
--- a/.github/actions/env/action.yaml
+++ b/.github/actions/env/action.yaml
@@ -32,7 +32,7 @@ runs:
       run: |
         if ! test '${{ inputs.build_wasm }}' = ''
         then
-          FEATURES='cosmwasm-bindings'
+          FEATURES='contract'
         else
           FEATURES=''
         fi

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -146,7 +146,7 @@ jobs:
         run: "cargo install cargo-hack cosmwasm-check"
       - name: "Building WASM binaries"
         shell: "sh"
-        run: "cargo hack build --features 'cosmwasm-bindings,${{ needs.setup_env.outputs.features }}' --ignore-unknown-features --release --target wasm32-unknown-unknown"
+        run: "cargo hack build --features 'contract,${{ needs.setup_env.outputs.features }}' --ignore-unknown-features --release --target wasm32-unknown-unknown"
         working-directory: "${{ inputs.working_directory }}"
       - name: "Checking WASM binaries"
         shell: "sh"

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ each set of contracts, depending on their workspace (indicated by
     -v "$(pwd)/${WORKSPACE_DIR_NAME}/:/code/" \
     -v "$(pwd)/artifacts/${ARTIFACTS_SUBDIR}/:/artifacts/" \
     --env "RELEASE_VERSION=`git describe`-`date -Iminute`" \
-    --env "features=cosmwasm-bindings$(if test "${WORKSPACE_DIR_NAME}" = 'protocol'; then echo ",net_${NET}"; fi)$(if test "${WORKSPACE_DIR_NAME}" = 'protocol'; then echo ",${PROTOCOL}"; fi)"
+    --env "features=contract$(if test "${WORKSPACE_DIR_NAME}" = 'protocol'; then echo ",net_${NET}"; fi)$(if test "${WORKSPACE_DIR_NAME}" = 'protocol'; then echo ",${PROTOCOL}"; fi)"
     wasm-optimizer
   ```
 

--- a/platform/contracts/admin/Cargo.toml
+++ b/platform/contracts/admin/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-contract = ["dep:versioning"]
+contract = ["dep:cosmwasm-std", "dep:versioning"]
 
 [dependencies]
 access-control = { workspace = true }
@@ -22,7 +22,7 @@ sdk = { workspace = true, features = ["contract", "cosmos"] }
 versioning = { workspace = true, optional = true }
 
 # Required as a dependency by `entry_point` attribute macro
-cosmwasm-std = { workspace = true }
+cosmwasm-std = { workspace = true, optional = true }
 
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/platform/contracts/admin/Cargo.toml
+++ b/platform/contracts/admin/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-cosmwasm-bindings = ["contract"]
 contract = ["dep:versioning"]
 
 [dependencies]

--- a/platform/contracts/admin/src/endpoints.rs
+++ b/platform/contracts/admin/src/endpoints.rs
@@ -1,14 +1,6 @@
 use access_control::ContractOwnerAccess;
 use platform::{batch::Batch, contract::CodeId, response};
-#[cfg(feature = "contract")]
-use sdk::cosmwasm_std::entry_point;
-use sdk::{
-    cosmwasm_ext::Response as CwResponse,
-    cosmwasm_std::{
-        ensure_eq, to_json_binary, Addr, Api, Binary, CodeInfoResponse, Deps, DepsMut, Env,
-        MessageInfo, QuerierWrapper, Reply, Storage, WasmMsg,
-    },
-};
+use sdk::{cosmwasm_std::{entry_point, ensure_eq, to_json_binary, Addr, Api, Binary, CodeInfoResponse, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, Reply, Storage, WasmMsg}, cosmwasm_ext::Response as CwResponse};
 use versioning::{package_version, version, SemVer, Version, VersionSegment};
 
 use crate::{
@@ -29,7 +21,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 1;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn instantiate(
     mut deps: DepsMut<'_>,
     _env: Env,
@@ -48,7 +40,7 @@ pub fn instantiate(
     state_contracts::store(deps.storage, contracts).map(|()| response::empty_response())
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn migrate(
     mut deps: DepsMut<'_>,
     _env: Env,
@@ -71,7 +63,7 @@ pub fn migrate(
         .and_then(|(label, ())| response::response(label))
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn execute(
     mut deps: DepsMut<'_>,
     env: Env,
@@ -117,7 +109,7 @@ pub fn execute(
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn sudo(deps: DepsMut<'_>, env: Env, msg: SudoMsg) -> ContractResult<CwResponse> {
     match msg {
         SudoMsg::ChangeDexAdmin { ref new_dex_admin } => ContractOwnerAccess::new(deps.storage)
@@ -156,7 +148,7 @@ fn register_protocol(
     state_contracts::add_protocol_set(storage, name, contracts).map(|()| response::empty_response())
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn reply(deps: DepsMut<'_>, _env: Env, msg: Reply) -> ContractResult<CwResponse> {
     match ContractState::load(deps.storage)? {
         ContractState::Migration { release } => migration_reply(msg, release),
@@ -217,7 +209,7 @@ fn instantiate_reply(
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::InstantiateAddress { code_id, protocol } => {

--- a/platform/contracts/admin/src/endpoints.rs
+++ b/platform/contracts/admin/src/endpoints.rs
@@ -1,6 +1,6 @@
 use access_control::ContractOwnerAccess;
 use platform::{batch::Batch, contract::CodeId, response};
-#[cfg(feature = "cosmwasm-bindings")]
+#[cfg(feature = "contract")]
 use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
@@ -29,7 +29,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 1;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn instantiate(
     mut deps: DepsMut<'_>,
     _env: Env,
@@ -48,7 +48,7 @@ pub fn instantiate(
     state_contracts::store(deps.storage, contracts).map(|()| response::empty_response())
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn migrate(
     mut deps: DepsMut<'_>,
     _env: Env,
@@ -71,7 +71,7 @@ pub fn migrate(
         .and_then(|(label, ())| response::response(label))
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn execute(
     mut deps: DepsMut<'_>,
     env: Env,
@@ -117,7 +117,7 @@ pub fn execute(
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn sudo(deps: DepsMut<'_>, env: Env, msg: SudoMsg) -> ContractResult<CwResponse> {
     match msg {
         SudoMsg::ChangeDexAdmin { ref new_dex_admin } => ContractOwnerAccess::new(deps.storage)
@@ -156,7 +156,7 @@ fn register_protocol(
     state_contracts::add_protocol_set(storage, name, contracts).map(|()| response::empty_response())
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn reply(deps: DepsMut<'_>, _env: Env, msg: Reply) -> ContractResult<CwResponse> {
     match ContractState::load(deps.storage)? {
         ContractState::Migration { release } => migration_reply(msg, release),
@@ -217,7 +217,7 @@ fn instantiate_reply(
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::InstantiateAddress { code_id, protocol } => {

--- a/platform/contracts/admin/src/endpoints.rs
+++ b/platform/contracts/admin/src/endpoints.rs
@@ -1,6 +1,12 @@
 use access_control::ContractOwnerAccess;
 use platform::{batch::Batch, contract::CodeId, response};
-use sdk::{cosmwasm_std::{entry_point, ensure_eq, to_json_binary, Addr, Api, Binary, CodeInfoResponse, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, Reply, Storage, WasmMsg}, cosmwasm_ext::Response as CwResponse};
+use sdk::{
+    cosmwasm_ext::Response as CwResponse,
+    cosmwasm_std::{
+        ensure_eq, entry_point, to_json_binary, Addr, Api, Binary, CodeInfoResponse, Deps, DepsMut,
+        Env, MessageInfo, QuerierWrapper, Reply, Storage, WasmMsg,
+    },
+};
 use versioning::{package_version, version, SemVer, Version, VersionSegment};
 
 use crate::{

--- a/platform/contracts/dispatcher/Cargo.toml
+++ b/platform/contracts/dispatcher/Cargo.toml
@@ -10,9 +10,6 @@ license.workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-contract = []
-
 [dependencies]
 lpp-platform = { workspace = true }
 oracle-platform = { workspace = true, features = ["unchecked-base-currency"]  }

--- a/platform/contracts/dispatcher/Cargo.toml
+++ b/platform/contracts/dispatcher/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-cosmwasm-bindings = []
+contract = []
 
 [dependencies]
 lpp-platform = { workspace = true }

--- a/platform/contracts/dispatcher/src/contract.rs
+++ b/platform/contracts/dispatcher/src/contract.rs
@@ -4,7 +4,7 @@ use access_control::SingleUserAccess;
 use finance::{duration::Duration, percent::Percent, period::Period};
 use lpp_platform::UsdGroup;
 use platform::{batch::Batch, message::Response as MessageResponse, response};
-#[cfg(feature = "cosmwasm-bindings")]
+#[cfg(feature = "contract")]
 use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
@@ -28,7 +28,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 1;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn instantiate(
     mut deps: DepsMut<'_>,
     env: Env,
@@ -66,7 +66,7 @@ pub fn instantiate(
     .map(response::response_only_messages)
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult<CwResponse> {
     use crate::state::migration;
     versioning::update_software_and_storage::<CONTRACT_STORAGE_VERSION_FROM, _, _, _, _>(
@@ -79,7 +79,7 @@ pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult
     .and_then(response::response)
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn execute(
     deps: DepsMut<'_>,
     env: Env,
@@ -99,7 +99,7 @@ pub fn execute(
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<CwResponse> {
     match msg {
         SudoMsg::Config { cadence_hours } => {
@@ -115,7 +115,7 @@ pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<CwResp
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_json_binary(&query_config(deps.storage)?),

--- a/platform/contracts/dispatcher/src/contract.rs
+++ b/platform/contracts/dispatcher/src/contract.rs
@@ -4,13 +4,11 @@ use access_control::SingleUserAccess;
 use finance::{duration::Duration, percent::Percent, period::Period};
 use lpp_platform::UsdGroup;
 use platform::{batch::Batch, message::Response as MessageResponse, response};
-#[cfg(feature = "contract")]
-use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
     cosmwasm_std::{
-        to_json_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, StdResult,
-        Storage, Timestamp,
+        entry_point, to_json_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, QuerierWrapper,
+        StdResult, Storage, Timestamp,
     },
 };
 use timealarms::stub::TimeAlarmsRef;
@@ -28,7 +26,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 1;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn instantiate(
     mut deps: DepsMut<'_>,
     env: Env,
@@ -66,7 +64,7 @@ pub fn instantiate(
     .map(response::response_only_messages)
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult<CwResponse> {
     use crate::state::migration;
     versioning::update_software_and_storage::<CONTRACT_STORAGE_VERSION_FROM, _, _, _, _>(
@@ -79,7 +77,7 @@ pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult
     .and_then(response::response)
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn execute(
     deps: DepsMut<'_>,
     env: Env,
@@ -99,7 +97,7 @@ pub fn execute(
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<CwResponse> {
     match msg {
         SudoMsg::Config { cadence_hours } => {
@@ -115,7 +113,7 @@ pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<CwResp
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_json_binary(&query_config(deps.storage)?),

--- a/platform/contracts/timealarms/Cargo.toml
+++ b/platform/contracts/timealarms/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-cosmwasm-bindings = ["contract"]
 contract = ["stub"]
 stub = []
 testing = []

--- a/platform/contracts/timealarms/Cargo.toml
+++ b/platform/contracts/timealarms/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-contract = ["stub"]
+contract = ["stub", "dep:cosmwasm-std", "dep:versioning"]
 stub = []
 testing = []
 
@@ -19,10 +19,10 @@ testing = []
 platform = { workspace = true }
 sdk = { workspace = true, features = ["contract"] }
 time-oracle = { workspace = true }
-versioning = { workspace = true }
+versioning = { workspace = true, optional = true }
 
 # Required as a dependency by `entry_point` attribute macro
-cosmwasm-std = { workspace = true }
+cosmwasm-std = { workspace = true, optional = true }
 
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/platform/contracts/timealarms/src/contract.rs
+++ b/platform/contracts/timealarms/src/contract.rs
@@ -2,12 +2,11 @@ use platform::{
     batch::{Emit, Emitter},
     response,
 };
-#[cfg(feature = "contract")]
-use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
     cosmwasm_std::{
-        to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Storage, SubMsgResult,
+        entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Storage,
+        SubMsgResult,
     },
 };
 use versioning::{package_version, version, SemVer, Version, VersionSegment};
@@ -24,7 +23,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 1;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn instantiate(
     deps: DepsMut<'_>,
     _env: Env,
@@ -36,13 +35,13 @@ pub fn instantiate(
     Ok(response::empty_response())
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult<CwResponse> {
     versioning::update_software(deps.storage, CONTRACT_VERSION, Into::into)
         .and_then(response::response)
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn execute(
     deps: DepsMut<'_>,
     env: Env,
@@ -63,12 +62,12 @@ pub fn execute(
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn sudo(_deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<CwResponse> {
     match msg {}
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::ContractVersion {} => Ok(to_json_binary(&PACKAGE_VERSION)?),
@@ -78,7 +77,7 @@ pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> 
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn reply(deps: DepsMut<'_>, env: Env, msg: Reply) -> ContractResult<CwResponse> {
     const EVENT_TYPE: &str = "time-alarm";
     const KEY_DELIVERED: &str = "delivered";

--- a/platform/contracts/timealarms/src/contract.rs
+++ b/platform/contracts/timealarms/src/contract.rs
@@ -2,7 +2,7 @@ use platform::{
     batch::{Emit, Emitter},
     response,
 };
-#[cfg(feature = "cosmwasm-bindings")]
+#[cfg(feature = "contract")]
 use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
@@ -24,7 +24,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 1;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn instantiate(
     deps: DepsMut<'_>,
     _env: Env,
@@ -36,13 +36,13 @@ pub fn instantiate(
     Ok(response::empty_response())
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult<CwResponse> {
     versioning::update_software(deps.storage, CONTRACT_VERSION, Into::into)
         .and_then(response::response)
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn execute(
     deps: DepsMut<'_>,
     env: Env,
@@ -63,12 +63,12 @@ pub fn execute(
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn sudo(_deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<CwResponse> {
     match msg {}
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::ContractVersion {} => Ok(to_json_binary(&PACKAGE_VERSION)?),
@@ -78,7 +78,7 @@ pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> 
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn reply(deps: DepsMut<'_>, env: Env, msg: Reply) -> ContractResult<CwResponse> {
     const EVENT_TYPE: &str = "time-alarm";
     const KEY_DELIVERED: &str = "delivered";

--- a/platform/contracts/timealarms/src/lib.rs
+++ b/platform/contracts/timealarms/src/lib.rs
@@ -7,7 +7,7 @@ pub mod result;
 #[cfg(any(feature = "stub", test))]
 pub mod stub;
 
-#[cfg(any(feature = "contract", test))]
+#[cfg(feature = "contract")]
 mod alarms;
-#[cfg(any(feature = "contract", test))]
+#[cfg(feature = "contract")]
 pub mod contract;

--- a/platform/contracts/treasury/Cargo.toml
+++ b/platform/contracts/treasury/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-contract = []
+contract = ["dep:cosmwasm-std", "dep:versioning"]
 
 [dependencies]
 access-control = { workspace = true }
@@ -19,10 +19,10 @@ currency = { workspace = true }
 finance = { workspace = true }
 platform = { workspace = true }
 sdk = { workspace = true, features = ["contract"] }
-versioning = { workspace = true }
+versioning = { workspace = true, optional = true }
 
 # Required as a dependency by `entry_point` attribute macro
-cosmwasm-std = { workspace = true }
+cosmwasm-std = { workspace = true, optional = true }
 
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/platform/contracts/treasury/Cargo.toml
+++ b/platform/contracts/treasury/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-cosmwasm-bindings = ["contract"]
 contract = []
 
 [dependencies]

--- a/platform/contracts/treasury/src/contract.rs
+++ b/platform/contracts/treasury/src/contract.rs
@@ -6,7 +6,7 @@ use platform::{
     message::Response as PlatformResponse,
     response,
 };
-#[cfg(feature = "cosmwasm-bindings")]
+#[cfg(feature = "contract")]
 use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
@@ -25,7 +25,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 0;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn instantiate(
     deps: DepsMut<'_>,
     _env: Env,
@@ -39,13 +39,13 @@ pub fn instantiate(
     Ok(response::empty_response())
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult<CwResponse> {
     versioning::update_software(deps.storage, CONTRACT_VERSION, Into::into)
         .and_then(response::response)
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn execute(
     deps: DepsMut<'_>,
     env: Env,
@@ -65,7 +65,7 @@ pub fn execute(
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<CwResponse> {
     match msg {
         SudoMsg::ConfigureRewardTransfer { rewards_dispatcher } => {

--- a/platform/contracts/treasury/src/contract.rs
+++ b/platform/contracts/treasury/src/contract.rs
@@ -6,11 +6,9 @@ use platform::{
     message::Response as PlatformResponse,
     response,
 };
-#[cfg(feature = "contract")]
-use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
-    cosmwasm_std::{Addr, DepsMut, Env, MessageInfo, Storage},
+    cosmwasm_std::{entry_point, Addr, DepsMut, Env, MessageInfo, Storage},
 };
 use versioning::{package_version, version, SemVer, Version, VersionSegment};
 
@@ -25,7 +23,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 0;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn instantiate(
     deps: DepsMut<'_>,
     _env: Env,
@@ -39,13 +37,13 @@ pub fn instantiate(
     Ok(response::empty_response())
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult<CwResponse> {
     versioning::update_software(deps.storage, CONTRACT_VERSION, Into::into)
         .and_then(response::response)
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn execute(
     deps: DepsMut<'_>,
     env: Env,
@@ -65,7 +63,7 @@ pub fn execute(
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<CwResponse> {
     match msg {
         SudoMsg::ConfigureRewardTransfer { rewards_dispatcher } => {

--- a/platform/contracts/treasury/src/lib.rs
+++ b/platform/contracts/treasury/src/lib.rs
@@ -4,7 +4,7 @@ pub mod error;
 pub mod msg;
 pub mod result;
 
-#[cfg(any(feature = "contract", test))]
+#[cfg(feature = "contract")]
 mod access_control;
-#[cfg(any(feature = "contract", test))]
+#[cfg(feature = "contract")]
 pub mod contract;

--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -1575,13 +1575,11 @@ dependencies = [
 name = "timealarms"
 version = "0.4.2"
 dependencies = [
- "cosmwasm-std",
  "platform",
  "sdk",
  "serde",
  "thiserror",
  "time-oracle",
- "versioning",
 ]
 
 [[package]]

--- a/protocol/contracts/lease/Cargo.toml
+++ b/protocol/contracts/lease/Cargo.toml
@@ -16,7 +16,7 @@ net_main = ["dex/net_main"]
 astroport = ["skel", "dex/astroport", "dex/migration"]
 osmosis = ["skel", "dex/osmosis", "dex/migration"]
 
-cosmwasm-bindings = []
+contract = []
 api = ["dep:dex"]
 skel = ["api"]
 testing = ["currencies/testing", "currency/testing", "finance/testing"]

--- a/protocol/contracts/lease/Cargo.toml
+++ b/protocol/contracts/lease/Cargo.toml
@@ -9,40 +9,56 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-net_dev = ["dex/net_dev"]
-net_test = ["dex/net_test"]
-net_main = ["dex/net_main"]
+net_dev = ["contract", "dex/net_dev"]
+net_test = ["contract", "dex/net_test"]
+net_main = ["contract", "dex/net_main"]
 
-astroport = ["skel", "dex/astroport", "dex/migration"]
-osmosis = ["skel", "dex/osmosis", "dex/migration"]
+astroport = ["contract", "dex/astroport", "dex/migration"]
+osmosis = ["contract", "dex/osmosis", "dex/migration"]
 
-api = ["dep:dex"]
-skel = ["api"]
+contract = [
+    "skel",
+    "sdk/contract",
+    "dep:enum_dispatch",
+    "dep:marketprice",
+    "dep:versioning",
+]
+skel = [
+    "dep:access-control",
+    "dep:dex",
+    "dep:lpp",
+    "dep:oracle",
+    "dep:oracle-platform",
+    "dep:platform",
+    "dep:profit",
+    "dep:timealarms",
+    "dep:thiserror",
+]
 testing = ["currencies/testing", "currency/testing", "finance/testing"]
 
 [dependencies]
-access-control = { workspace = true }
-profit = { workspace = true, features = ["stub"] }
-timealarms = { workspace = true, features = ["stub"] }
+access-control = { workspace = true, optional = true }
+profit = { workspace = true, optional = true, features = ["stub"] }
+timealarms = { workspace = true, optional = true, features = ["stub"] }
 
 currencies = { workspace = true }
 currency = { workspace = true }
 dex = { workspace = true, optional = true }
 finance = { workspace = true }
-lpp = { workspace = true, features = ["stub"] }
-lpp-platform = { workspace = true }
-marketprice = { workspace = true }
-oracle = { workspace = true, features = ["stub"] }
-oracle-platform = { workspace = true }
-platform = { workspace = true }
-sdk = { workspace = true, features = ["contract"] }
-versioning = { workspace = true }
+lpp = { workspace = true, optional = true, features = ["stub"] }
+lpp-platform = { workspace = true, optional = true }
+marketprice = { workspace = true, optional = true }
+oracle = { workspace = true, optional = true, features = ["stub"] }
+oracle-platform = { workspace = true, optional = true }
+platform = { workspace = true, optional = true }
+sdk = { workspace = true }
+versioning = { workspace = true, optional = true }
 
 # Required as a dependency by `entry_point` attribute macro
-cosmwasm-std = { workspace = true }
+cosmwasm-std = { workspace = true, optional = true }
 
-enum_dispatch = { workspace = true }
-thiserror = { workspace = true }
+enum_dispatch = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/protocol/contracts/lease/Cargo.toml
+++ b/protocol/contracts/lease/Cargo.toml
@@ -16,7 +16,6 @@ net_main = ["dex/net_main"]
 astroport = ["skel", "dex/astroport", "dex/migration"]
 osmosis = ["skel", "dex/osmosis", "dex/migration"]
 
-contract = []
 api = ["dep:dex"]
 skel = ["api"]
 testing = ["currencies/testing", "currency/testing", "finance/testing"]

--- a/protocol/contracts/lease/Cargo.toml
+++ b/protocol/contracts/lease/Cargo.toml
@@ -19,6 +19,7 @@ osmosis = ["contract", "dex/osmosis", "dex/migration"]
 contract = [
     "skel",
     "sdk/contract",
+    "dep:cosmwasm-std",
     "dep:enum_dispatch",
     "dep:marketprice",
     "dep:versioning",

--- a/protocol/contracts/lease/src/contract/endpoins.rs
+++ b/protocol/contracts/lease/src/contract/endpoins.rs
@@ -1,11 +1,10 @@
 use currencies::LeaseGroup;
 use platform::{error as platform_error, message::Response as MessageResponse, response};
-
-#[cfg(feature = "contract")]
-use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
-    cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Storage},
+    cosmwasm_std::{
+        entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Storage,
+    },
     neutron_sdk::sudo::msg::SudoMsg,
 };
 use versioning::{package_version, version, SemVer, Version, VersionSegment};
@@ -23,7 +22,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 7;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn instantiate(
     mut deps: DepsMut<'_>,
     _env: Env,
@@ -48,7 +47,7 @@ pub fn instantiate(
         .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult<CwResponse> {
     versioning::update_software_and_storage::<CONTRACT_STORAGE_VERSION_FROM, _, _, _, _>(
         deps.storage,
@@ -60,7 +59,7 @@ pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult
     .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn reply(mut deps: DepsMut<'_>, env: Env, msg: Reply) -> ContractResult<CwResponse> {
     state::load(deps.storage)
         .and_then(|state| state.reply(&mut deps, env, msg))
@@ -74,7 +73,7 @@ pub fn reply(mut deps: DepsMut<'_>, env: Env, msg: Reply) -> ContractResult<CwRe
         .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn execute(
     mut deps: DepsMut<'_>,
     env: Env,
@@ -93,7 +92,7 @@ pub fn execute(
         .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn sudo(deps: DepsMut<'_>, env: Env, msg: SudoMsg) -> ContractResult<CwResponse> {
     state::load(deps.storage)
         .and_then(|state| process_sudo(msg, state, deps.as_ref(), env))
@@ -107,7 +106,7 @@ pub fn sudo(deps: DepsMut<'_>, env: Env, msg: SudoMsg) -> ContractResult<CwRespo
         .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn query(deps: Deps<'_>, env: Env, _msg: StateQuery) -> ContractResult<Binary> {
     state::load(deps.storage)
         .and_then(|state| state.state(env.block.time, deps.querier))

--- a/protocol/contracts/lease/src/contract/endpoins.rs
+++ b/protocol/contracts/lease/src/contract/endpoins.rs
@@ -1,7 +1,7 @@
 use currencies::LeaseGroup;
 use platform::{error as platform_error, message::Response as MessageResponse, response};
 
-#[cfg(feature = "cosmwasm-bindings")]
+#[cfg(feature = "contract")]
 use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
@@ -23,7 +23,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 7;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn instantiate(
     mut deps: DepsMut<'_>,
     _env: Env,
@@ -48,7 +48,7 @@ pub fn instantiate(
         .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult<CwResponse> {
     versioning::update_software_and_storage::<CONTRACT_STORAGE_VERSION_FROM, _, _, _, _>(
         deps.storage,
@@ -60,7 +60,7 @@ pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult
     .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn reply(mut deps: DepsMut<'_>, env: Env, msg: Reply) -> ContractResult<CwResponse> {
     state::load(deps.storage)
         .and_then(|state| state.reply(&mut deps, env, msg))
@@ -74,7 +74,7 @@ pub fn reply(mut deps: DepsMut<'_>, env: Env, msg: Reply) -> ContractResult<CwRe
         .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn execute(
     mut deps: DepsMut<'_>,
     env: Env,
@@ -93,7 +93,7 @@ pub fn execute(
         .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn sudo(deps: DepsMut<'_>, env: Env, msg: SudoMsg) -> ContractResult<CwResponse> {
     state::load(deps.storage)
         .and_then(|state| process_sudo(msg, state, deps.as_ref(), env))
@@ -107,7 +107,7 @@ pub fn sudo(deps: DepsMut<'_>, env: Env, msg: SudoMsg) -> ContractResult<CwRespo
         .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn query(deps: Deps<'_>, env: Env, _msg: StateQuery) -> ContractResult<Binary> {
     state::load(deps.storage)
         .and_then(|state| state.state(env.block.time, deps.querier))

--- a/protocol/contracts/lease/src/contract/mod.rs
+++ b/protocol/contracts/lease/src/contract/mod.rs
@@ -5,13 +5,11 @@ use sdk::cosmwasm_std::QuerierWrapper;
 
 use crate::lease::{with_lease::WithLease, LeaseDTO};
 
-#[cfg(feature = "contract")]
 pub use self::endpoins::{execute, instantiate, migrate, query, reply, sudo};
 use self::finalize::FinalizerRef;
 
 mod api;
 mod cmd;
-#[cfg(feature = "contract")]
 mod endpoins;
 mod finalize;
 pub mod msg;

--- a/protocol/contracts/lease/src/contract/mod.rs
+++ b/protocol/contracts/lease/src/contract/mod.rs
@@ -5,11 +5,13 @@ use sdk::cosmwasm_std::QuerierWrapper;
 
 use crate::lease::{with_lease::WithLease, LeaseDTO};
 
+#[cfg(feature = "contract")]
 pub use self::endpoins::{execute, instantiate, migrate, query, reply, sudo};
 use self::finalize::FinalizerRef;
 
 mod api;
 mod cmd;
+#[cfg(feature = "contract")]
 mod endpoins;
 mod finalize;
 pub mod msg;

--- a/protocol/contracts/lease/src/lib.rs
+++ b/protocol/contracts/lease/src/lib.rs
@@ -1,20 +1,13 @@
-#[cfg(feature = "api")]
 pub mod api;
-
+#[cfg(feature = "contract")]
+pub mod contract;
 #[cfg(feature = "skel")]
 pub mod error;
-
-#[cfg(any(feature = "astroport", feature = "osmosis"))]
-pub mod contract;
-
-#[cfg(any(feature = "astroport", feature = "osmosis"))]
+#[cfg(feature = "contract")]
 mod event;
-
-#[cfg(any(feature = "astroport", feature = "osmosis"))]
+#[cfg(feature = "contract")]
 mod lease;
-
-#[cfg(any(feature = "astroport", feature = "osmosis"))]
+#[cfg(feature = "contract")]
 mod loan;
-
-#[cfg(any(feature = "astroport", feature = "osmosis"))]
+#[cfg(feature = "contract")]
 mod position;

--- a/protocol/contracts/leaser/Cargo.toml
+++ b/protocol/contracts/leaser/Cargo.toml
@@ -16,7 +16,7 @@ net_main = ["currencies/net_main"]
 astroport = ["currencies/astroport"]
 osmosis = ["currencies/osmosis"]
 
-cosmwasm-bindings = []
+contract = []
 testing = ["currency/testing", "lease/testing"]
 
 [dependencies]

--- a/protocol/contracts/leaser/Cargo.toml
+++ b/protocol/contracts/leaser/Cargo.toml
@@ -16,7 +16,6 @@ net_main = ["currencies/net_main"]
 astroport = ["currencies/astroport"]
 osmosis = ["currencies/osmosis"]
 
-contract = []
 testing = ["currency/testing", "lease/testing"]
 
 [dependencies]

--- a/protocol/contracts/leaser/src/contract.rs
+++ b/protocol/contracts/leaser/src/contract.rs
@@ -6,7 +6,7 @@ use platform::{
     batch::Batch, contract, error as platform_error, message::Response as MessageResponse, reply,
     response,
 };
-#[cfg(feature = "cosmwasm-bindings")]
+#[cfg(feature = "contract")]
 use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response,
@@ -29,7 +29,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 1;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn instantiate(
     mut deps: DepsMut<'_>,
     _env: Env,
@@ -53,7 +53,7 @@ pub fn instantiate(
         .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, msg: MigrateMsg) -> ContractResult<Response> {
     // Statically assert that the message is empty when doing a software-only update.
     let MigrateMsg {}: MigrateMsg = msg;
@@ -63,7 +63,7 @@ pub fn migrate(deps: DepsMut<'_>, _env: Env, msg: MigrateMsg) -> ContractResult<
         .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn execute(
     deps: DepsMut<'_>,
     env: Env,
@@ -127,7 +127,7 @@ pub fn execute(
     .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<Response> {
     match msg {
         SudoMsg::SetupDex(params) => leaser::try_setup_dex(deps.storage, params),
@@ -146,7 +146,7 @@ pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<Respon
     .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn query(deps: Deps<'_>, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_json_binary(&Leaser::new(deps).config()?),
@@ -161,7 +161,7 @@ pub fn query(deps: Deps<'_>, _env: Env, msg: QueryMsg) -> ContractResult<Binary>
     .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn reply(deps: DepsMut<'_>, _env: Env, msg: Reply) -> ContractResult<Response> {
     reply::from_instantiate_addr_only(deps.api, msg)
         .map_err(|err| ContractError::ParseError {

--- a/protocol/contracts/leaser/src/contract.rs
+++ b/protocol/contracts/leaser/src/contract.rs
@@ -6,12 +6,11 @@ use platform::{
     batch::Batch, contract, error as platform_error, message::Response as MessageResponse, reply,
     response,
 };
-#[cfg(feature = "contract")]
-use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response,
     cosmwasm_std::{
-        to_json_binary, Addr, Api, Binary, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, Reply,
+        entry_point, to_json_binary, Addr, Api, Binary, Deps, DepsMut, Env, MessageInfo,
+        QuerierWrapper, Reply,
     },
 };
 use versioning::{package_version, version, SemVer, Version, VersionSegment};
@@ -29,7 +28,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 1;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn instantiate(
     mut deps: DepsMut<'_>,
     _env: Env,
@@ -53,7 +52,7 @@ pub fn instantiate(
         .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, msg: MigrateMsg) -> ContractResult<Response> {
     // Statically assert that the message is empty when doing a software-only update.
     let MigrateMsg {}: MigrateMsg = msg;
@@ -63,7 +62,7 @@ pub fn migrate(deps: DepsMut<'_>, _env: Env, msg: MigrateMsg) -> ContractResult<
         .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn execute(
     deps: DepsMut<'_>,
     env: Env,
@@ -127,7 +126,7 @@ pub fn execute(
     .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<Response> {
     match msg {
         SudoMsg::SetupDex(params) => leaser::try_setup_dex(deps.storage, params),
@@ -146,7 +145,7 @@ pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<Respon
     .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn query(deps: Deps<'_>, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_json_binary(&Leaser::new(deps).config()?),
@@ -161,7 +160,7 @@ pub fn query(deps: Deps<'_>, _env: Env, msg: QueryMsg) -> ContractResult<Binary>
     .or_else(|err| platform_error::log(err, deps.api))
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn reply(deps: DepsMut<'_>, _env: Env, msg: Reply) -> ContractResult<Response> {
     reply::from_instantiate_addr_only(deps.api, msg)
         .map_err(|err| ContractError::ParseError {

--- a/protocol/contracts/leaser/src/lib.rs
+++ b/protocol/contracts/leaser/src/lib.rs
@@ -1,7 +1,10 @@
-pub use crate::error::ContractError;
+pub use self::error::ContractError;
+#[cfg(feature = "contract")]
+pub use self::contract::{execute, instantiate, migrate, query, reply, sudo};
 
 mod cmd;
-pub mod contract;
+#[cfg(feature = "contract")]
+mod contract;
 pub mod error;
 mod leaser;
 mod migrate;

--- a/protocol/contracts/leaser/src/lib.rs
+++ b/protocol/contracts/leaser/src/lib.rs
@@ -1,16 +1,16 @@
-#[cfg(feature = "contract")]
-pub use self::contract::{execute, instantiate, migrate, query, reply, sudo};
-pub use self::error::ContractError;
+pub use self::{
+    contract::{execute, instantiate, migrate, query, reply, sudo},
+    error::ContractError,
+};
 
 mod cmd;
-#[cfg(feature = "contract")]
 mod contract;
 pub mod error;
 mod leaser;
 mod migrate;
 pub mod msg;
 pub mod result;
-pub mod state;
+mod state;
 
 #[cfg(test)]
 mod tests;

--- a/protocol/contracts/leaser/src/lib.rs
+++ b/protocol/contracts/leaser/src/lib.rs
@@ -1,6 +1,6 @@
-pub use self::error::ContractError;
 #[cfg(feature = "contract")]
 pub use self::contract::{execute, instantiate, migrate, query, reply, sudo};
+pub use self::error::ContractError;
 
 mod cmd;
 #[cfg(feature = "contract")]

--- a/protocol/contracts/leaser/src/msg.rs
+++ b/protocol/contracts/leaser/src/msg.rs
@@ -11,7 +11,7 @@ use sdk::{
     schemars::{self, JsonSchema},
 };
 
-use crate::state::config::Config;
+pub use crate::state::config::Config;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
 #[cfg_attr(any(test, feature = "testing"), derive(Debug))]

--- a/protocol/contracts/leaser/src/state/leases.rs
+++ b/protocol/contracts/leaser/src/state/leases.rs
@@ -10,7 +10,7 @@ use crate::{
     result::ContractResult,
 };
 
-pub struct Leases {}
+pub(crate) struct Leases {}
 
 impl Leases {
     const PENDING_CUSTOMER: Item<'static, Addr> = Item::new("pending_customer");

--- a/protocol/contracts/leaser/src/state/mod.rs
+++ b/protocol/contracts/leaser/src/state/mod.rs
@@ -1,2 +1,2 @@
-pub mod config;
-pub mod leases;
+pub(crate) mod config;
+pub(crate) mod leases;

--- a/protocol/contracts/lpp/Cargo.toml
+++ b/protocol/contracts/lpp/Cargo.toml
@@ -16,7 +16,7 @@ net_main = ["currencies/net_main"]
 astroport = ["currencies/astroport"]
 osmosis = ["currencies/osmosis"]
 
-contract = ["stub"]
+contract = ["stub", "dep:cosmwasm-std", "dep:versioning"]
 stub = []
 testing = ["currency/testing"]
 
@@ -28,10 +28,10 @@ finance = { workspace = true }
 lpp-platform = { workspace = true }
 platform = { workspace = true }
 sdk = { workspace = true, features = ["contract"] }
-versioning = { workspace = true }
+versioning = { workspace = true, optional = true }
 
 # Required as a dependency by `entry_point` attribute macro
-cosmwasm-std = { workspace = true }
+cosmwasm-std = { workspace = true, optional = true }
 
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/protocol/contracts/lpp/Cargo.toml
+++ b/protocol/contracts/lpp/Cargo.toml
@@ -16,7 +16,6 @@ net_main = ["currencies/net_main"]
 astroport = ["currencies/astroport"]
 osmosis = ["currencies/osmosis"]
 
-cosmwasm-bindings = ["contract"]
 contract = ["stub"]
 stub = []
 testing = ["currency/testing"]

--- a/protocol/contracts/lpp/Cargo.toml
+++ b/protocol/contracts/lpp/Cargo.toml
@@ -9,14 +9,14 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-net_dev = ["currencies/net_dev"]
-net_test = ["currencies/net_test"]
-net_main = ["currencies/net_main"]
+net_dev = ["contract", "currencies/net_dev"]
+net_test = ["contract", "currencies/net_test"]
+net_main = ["contract", "currencies/net_main"]
 
-astroport = ["currencies/astroport"]
-osmosis = ["currencies/osmosis"]
+astroport = ["contract", "currencies/astroport"]
+osmosis = ["contract", "currencies/osmosis"]
 
-contract = ["stub", "dep:cosmwasm-std", "dep:versioning"]
+contract = ["stub", "sdk/contract", "dep:cosmwasm-std", "dep:versioning"]
 stub = []
 testing = ["currency/testing"]
 
@@ -27,7 +27,7 @@ currency = { workspace = true }
 finance = { workspace = true }
 lpp-platform = { workspace = true }
 platform = { workspace = true }
-sdk = { workspace = true, features = ["contract"] }
+sdk = { workspace = true }
 versioning = { workspace = true, optional = true }
 
 # Required as a dependency by `entry_point` attribute macro

--- a/protocol/contracts/lpp/src/contract/mod.rs
+++ b/protocol/contracts/lpp/src/contract/mod.rs
@@ -6,7 +6,7 @@ use access_control::SingleUserAccess;
 use currencies::Lpns;
 use currency::{AnyVisitor, AnyVisitorResult, Currency, GroupVisit, Tickers};
 use platform::{message::Response as PlatformResponse, response};
-#[cfg(feature = "cosmwasm-bindings")]
+#[cfg(feature = "contract")]
 use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
@@ -70,7 +70,7 @@ impl<'a> AnyVisitor for InstantiateWithLpn<'a> {
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn instantiate(
     deps: DepsMut<'_>,
     _env: Env,
@@ -84,7 +84,7 @@ pub fn instantiate(
     InstantiateWithLpn::cmd(deps, msg).map(|()| response::empty_response())
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, msg: MigrateMsg) -> Result<CwResponse> {
     // Statically assert that the message is empty when doing a software-only update.
     let MigrateMsg {}: MigrateMsg = msg;
@@ -171,7 +171,7 @@ impl<'a> AnyVisitor for ExecuteWithLpn<'a> {
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn execute(
     mut deps: DepsMut<'_>,
     env: Env,
@@ -202,7 +202,7 @@ pub fn execute(
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> Result<CwResponse> {
     // no currency context variants
     match msg {
@@ -274,7 +274,7 @@ impl<'a> AnyVisitor for QueryWithLpn<'a> {
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> Result<Binary> {
     match msg {
         QueryMsg::Config() => to_json_binary(&Config::load(deps.storage)?).map_err(Into::into),

--- a/protocol/contracts/lpp/src/contract/mod.rs
+++ b/protocol/contracts/lpp/src/contract/mod.rs
@@ -6,11 +6,9 @@ use access_control::SingleUserAccess;
 use currencies::Lpns;
 use currency::{AnyVisitor, AnyVisitorResult, Currency, GroupVisit, Tickers};
 use platform::{message::Response as PlatformResponse, response};
-#[cfg(feature = "contract")]
-use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
-    cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo},
+    cosmwasm_std::{entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo},
 };
 use versioning::{package_version, version, SemVer, Version, VersionSegment};
 
@@ -70,7 +68,7 @@ impl<'a> AnyVisitor for InstantiateWithLpn<'a> {
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn instantiate(
     deps: DepsMut<'_>,
     _env: Env,
@@ -84,7 +82,7 @@ pub fn instantiate(
     InstantiateWithLpn::cmd(deps, msg).map(|()| response::empty_response())
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, msg: MigrateMsg) -> Result<CwResponse> {
     // Statically assert that the message is empty when doing a software-only update.
     let MigrateMsg {}: MigrateMsg = msg;
@@ -171,7 +169,7 @@ impl<'a> AnyVisitor for ExecuteWithLpn<'a> {
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn execute(
     mut deps: DepsMut<'_>,
     env: Env,
@@ -202,7 +200,7 @@ pub fn execute(
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> Result<CwResponse> {
     // no currency context variants
     match msg {
@@ -274,7 +272,7 @@ impl<'a> AnyVisitor for QueryWithLpn<'a> {
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> Result<Binary> {
     match msg {
         QueryMsg::Config() => to_json_binary(&Config::load(deps.storage)?).map_err(Into::into),

--- a/protocol/contracts/lpp/src/lib.rs
+++ b/protocol/contracts/lpp/src/lib.rs
@@ -1,17 +1,15 @@
+#[cfg(feature = "contract")]
+pub mod access_control;
 pub mod borrow;
+#[cfg(feature = "contract")]
+pub mod contract;
 pub mod error;
+#[cfg(feature = "contract")]
+pub mod event;
 pub mod loan;
+#[cfg(feature = "contract")]
+mod lpp;
 pub mod msg;
 pub mod state;
-
-#[cfg(any(feature = "stub", test))]
+#[cfg(feature = "stub")]
 pub mod stub;
-
-#[cfg(any(feature = "contract", test))]
-pub mod access_control;
-#[cfg(any(feature = "contract", test))]
-pub mod contract;
-#[cfg(any(feature = "contract", test))]
-pub mod event;
-#[cfg(any(feature = "contract", test))]
-mod lpp;

--- a/protocol/contracts/oracle/Cargo.toml
+++ b/protocol/contracts/oracle/Cargo.toml
@@ -11,25 +11,31 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-net_dev = ["currencies/net_dev"]
-net_test = ["currencies/net_test"]
-net_main = ["currencies/net_main"]
+net_dev = ["contract", "currencies/net_dev"]
+net_test = ["contract", "currencies/net_test"]
+net_main = ["contract", "currencies/net_main"]
 
-astroport = ["currencies/astroport"]
-osmosis = ["currencies/osmosis"]
+astroport = ["contract", "currencies/astroport"]
+osmosis = ["contract", "currencies/osmosis"]
 
-contract = ["stub", "dep:cosmwasm-std", "dep:versioning"]
+contract = [
+    "stub",
+    "sdk/contract",
+    "dep:cosmwasm-std",
+    "dep:currencies",
+    "dep:versioning",
+]
 testing = ["stub", "marketprice/testing"]
-stub = [] # TODO strip off any unnecessary dependency
+stub = ["dep:oracle-platform"]
 
 [dependencies]
-currencies = { workspace = true }
+currencies = { workspace = true, optional = true }
 currency = { workspace = true }
 finance = { workspace = true }
 marketprice = { workspace = true }
-oracle-platform = { workspace = true }
+oracle-platform = { workspace = true, optional = true }
 platform = { workspace = true }
-sdk = { workspace = true, features = ["contract"] }
+sdk = { workspace = true }
 swap = { workspace = true }
 tree = { workspace = true, features = ["schema"] }
 versioning = { workspace = true, optional = true, features = ["schema"] }

--- a/protocol/contracts/oracle/Cargo.toml
+++ b/protocol/contracts/oracle/Cargo.toml
@@ -18,7 +18,7 @@ net_main = ["currencies/net_main"]
 astroport = ["currencies/astroport"]
 osmosis = ["currencies/osmosis"]
 
-contract = ["stub"]
+contract = ["stub", "dep:cosmwasm-std", "dep:versioning"]
 testing = ["stub", "marketprice/testing"]
 stub = [] # TODO strip off any unnecessary dependency
 
@@ -32,10 +32,10 @@ platform = { workspace = true }
 sdk = { workspace = true, features = ["contract"] }
 swap = { workspace = true }
 tree = { workspace = true, features = ["schema"] }
-versioning = { workspace = true, features = ["schema"] }
+versioning = { workspace = true, optional = true, features = ["schema"] }
 
 # Required as a dependency by `entry_point` attribute macro
-cosmwasm-std = { workspace = true }
+cosmwasm-std = { workspace = true, optional = true }
 
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/protocol/contracts/oracle/Cargo.toml
+++ b/protocol/contracts/oracle/Cargo.toml
@@ -18,7 +18,6 @@ net_main = ["currencies/net_main"]
 astroport = ["currencies/astroport"]
 osmosis = ["currencies/osmosis"]
 
-cosmwasm-bindings = ["contract"]
 contract = ["stub"]
 testing = ["stub", "marketprice/testing"]
 stub = [] # TODO strip off any unnecessary dependency

--- a/protocol/contracts/oracle/src/contract/mod.rs
+++ b/protocol/contracts/oracle/src/contract/mod.rs
@@ -4,7 +4,7 @@ use platform::{
     batch::{Emit, Emitter},
     response,
 };
-#[cfg(feature = "cosmwasm-bindings")]
+#[cfg(feature = "contract")]
 use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
@@ -74,7 +74,7 @@ impl<'a> AnyVisitor for InstantiateWithCurrency<'a> {
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn instantiate(
     deps: DepsMut<'_>,
     _env: Env,
@@ -89,7 +89,7 @@ pub fn instantiate(
     Ok(response::empty_response())
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult<CwResponse> {
     versioning::update_software(
         deps.storage,
@@ -99,7 +99,7 @@ pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult
     .and_then(response::response)
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::ContractVersion {} => {
@@ -120,7 +120,7 @@ pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> 
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn execute(
     deps: DepsMut<'_>,
     env: Env,
@@ -130,7 +130,7 @@ pub fn execute(
     ExecWithOracleBase::cmd(deps, env, msg, info.sender)
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<CwResponse> {
     match msg {
         SudoMsg::UpdateConfig(price_config) => Config::update(deps.storage, price_config),
@@ -142,7 +142,7 @@ pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<CwResp
 }
 
 // TODO: compare gas usage of this solution vs reply on error
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn reply(deps: DepsMut<'_>, _env: Env, msg: Reply) -> ContractResult<CwResponse> {
     const EVENT_TYPE: &str = "market-alarm";
     const KEY_DELIVERED: &str = "delivered";

--- a/protocol/contracts/oracle/src/contract/mod.rs
+++ b/protocol/contracts/oracle/src/contract/mod.rs
@@ -4,12 +4,11 @@ use platform::{
     batch::{Emit, Emitter},
     response,
 };
-#[cfg(feature = "contract")]
-use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
     cosmwasm_std::{
-        to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Storage, SubMsgResult,
+        entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Storage,
+        SubMsgResult,
     },
 };
 use versioning::{package_version, version, SemVer, Version, VersionSegment};
@@ -74,7 +73,7 @@ impl<'a> AnyVisitor for InstantiateWithCurrency<'a> {
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn instantiate(
     deps: DepsMut<'_>,
     _env: Env,
@@ -89,7 +88,7 @@ pub fn instantiate(
     Ok(response::empty_response())
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult<CwResponse> {
     versioning::update_software(
         deps.storage,
@@ -99,7 +98,7 @@ pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult
     .and_then(response::response)
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::ContractVersion {} => {
@@ -120,7 +119,7 @@ pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> 
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn execute(
     deps: DepsMut<'_>,
     env: Env,
@@ -130,7 +129,7 @@ pub fn execute(
     ExecWithOracleBase::cmd(deps, env, msg, info.sender)
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<CwResponse> {
     match msg {
         SudoMsg::UpdateConfig(price_config) => Config::update(deps.storage, price_config),
@@ -142,7 +141,7 @@ pub fn sudo(deps: DepsMut<'_>, _env: Env, msg: SudoMsg) -> ContractResult<CwResp
 }
 
 // TODO: compare gas usage of this solution vs reply on error
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn reply(deps: DepsMut<'_>, _env: Env, msg: Reply) -> ContractResult<CwResponse> {
     const EVENT_TYPE: &str = "market-alarm";
     const KEY_DELIVERED: &str = "delivered";

--- a/protocol/contracts/oracle/src/error.rs
+++ b/protocol/contracts/oracle/src/error.rs
@@ -2,7 +2,9 @@ use std::{num::TryFromIntError, result::Result as StdResult};
 
 use thiserror::Error;
 
-use currency::{Currency, SymbolOwned, SymbolSlice};
+use currency::SymbolOwned;
+#[cfg(feature = "contract")]
+use currency::{Currency, SymbolSlice};
 use marketprice::{alarms::errors::AlarmError, error::PriceFeedsError, feeders::PriceFeedersError};
 use sdk::cosmwasm_std::{Addr, StdError};
 
@@ -98,7 +100,8 @@ pub enum ContractError {
     Conversion(#[from] TryFromIntError),
 }
 
-pub fn unsupported_currency<C>(unsupported: &SymbolSlice) -> ContractError
+#[cfg(feature = "contract")]
+pub(crate) fn unsupported_currency<C>(unsupported: &SymbolSlice) -> ContractError
 where
     C: Currency,
 {

--- a/protocol/contracts/oracle/src/lib.rs
+++ b/protocol/contracts/oracle/src/lib.rs
@@ -4,7 +4,7 @@ pub mod alarms;
 #[cfg(feature = "contract")]
 pub mod contract;
 pub mod error;
-#[cfg(feature = "testing")]
+#[cfg(any(feature = "testing", test))]
 mod macros;
 pub mod msg;
 pub mod result;

--- a/protocol/contracts/oracle/src/lib.rs
+++ b/protocol/contracts/oracle/src/lib.rs
@@ -1,18 +1,15 @@
 pub use crate::error::ContractError;
 
 pub mod alarms;
+#[cfg(feature = "contract")]
+pub mod contract;
 pub mod error;
+#[cfg(feature = "testing")]
+mod macros;
 pub mod msg;
 pub mod result;
 pub mod state;
-
-#[cfg(any(feature = "contract", test))]
-pub mod contract;
-#[cfg(any(feature = "stub", test))]
+#[cfg(feature = "stub")]
 pub mod stub;
-
-#[cfg(any(test, feature = "testing"))]
-mod macros;
-
 #[cfg(test)]
-pub mod tests;
+mod tests;

--- a/protocol/contracts/oracle/src/state/supported_pairs/contract.rs
+++ b/protocol/contracts/oracle/src/state/supported_pairs/contract.rs
@@ -1,0 +1,204 @@
+use std::{fmt::Debug, marker::PhantomData};
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use currencies::PaymentGroup;
+use currency::{
+    AnyVisitor, AnyVisitorResult, Currency, GroupVisit, SymbolOwned, SymbolSlice, Tickers,
+};
+use sdk::{cosmwasm_std::Storage, cw_storage_plus::Item};
+use swap::SwapTarget;
+use tree::{FindBy as _, NodeRef};
+
+use crate::{
+    error::{self, ContractError},
+    result::ContractResult,
+};
+
+use super::{CurrencyPair, SwapLeg};
+
+type Tree = tree::Tree<SwapTarget>;
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+pub struct SupportedPairs<B>
+where
+    B: Currency,
+{
+    tree: Tree,
+    _type: PhantomData<B>,
+}
+
+impl<'a, B> SupportedPairs<B>
+where
+    B: Currency,
+{
+    const DB_ITEM: Item<'a, SupportedPairs<B>> = Item::new("supported_pairs");
+
+    pub fn new(tree: Tree) -> Result<Self, ContractError> {
+        if tree.root().value().target != B::TICKER {
+            return Err(ContractError::InvalidBaseCurrency(
+                tree.root().value().target.clone(),
+                ToOwned::to_owned(B::TICKER),
+            ));
+        }
+
+        // check for duplicated nodes
+        let mut supported_currencies: Vec<&SymbolOwned> =
+            tree.iter().map(|node| &node.value().target).collect();
+
+        supported_currencies.sort();
+
+        if (0..supported_currencies.len() - 1)
+            .any(|index| supported_currencies[index] == supported_currencies[index + 1])
+        {
+            return Err(ContractError::DuplicatedNodes {});
+        }
+
+        Ok(SupportedPairs {
+            tree,
+            _type: PhantomData,
+        })
+    }
+
+    pub fn validate_tickers(&self) -> Result<&Self, ContractError> {
+        struct TickerChecker;
+
+        impl AnyVisitor for TickerChecker {
+            type Output = ();
+            type Error = ContractError;
+
+            fn on<C>(self) -> AnyVisitorResult<Self>
+            where
+                C: Currency + Serialize + DeserializeOwned + 'static,
+            {
+                Ok(())
+            }
+        }
+
+        for swap in self.tree.iter() {
+            Tickers.visit_any::<PaymentGroup, _>(&swap.value().target, TickerChecker)?;
+        }
+
+        Ok(self)
+    }
+
+    pub fn load(storage: &dyn Storage) -> ContractResult<Self> {
+        Self::DB_ITEM
+            .load(storage)
+            .map_err(ContractError::LoadSupportedPairs)
+    }
+
+    pub fn save(&self, storage: &mut dyn Storage) -> ContractResult<()> {
+        Self::DB_ITEM
+            .save(storage, self)
+            .map_err(ContractError::StoreSupportedPairs)
+    }
+
+    pub fn load_path(
+        &self,
+        query: &SymbolSlice,
+    ) -> Result<impl Iterator<Item = &SymbolSlice> + DoubleEndedIterator + '_, ContractError> {
+        self.internal_load_path(query)
+            .map(|iter| iter.map(|node| node.value().target.as_str()))
+    }
+
+    pub fn load_swap_path(
+        &self,
+        from: &SymbolSlice,
+        to: &SymbolSlice,
+    ) -> Result<Vec<SwapTarget>, ContractError> {
+        let path_from = self.internal_load_path(from)?;
+
+        let mut path_to: Vec<_> = self.internal_load_path(to)?.collect();
+
+        let mut path = vec![];
+
+        path.extend(
+            path_from
+                .take_while(|node| {
+                    if let Some((index, _)) = path_to
+                        .iter()
+                        .enumerate()
+                        .rfind(|&(_, to_node)| node.value() == to_node.value())
+                    {
+                        path_to.truncate(index);
+
+                        return false;
+                    }
+
+                    true
+                })
+                .filter_map(|node| {
+                    Some(SwapTarget {
+                        pool_id: node.value().pool_id,
+                        target: node.parent()?.value().target.clone(),
+                    })
+                }),
+        );
+
+        path_to
+            .into_iter()
+            .rev()
+            .for_each(|node| path.push(node.value().clone()));
+
+        Ok(path)
+    }
+
+    pub fn load_affected(&self, pair: CurrencyPair<'_>) -> Result<Vec<SymbolOwned>, ContractError> {
+        if let Some(node) = self.tree.find_by(|target| target.target == pair.0) {
+            if node
+                .parent()
+                .map_or(false, |parent| parent.value().target == pair.1)
+            {
+                return Ok(node
+                    .to_subtree()
+                    .iter()
+                    .map(|node| node.value().target.clone())
+                    .collect());
+            }
+        }
+
+        Err(ContractError::InvalidDenomPair(
+            ToOwned::to_owned(pair.0),
+            ToOwned::to_owned(pair.1),
+        ))
+    }
+
+    pub fn swap_pairs_df(&self) -> impl Iterator<Item = SwapLeg> + '_ {
+        self.tree
+            .iter()
+            .filter_map(|node: NodeRef<'_, SwapTarget>| {
+                let parent: NodeRef<'_, SwapTarget> = node.parent()?;
+
+                let SwapTarget {
+                    pool_id,
+                    target: child,
+                } = node.value().clone();
+
+                Some(SwapLeg {
+                    from: child,
+                    to: SwapTarget {
+                        pool_id,
+                        target: parent.value().target.clone(),
+                    },
+                })
+            })
+    }
+
+    pub fn query_swap_tree(self) -> Tree {
+        self.tree
+    }
+
+    fn internal_load_path(
+        &self,
+        query: &SymbolSlice,
+    ) -> Result<
+        impl Iterator<Item = NodeRef<'_, SwapTarget>> + DoubleEndedIterator + '_,
+        ContractError,
+    > {
+        self.tree
+            .find_by(|target| target.target == query)
+            .map(|node| std::iter::once(node).chain(node.parents_iter()))
+            .ok_or_else(|| error::unsupported_currency::<B>(query))
+    }
+}

--- a/protocol/contracts/oracle/src/state/supported_pairs/mod.rs
+++ b/protocol/contracts/oracle/src/state/supported_pairs/mod.rs
@@ -1,19 +1,15 @@
-use std::{fmt::Debug, marker::PhantomData};
+use std::fmt::Debug;
 
-use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use currencies::PaymentGroup;
-use currency::{
-    AnyVisitor, AnyVisitorResult, Currency, GroupVisit, SymbolOwned, SymbolSlice, Tickers,
-};
-use sdk::{cosmwasm_std::Storage, cw_storage_plus::Item};
+use currency::{SymbolOwned, SymbolSlice};
 use swap::SwapTarget;
-use tree::{FindBy as _, NodeRef};
 
-use crate::{
-    error::{self, ContractError},
-    result::ContractResult,
-};
+#[cfg(feature = "contract")]
+pub use self::contract::SupportedPairs;
+
+#[cfg(feature = "contract")]
+mod contract;
 
 pub type ResolutionPath = Vec<SymbolOwned>;
 pub type CurrencyPair<'a> = (&'a SymbolSlice, &'a SymbolSlice);
@@ -39,192 +35,6 @@ impl<'de> Deserialize<'de> for SwapLeg {
         D: Deserializer<'de>,
     {
         Deserialize::deserialize(deserializer).map(|(from, to)| Self { from, to })
-    }
-}
-
-type Tree = tree::Tree<SwapTarget>;
-
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-pub struct SupportedPairs<B>
-where
-    B: Currency,
-{
-    tree: Tree,
-    _type: PhantomData<B>,
-}
-
-impl<'a, B> SupportedPairs<B>
-where
-    B: Currency,
-{
-    const DB_ITEM: Item<'a, SupportedPairs<B>> = Item::new("supported_pairs");
-
-    pub fn new(tree: Tree) -> Result<Self, ContractError> {
-        if tree.root().value().target != B::TICKER {
-            return Err(ContractError::InvalidBaseCurrency(
-                tree.root().value().target.clone(),
-                ToOwned::to_owned(B::TICKER),
-            ));
-        }
-
-        // check for duplicated nodes
-        let mut supported_currencies: Vec<&SymbolOwned> =
-            tree.iter().map(|node| &node.value().target).collect();
-
-        supported_currencies.sort();
-
-        if (0..supported_currencies.len() - 1)
-            .any(|index| supported_currencies[index] == supported_currencies[index + 1])
-        {
-            return Err(ContractError::DuplicatedNodes {});
-        }
-
-        Ok(SupportedPairs {
-            tree,
-            _type: PhantomData,
-        })
-    }
-
-    pub fn validate_tickers(&self) -> Result<&Self, ContractError> {
-        struct TickerChecker;
-
-        impl AnyVisitor for TickerChecker {
-            type Output = ();
-            type Error = ContractError;
-
-            fn on<C>(self) -> AnyVisitorResult<Self>
-            where
-                C: Currency + Serialize + DeserializeOwned + 'static,
-            {
-                Ok(())
-            }
-        }
-
-        for swap in self.tree.iter() {
-            Tickers.visit_any::<PaymentGroup, _>(&swap.value().target, TickerChecker)?;
-        }
-
-        Ok(self)
-    }
-
-    pub fn load(storage: &dyn Storage) -> ContractResult<Self> {
-        Self::DB_ITEM
-            .load(storage)
-            .map_err(ContractError::LoadSupportedPairs)
-    }
-
-    pub fn save(&self, storage: &mut dyn Storage) -> ContractResult<()> {
-        Self::DB_ITEM
-            .save(storage, self)
-            .map_err(ContractError::StoreSupportedPairs)
-    }
-
-    pub fn load_path(
-        &self,
-        query: &SymbolSlice,
-    ) -> Result<impl Iterator<Item = &SymbolSlice> + DoubleEndedIterator + '_, ContractError> {
-        self.internal_load_path(query)
-            .map(|iter| iter.map(|node| node.value().target.as_str()))
-    }
-
-    pub fn load_swap_path(
-        &self,
-        from: &SymbolSlice,
-        to: &SymbolSlice,
-    ) -> Result<Vec<SwapTarget>, ContractError> {
-        let path_from = self.internal_load_path(from)?;
-
-        let mut path_to: Vec<_> = self.internal_load_path(to)?.collect();
-
-        let mut path = vec![];
-
-        path.extend(
-            path_from
-                .take_while(|node| {
-                    if let Some((index, _)) = path_to
-                        .iter()
-                        .enumerate()
-                        .rfind(|&(_, to_node)| node.value() == to_node.value())
-                    {
-                        path_to.truncate(index);
-
-                        return false;
-                    }
-
-                    true
-                })
-                .filter_map(|node| {
-                    Some(SwapTarget {
-                        pool_id: node.value().pool_id,
-                        target: node.parent()?.value().target.clone(),
-                    })
-                }),
-        );
-
-        path_to
-            .into_iter()
-            .rev()
-            .for_each(|node| path.push(node.value().clone()));
-
-        Ok(path)
-    }
-
-    pub fn load_affected(&self, pair: CurrencyPair<'_>) -> Result<Vec<SymbolOwned>, ContractError> {
-        if let Some(node) = self.tree.find_by(|target| target.target == pair.0) {
-            if node
-                .parent()
-                .map_or(false, |parent| parent.value().target == pair.1)
-            {
-                return Ok(node
-                    .to_subtree()
-                    .iter()
-                    .map(|node| node.value().target.clone())
-                    .collect());
-            }
-        }
-
-        Err(ContractError::InvalidDenomPair(
-            ToOwned::to_owned(pair.0),
-            ToOwned::to_owned(pair.1),
-        ))
-    }
-
-    pub fn swap_pairs_df(&self) -> impl Iterator<Item = SwapLeg> + '_ {
-        self.tree
-            .iter()
-            .filter_map(|node: NodeRef<'_, SwapTarget>| {
-                let parent: NodeRef<'_, SwapTarget> = node.parent()?;
-
-                let SwapTarget {
-                    pool_id,
-                    target: child,
-                } = node.value().clone();
-
-                Some(SwapLeg {
-                    from: child,
-                    to: SwapTarget {
-                        pool_id,
-                        target: parent.value().target.clone(),
-                    },
-                })
-            })
-    }
-
-    pub fn query_swap_tree(self) -> Tree {
-        self.tree
-    }
-
-    fn internal_load_path(
-        &self,
-        query: &SymbolSlice,
-    ) -> Result<
-        impl Iterator<Item = NodeRef<'_, SwapTarget>> + DoubleEndedIterator + '_,
-        ContractError,
-    > {
-        self.tree
-            .find_by(|target| target.target == query)
-            .map(|node| std::iter::once(node).chain(node.parents_iter()))
-            .ok_or_else(|| error::unsupported_currency::<B>(query))
     }
 }
 

--- a/protocol/contracts/oracle/src/tests/mod.rs
+++ b/protocol/contracts/oracle/src/tests/mod.rs
@@ -74,7 +74,7 @@ pub(crate) fn dummy_default_instantiate_msg() -> InstantiateMsg {
         StableC1::TICKER.to_string(),
         60,
         Percent::from_percent(50),
-        cosmwasm_std::from_json(format!(
+        sdk::cosmwasm_std::from_json(format!(
             r#"{{
                 "value":[0,"{usdc}"],
                 "children":[

--- a/protocol/contracts/profit/Cargo.toml
+++ b/protocol/contracts/profit/Cargo.toml
@@ -18,7 +18,7 @@ net_main = ["dex/net_main"]
 astroport = ["api", "dex/astroport"]
 osmosis = ["api", "dex/osmosis"]
 
-cosmwasm-bindings = []
+contract = []
 api = []
 stub = ["api"]
 testing = []

--- a/protocol/contracts/profit/Cargo.toml
+++ b/protocol/contracts/profit/Cargo.toml
@@ -18,7 +18,7 @@ net_main = ["dex/net_main"]
 astroport = ["api", "dex/astroport"]
 osmosis = ["api", "dex/osmosis"]
 
-contract = []
+contract = ["dep:cosmwasm-std", "dep:versioning"]
 api = []
 stub = ["api"]
 testing = []
@@ -33,10 +33,10 @@ oracle-platform = { workspace = true }
 platform = { workspace = true }
 sdk = { workspace = true, features = ["contract"] }
 timealarms = { workspace = true, features = ["stub"] }
-versioning = { workspace = true }
+versioning = { workspace = true, optional = true }
 
 # Required as a dependency by `entry_point` attribute macro
-cosmwasm-std = { workspace = true }
+cosmwasm-std = { workspace = true, optional = true }
 
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/protocol/contracts/profit/Cargo.toml
+++ b/protocol/contracts/profit/Cargo.toml
@@ -11,34 +11,46 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-net_dev = ["dex/net_dev"]
-net_test = ["dex/net_test"]
-net_main = ["dex/net_main"]
+net_dev = ["contract", "dex/net_dev"]
+net_test = ["contract", "dex/net_test"]
+net_main = ["contract", "dex/net_main"]
 
-astroport = ["api", "dex/astroport"]
-osmosis = ["api", "dex/osmosis"]
+astroport = ["contract", "dex/astroport"]
+osmosis = ["contract", "dex/osmosis"]
 
-contract = ["dep:cosmwasm-std", "dep:versioning"]
-api = []
-stub = ["api"]
+contract = [
+    "sdk/contract",
+    "dep:access-control",
+    "dep:cosmwasm-std",
+    "dep:currencies",
+    "dep:currency",
+    "dep:dex",
+    "dep:finance",
+    "dep:oracle-platform",
+    "dep:platform",
+    "dep:timealarms",
+    "dep:thiserror",
+    "dep:versioning",
+]
+stub = ["dep:platform", "dep:thiserror"]
 testing = []
 
 [dependencies]
-access-control = { workspace = true }
-currencies = { workspace = true }
-currency = { workspace = true }
+access-control = { workspace = true, optional = true }
+currencies = { workspace = true, optional = true }
+currency = { workspace = true, optional = true }
 dex = { workspace = true, optional = true }
-finance = { workspace = true }
-oracle-platform = { workspace = true }
-platform = { workspace = true }
-sdk = { workspace = true, features = ["contract"] }
-timealarms = { workspace = true, features = ["stub"] }
+finance = { workspace = true, optional = true }
+oracle-platform = { workspace = true, optional = true }
+platform = { workspace = true, optional = true }
+sdk = { workspace = true }
+timealarms = { workspace = true, optional = true, features = ["stub"] }
 versioning = { workspace = true, optional = true }
 
 # Required as a dependency by `entry_point` attribute macro
 cosmwasm-std = { workspace = true, optional = true }
 
-thiserror = { workspace = true }
+thiserror = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/protocol/contracts/profit/src/contract.rs
+++ b/protocol/contracts/profit/src/contract.rs
@@ -9,7 +9,7 @@ use oracle_platform::OracleRef;
 use platform::{
     message::Response as MessageResponse, response, state_machine::Response as StateMachineResponse,
 };
-#[cfg(feature = "cosmwasm-bindings")]
+#[cfg(feature = "contract")]
 use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
@@ -32,7 +32,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 1;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn instantiate(
     mut deps: DepsMut<'_>,
     _env: Env,
@@ -64,13 +64,13 @@ pub fn instantiate(
     Ok(response::empty_response())
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult<CwResponse> {
     versioning::update_software(deps.storage, CONTRACT_VERSION, Into::into)
         .and_then(response::response)
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn execute(
     deps: DepsMut<'_>,
     env: Env,
@@ -115,7 +115,7 @@ pub fn execute(
     }
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn sudo(deps: DepsMut<'_>, env: Env, msg: NeutronSudoMsg) -> ContractResult<CwResponse> {
     let state: State = State::load(deps.storage)?;
 
@@ -129,7 +129,7 @@ pub fn sudo(deps: DepsMut<'_>, env: Env, msg: NeutronSudoMsg) -> ContractResult<
     Ok(response::response_only_messages(response))
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn reply(deps: DepsMut<'_>, env: Env, msg: Reply) -> ContractResult<CwResponse> {
     try_handle_reply_message(deps, env, msg, State::reply).map(response::response_only_messages)
 }
@@ -217,7 +217,7 @@ where
         .map_err(Into::into)
 }
 
-#[cfg_attr(feature = "cosmwasm-bindings", entry_point)]
+#[cfg_attr(feature = "contract", entry_point)]
 pub fn query(deps: Deps<'_>, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_json_binary(&Profit::query_config(deps.storage)?),

--- a/protocol/contracts/profit/src/contract.rs
+++ b/protocol/contracts/profit/src/contract.rs
@@ -9,11 +9,9 @@ use oracle_platform::OracleRef;
 use platform::{
     message::Response as MessageResponse, response, state_machine::Response as StateMachineResponse,
 };
-#[cfg(feature = "contract")]
-use sdk::cosmwasm_std::entry_point;
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
-    cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply},
+    cosmwasm_std::{entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply},
     neutron_sdk::sudo::msg::SudoMsg as NeutronSudoMsg,
 };
 use timealarms::stub::TimeAlarmsRef;
@@ -32,7 +30,7 @@ const CONTRACT_STORAGE_VERSION: VersionSegment = 1;
 const PACKAGE_VERSION: SemVer = package_version!();
 const CONTRACT_VERSION: Version = version!(CONTRACT_STORAGE_VERSION, PACKAGE_VERSION);
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn instantiate(
     mut deps: DepsMut<'_>,
     _env: Env,
@@ -64,13 +62,13 @@ pub fn instantiate(
     Ok(response::empty_response())
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> ContractResult<CwResponse> {
     versioning::update_software(deps.storage, CONTRACT_VERSION, Into::into)
         .and_then(response::response)
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn execute(
     deps: DepsMut<'_>,
     env: Env,
@@ -115,7 +113,7 @@ pub fn execute(
     }
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn sudo(deps: DepsMut<'_>, env: Env, msg: NeutronSudoMsg) -> ContractResult<CwResponse> {
     let state: State = State::load(deps.storage)?;
 
@@ -129,7 +127,7 @@ pub fn sudo(deps: DepsMut<'_>, env: Env, msg: NeutronSudoMsg) -> ContractResult<
     Ok(response::response_only_messages(response))
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn reply(deps: DepsMut<'_>, env: Env, msg: Reply) -> ContractResult<CwResponse> {
     try_handle_reply_message(deps, env, msg, State::reply).map(response::response_only_messages)
 }
@@ -217,7 +215,7 @@ where
         .map_err(Into::into)
 }
 
-#[cfg_attr(feature = "contract", entry_point)]
+#[entry_point]
 pub fn query(deps: Deps<'_>, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_json_binary(&Profit::query_config(deps.storage)?),

--- a/protocol/contracts/profit/src/error.rs
+++ b/protocol/contracts/profit/src/error.rs
@@ -46,6 +46,7 @@ pub enum ContractError {
     EmptyBalance {},
 }
 
+#[cfg(feature = "contract")]
 impl ContractError {
     pub(crate) fn unsupported_operation(msg: &'static str) -> Self {
         Self::UnsupportedOperation(String::from(msg))

--- a/protocol/contracts/profit/src/error.rs
+++ b/protocol/contracts/profit/src/error.rs
@@ -46,7 +46,6 @@ pub enum ContractError {
     EmptyBalance {},
 }
 
-#[cfg(feature = "contract")]
 impl ContractError {
     pub(crate) fn unsupported_operation(msg: &'static str) -> Self {
         Self::UnsupportedOperation(String::from(msg))

--- a/protocol/contracts/profit/src/lib.rs
+++ b/protocol/contracts/profit/src/lib.rs
@@ -9,7 +9,7 @@ pub mod stub;
 #[cfg(any(feature = "astroport", feature = "osmosis"))]
 mod access_control;
 
-#[cfg(any(feature = "astroport", feature = "osmosis"))]
+#[cfg(all(feature = "contract", any(feature = "astroport", feature = "osmosis")))]
 pub mod contract;
 
 #[cfg(any(feature = "astroport", feature = "osmosis"))]

--- a/protocol/contracts/profit/src/lib.rs
+++ b/protocol/contracts/profit/src/lib.rs
@@ -6,20 +6,15 @@ pub mod typedefs;
 #[cfg(feature = "stub")]
 pub mod stub;
 
-#[cfg(any(feature = "astroport", feature = "osmosis"))]
+#[cfg(all(feature = "contract", any(feature = "astroport", feature = "osmosis")))]
 mod access_control;
-
 #[cfg(all(feature = "contract", any(feature = "astroport", feature = "osmosis")))]
 pub mod contract;
-
 #[cfg(any(feature = "astroport", feature = "osmosis"))]
 pub mod error;
-
-#[cfg(any(feature = "astroport", feature = "osmosis"))]
+#[cfg(all(feature = "contract", any(feature = "astroport", feature = "osmosis")))]
 pub mod profit;
-
 #[cfg(any(feature = "astroport", feature = "osmosis"))]
 pub mod result;
-
-#[cfg(any(feature = "astroport", feature = "osmosis"))]
+#[cfg(all(feature = "contract", any(feature = "astroport", feature = "osmosis")))]
 pub mod state;

--- a/protocol/contracts/profit/src/lib.rs
+++ b/protocol/contracts/profit/src/lib.rs
@@ -1,20 +1,18 @@
-#[cfg(feature = "api")]
 pub mod msg;
-#[cfg(feature = "api")]
 pub mod typedefs;
 
 #[cfg(feature = "stub")]
 pub mod stub;
 
-#[cfg(all(feature = "contract", any(feature = "astroport", feature = "osmosis")))]
+#[cfg(feature = "contract")]
 mod access_control;
-#[cfg(all(feature = "contract", any(feature = "astroport", feature = "osmosis")))]
+#[cfg(feature = "contract")]
 pub mod contract;
-#[cfg(any(feature = "astroport", feature = "osmosis"))]
+#[cfg(feature = "contract")]
 pub mod error;
-#[cfg(all(feature = "contract", any(feature = "astroport", feature = "osmosis")))]
+#[cfg(feature = "contract")]
 pub mod profit;
-#[cfg(any(feature = "astroport", feature = "osmosis"))]
+#[cfg(feature = "contract")]
 pub mod result;
-#[cfg(all(feature = "contract", any(feature = "astroport", feature = "osmosis")))]
+#[cfg(feature = "contract")]
 pub mod state;

--- a/protocol/contracts/profit/src/state/open_transfer_channel.rs
+++ b/protocol/contracts/profit/src/state/open_transfer_channel.rs
@@ -56,6 +56,6 @@ impl SetupDexHandler for OpenTransferChannel {
 
 impl Display for OpenTransferChannel {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_fmt(format_args!("OpenTransferChannel"))
+        f.write_str("OpenTransferChannel")
     }
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,8 +12,8 @@ astroport = ["lease/astroport", "profit/astroport"]
 osmosis = ["lease/osmosis", "profit/osmosis"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-lease = { path = "../protocol/contracts/lease", features = ["net_main", "contract", "testing"] }
-leaser = { path = "../protocol/contracts/leaser", features = ["net_main", "contract", "testing"] }
+lease = { path = "../protocol/contracts/lease", features = ["net_main", "testing"] }
+leaser = { path = "../protocol/contracts/leaser", features = ["net_main", "testing"] }
 lpp = { path = "../protocol/contracts/lpp", features = ["net_main", "contract", "testing"] }
 oracle = { path = "../protocol/contracts/oracle", features = ["net_main", "contract", "testing"] }
 profit = { path = "../protocol/contracts/profit", features = ["net_main", "contract", "testing"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,11 +12,11 @@ astroport = ["lease/astroport", "profit/astroport"]
 osmosis = ["lease/osmosis", "profit/osmosis"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-lease = { path = "../protocol/contracts/lease", features = ["net_main", "testing"] }
-leaser = { path = "../protocol/contracts/leaser", features = ["net_main", "testing"] }
+lease = { path = "../protocol/contracts/lease", features = ["net_main", "contract", "testing"] }
+leaser = { path = "../protocol/contracts/leaser", features = ["net_main", "contract", "testing"] }
 lpp = { path = "../protocol/contracts/lpp", features = ["net_main", "contract", "testing"] }
 oracle = { path = "../protocol/contracts/oracle", features = ["net_main", "contract", "testing"] }
-profit = { path = "../protocol/contracts/profit", features = ["net_main", "testing"] }
+profit = { path = "../protocol/contracts/profit", features = ["net_main", "contract", "testing"] }
 rewards_dispatcher = { path = "../platform/contracts/dispatcher", features = [] }
 timealarms = { path = "../platform/contracts/timealarms", features = ["contract", "testing"] }
 treasury = { path = "../platform/contracts/treasury", features = ["contract"] }

--- a/tests/src/common/leaser.rs
+++ b/tests/src/common/leaser.rs
@@ -4,8 +4,9 @@ use currency::Currency;
 use finance::{coin::Coin, duration::Duration, liability::Liability, percent::Percent, test};
 use lease::api::{InterestPaymentSpec, LpnCoin, PositionSpecDTO};
 use leaser::{
-    contract::{execute, instantiate, query, reply, sudo},
+    execute, instantiate,
     msg::{InstantiateMsg, QueryMsg, QuoteResponse},
+    query, reply, sudo,
 };
 use platform::contract::CodeId;
 use sdk::cosmwasm_std::{Addr, Uint64};


### PR DESCRIPTION
As I investigated the `entry_point` attribute macro, it appears to only add exports only when the target is WebAssembly. As a consequence of that even when the integration tests pull the contract packages with the `contract` feature it won't affect the workflow, as the integration tests are in a way prohibited from targeting WebAssembly.

The result is that, `contract` and `cosmwasm-bindings` can be freely combined, which is the intent of this PR.