### PR TITLE
refactor: Abstract away CosmWasm's `dyn Storage`

### DIFF
--- a/platform/contracts/admin/src/contracts/impl_mod.rs
+++ b/platform/contracts/admin/src/contracts/impl_mod.rs
@@ -1,7 +1,10 @@
 use std::collections::BTreeMap;
 
 use platform::{batch::Batch, message::Response as MessageResponse};
-use sdk::cosmwasm_std::{Addr, Binary, Storage, WasmMsg};
+use sdk::{
+    cosmwasm_ext::as_dyn::storage,
+    cosmwasm_std::{Addr, Binary, WasmMsg},
+};
 use versioning::ReleaseLabel;
 
 use crate::{
@@ -73,13 +76,16 @@ where
     }
 }
 
-pub(crate) fn migrate(
-    storage: &mut dyn Storage,
+pub(crate) fn migrate<S>(
+    storage: &mut S,
     admin_contract_addr: Addr,
     release: ReleaseLabel,
     migration_spec: ContractsMigration,
     post_migration_execute: ContractsPostMigrationExecute,
-) -> Result<MessageResponse> {
+) -> Result<MessageResponse>
+where
+    S: storage::DynMut + ?Sized,
+{
     ContractState::AwaitContractsMigrationReply { release }.store(storage)?;
 
     let contracts_addrs: ContractsGroupedByProtocol = state_contracts::load_all(storage)?;

--- a/platform/contracts/admin/src/endpoints.rs
+++ b/platform/contracts/admin/src/endpoints.rs
@@ -1,10 +1,10 @@
 use access_control::ContractOwnerAccess;
 use platform::{batch::Batch, contract::CodeId, response};
 use sdk::{
-    cosmwasm_ext::Response as CwResponse,
+    cosmwasm_ext::{as_dyn::storage, Response as CwResponse},
     cosmwasm_std::{
         ensure_eq, entry_point, to_json_binary, Addr, Api, Binary, CodeInfoResponse, Deps, DepsMut,
-        Env, MessageInfo, QuerierWrapper, Reply, Storage, WasmMsg,
+        Env, MessageInfo, QuerierWrapper, Reply, WasmMsg,
     },
 };
 use versioning::{package_version, version, ReleaseLabel, SemVer, Version, VersionSegment};
@@ -232,12 +232,15 @@ fn instantiate_reply(
     }
 }
 
-fn register_protocol(
-    storage: &mut dyn Storage,
+fn register_protocol<S>(
+    storage: &mut S,
     querier: QuerierWrapper<'_>,
     name: String,
     protocol: &Protocol,
-) -> ContractResult<CwResponse> {
+) -> ContractResult<CwResponse>
+where
+    S: storage::DynMut + ?Sized,
+{
     protocol.validate(querier)?;
 
     state_contracts::add_protocol(storage, name, protocol).map(|()| response::empty_response())

--- a/platform/contracts/admin/src/state/contract.rs
+++ b/platform/contracts/admin/src/state/contract.rs
@@ -2,7 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use platform::contract::CodeId;
 use sdk::{
-    cosmwasm_std::{Addr, StdResult, Storage},
+    cosmwasm_ext::as_dyn::storage,
+    cosmwasm_std::{Addr, StdResult},
     cw_storage_plus::Item,
 };
 use versioning::ReleaseLabel;
@@ -21,15 +22,24 @@ pub(crate) enum Contract {
 }
 
 impl Contract {
-    pub(crate) fn store(&self, storage: &mut dyn Storage) -> StdResult<()> {
-        STORE.save(storage, self)
+    pub(crate) fn store<S>(&self, storage: &mut S) -> StdResult<()>
+    where
+        S: storage::DynMut + ?Sized,
+    {
+        STORE.save(storage.as_dyn_mut(), self)
     }
 
-    pub(crate) fn load(storage: &dyn Storage) -> StdResult<Self> {
-        STORE.load(storage)
+    pub(crate) fn load<S>(storage: &S) -> StdResult<Self>
+    where
+        S: storage::Dyn + ?Sized,
+    {
+        STORE.load(storage.as_dyn())
     }
 
-    pub(crate) fn clear(storage: &mut dyn Storage) {
-        STORE.remove(storage)
+    pub(crate) fn clear<S>(storage: &mut S)
+    where
+        S: storage::DynMut + ?Sized,
+    {
+        STORE.remove(storage.as_dyn_mut())
     }
 }

--- a/platform/contracts/admin/src/state/migration_release.rs
+++ b/platform/contracts/admin/src/state/migration_release.rs
@@ -1,14 +1,21 @@
 use sdk::{
+    cosmwasm_ext::as_dyn::{storage, AsDyn, AsDynMut},
     cosmwasm_std::{StdResult, Storage},
     cw_storage_plus::Item,
 };
 
 const STORAGE_ITEM: Item<'_, String> = Item::new("migration_release");
 
-pub(crate) fn store(storage: &mut dyn Storage, migration_release: String) -> StdResult<()> {
-    STORAGE_ITEM.save(storage, &migration_release)
+pub(crate) fn store<S>(storage: &mut S, migration_release: String) -> StdResult<()>
+where
+    S: storage::DynMut + ?Sized,
+{
+    STORAGE_ITEM.save(storage.as_dyn_mut(), &migration_release)
 }
 
-pub(crate) fn load(storage: &mut dyn Storage) -> StdResult<String> {
-    STORAGE_ITEM.load(storage)
+pub(crate) fn load<S>(storage: &S) -> StdResult<String>
+where
+    S: storage::Dyn + ?Sized,
+{
+    STORAGE_ITEM.load(storage.as_dyn())
 }

--- a/platform/contracts/timealarms/src/contract.rs
+++ b/platform/contracts/timealarms/src/contract.rs
@@ -5,8 +5,7 @@ use platform::{
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
     cosmwasm_std::{
-        entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Storage,
-        SubMsgResult,
+        entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, SubMsgResult,
     },
 };
 use versioning::{package_version, version, SemVer, Version, VersionSegment};
@@ -48,7 +47,7 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> ContractResult<CwResponse> {
-    let mut time_alarms: TimeAlarms<'_, &mut dyn Storage> = TimeAlarms::new(deps.storage);
+    let mut time_alarms = TimeAlarms::new(deps.storage);
 
     match msg {
         ExecuteMsg::AddAlarm { time } => time_alarms
@@ -85,7 +84,7 @@ pub fn reply(deps: DepsMut<'_>, env: Env, msg: Reply) -> ContractResult<CwRespon
 
     let emitter: Emitter = Emitter::of_type(EVENT_TYPE);
 
-    let mut time_alarms: TimeAlarms<'_, &mut dyn Storage> = TimeAlarms::new(deps.storage);
+    let mut time_alarms = TimeAlarms::new(deps.storage);
 
     Ok(response::response_only_messages(match msg.result {
         SubMsgResult::Ok(_) => {

--- a/platform/packages/sdk/Cargo.toml
+++ b/platform/packages/sdk/Cargo.toml
@@ -23,7 +23,7 @@ cosmos = []
 neutron = ["cosmwasm-std/stargate", "dep:neutron-sdk"]
 
 [dependencies]
-cosmwasm-std = { workspace = true }
+cosmwasm-std.workspace = true
 cosmwasm-schema = { workspace = true, optional = true }
 cw-storage-plus = { workspace = true, optional = true }
 cosmos-sdk-proto = { workspace = true, optional = true }
@@ -34,3 +34,6 @@ serde = { workspace = true, optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cw-multi-test = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
+
+[dev-dependencies]
+cw-multi-test.workspace = true

--- a/platform/packages/sdk/src/cosmwasm_ext/as_dyn/mod.rs
+++ b/platform/packages/sdk/src/cosmwasm_ext/as_dyn/mod.rs
@@ -1,0 +1,51 @@
+pub mod storage;
+
+pub trait HigherOrderDyn: 'static {
+    type Dyn<'r>: ?Sized + 'r
+    where
+        Self: 'r;
+}
+
+pub trait AsDyn<T>
+where
+    T: HigherOrderDyn + ?Sized,
+{
+    fn as_dyn(&self) -> &T::Dyn<'_>;
+}
+
+pub trait AsDynMut<T>: AsDyn<T>
+where
+    T: HigherOrderDyn + ?Sized,
+{
+    fn as_dyn_mut(&mut self) -> &mut T::Dyn<'_>;
+}
+
+impl<'r, T, U> AsDyn<U> for &'r T
+where
+    T: AsDyn<U> + ?Sized,
+    U: HigherOrderDyn + ?Sized,
+{
+    fn as_dyn(&self) -> &U::Dyn<'_> {
+        T::as_dyn(self)
+    }
+}
+
+impl<'r, T, U> AsDyn<U> for &'r mut T
+where
+    T: AsDyn<U> + ?Sized,
+    U: HigherOrderDyn + ?Sized,
+{
+    fn as_dyn(&self) -> &U::Dyn<'_> {
+        T::as_dyn(self)
+    }
+}
+
+impl<'r, T, U> AsDynMut<U> for &'r mut T
+where
+    T: AsDynMut<U> + ?Sized,
+    U: HigherOrderDyn + ?Sized,
+{
+    fn as_dyn_mut(&mut self) -> &mut U::Dyn<'_> {
+        T::as_dyn_mut(self)
+    }
+}

--- a/platform/packages/sdk/src/cosmwasm_ext/as_dyn/storage.rs
+++ b/platform/packages/sdk/src/cosmwasm_ext/as_dyn/storage.rs
@@ -1,0 +1,58 @@
+#[cfg(any(test, feature = "testing"))]
+use cosmwasm_std::testing::MockStorage;
+use cosmwasm_std::Storage;
+
+use super::{AsDyn, AsDynMut, HigherOrderDyn};
+
+pub trait Dyn: AsDyn<dyn Storage> {}
+
+impl<T> Dyn for T where T: AsDyn<dyn Storage> + ?Sized {}
+
+pub trait DynMut: AsDynMut<dyn Storage> {}
+
+impl<T> DynMut for T where T: AsDynMut<dyn Storage> + ?Sized {}
+
+impl HigherOrderDyn for dyn Storage {
+    type Dyn<'r> = dyn Storage + 'r where Self: 'r;
+}
+
+impl<'r> AsDyn<dyn Storage> for dyn Storage + 'r {
+    fn as_dyn(&self) -> &(dyn Storage + '_) {
+        self
+    }
+}
+
+impl<'r> AsDynMut<dyn Storage> for dyn Storage + 'r {
+    fn as_dyn_mut(&mut self) -> &mut (dyn Storage + '_) {
+        self
+    }
+}
+
+#[cfg(feature = "testing")]
+impl AsDyn<dyn Storage> for MockStorage {
+    fn as_dyn(&self) -> &(dyn Storage + '_) {
+        self
+    }
+}
+
+#[cfg(feature = "testing")]
+impl AsDynMut<dyn Storage> for MockStorage {
+    fn as_dyn_mut(&mut self) -> &mut (dyn Storage + '_) {
+        self
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_impls() {
+    let mut storage: MockStorage = MockStorage::new();
+
+    let storage: &mut dyn Storage = &mut storage;
+
+    let _ = storage.as_dyn();
+    let _ = storage.as_dyn_mut();
+
+    let storage: &dyn Storage = storage;
+
+    let _ = storage.as_dyn();
+}

--- a/platform/packages/sdk/src/cosmwasm_ext/mod.rs
+++ b/platform/packages/sdk/src/cosmwasm_ext/mod.rs
@@ -1,0 +1,10 @@
+#[cfg(not(feature = "neutron"))]
+pub use cosmwasm_std::Empty as InterChainMsg;
+#[cfg(feature = "neutron")]
+pub use neutron_sdk::bindings::msg::NeutronMsg as InterChainMsg;
+
+pub type Response = cosmwasm_std::Response<InterChainMsg>;
+pub type CosmosMsg = cosmwasm_std::CosmosMsg<InterChainMsg>;
+pub type SubMsg = cosmwasm_std::SubMsg<InterChainMsg>;
+
+pub mod as_dyn;

--- a/platform/packages/sdk/src/lib.rs
+++ b/platform/packages/sdk/src/lib.rs
@@ -14,13 +14,4 @@ pub use neutron_sdk;
 #[cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
 pub mod testing;
 
-pub mod cosmwasm_ext {
-    #[cfg(not(feature = "neutron"))]
-    pub use cosmwasm_std::Empty as InterChainMsg;
-    #[cfg(feature = "neutron")]
-    pub use neutron_sdk::bindings::msg::NeutronMsg as InterChainMsg;
-
-    pub type Response = cosmwasm_std::Response<InterChainMsg>;
-    pub type CosmosMsg = cosmwasm_std::CosmosMsg<InterChainMsg>;
-    pub type SubMsg = cosmwasm_std::SubMsg<InterChainMsg>;
-}
+pub mod cosmwasm_ext;

--- a/protocol/contracts/leaser/src/cmd/borrow.rs
+++ b/protocol/contracts/leaser/src/cmd/borrow.rs
@@ -1,9 +1,11 @@
 use currency::SymbolOwned;
 use finance::percent::Percent;
 use lease::api::open::{LoanForm, NewLeaseContract, NewLeaseForm};
-use platform::batch::Batch;
-use platform::message::Response as MessageResponse;
-use sdk::cosmwasm_std::{Addr, Coin, Storage};
+use platform::{batch::Batch, message::Response as MessageResponse};
+use sdk::{
+    cosmwasm_ext::as_dyn::storage,
+    cosmwasm_std::{Addr, Coin},
+};
 
 use crate::{
     state::{config::Config, leases::Leases},
@@ -13,15 +15,18 @@ use crate::{
 use super::Borrow;
 
 impl Borrow {
-    pub fn with(
-        storage: &mut dyn Storage,
+    pub fn with<S>(
+        storage: &mut S,
         amount: Vec<Coin>,
         customer: Addr,
         admin: Addr,
         finalizer: Addr,
         currency: SymbolOwned,
         max_ltd: Option<Percent>,
-    ) -> Result<MessageResponse, ContractError> {
+    ) -> Result<MessageResponse, ContractError>
+    where
+        S: storage::DynMut + ?Sized,
+    {
         Leases::cache_open_req(storage, &customer)
             .and_then(|()| Config::load(storage))
             .and_then(|config| {

--- a/protocol/contracts/leaser/src/contract.rs
+++ b/protocol/contracts/leaser/src/contract.rs
@@ -58,7 +58,7 @@ pub fn migrate(deps: DepsMut<'_>, _env: Env, msg: MigrateMsg) -> ContractResult<
     // Statically assert that the message is empty when doing a software-only update.
     let MigrateMsg {} = msg;
 
-    versioning::update_software_and_storage::<CONTRACT_STORAGE_VERSION_FROM, _, _, _, _>(
+    versioning::update_software_and_storage::<_, CONTRACT_STORAGE_VERSION_FROM, _, _, _, _>(
         deps.storage,
         CONTRACT_VERSION,
         |storage: &mut _| {

--- a/protocol/contracts/leaser/src/state/config.rs
+++ b/protocol/contracts/leaser/src/state/config.rs
@@ -4,7 +4,8 @@ use finance::{duration::Duration, percent::Percent};
 use lease::api::open::{ConnectionParams, PositionSpecDTO};
 use platform::contract::CodeId;
 use sdk::{
-    cosmwasm_std::{Addr, Storage},
+    cosmwasm_ext::as_dyn::storage,
+    cosmwasm_std::Addr,
     cw_storage_plus::Item,
     schemars::{self, JsonSchema},
 };
@@ -42,22 +43,33 @@ impl Config {
         }
     }
 
-    pub fn store(&self, storage: &mut dyn Storage) -> ContractResult<()> {
-        Self::STORAGE.save(storage, self).map_err(Into::into)
+    pub fn store<S>(&self, storage: &mut S) -> ContractResult<()>
+    where
+        S: storage::DynMut + ?Sized,
+    {
+        Self::STORAGE
+            .save(storage.as_dyn_mut(), self)
+            .map_err(Into::into)
     }
 
-    pub fn load(storage: &dyn Storage) -> ContractResult<Self> {
-        Self::STORAGE.load(storage).map_err(Into::into)
+    pub fn load<S>(storage: &S) -> ContractResult<Self>
+    where
+        S: storage::Dyn + ?Sized,
+    {
+        Self::STORAGE.load(storage.as_dyn()).map_err(Into::into)
     }
 
-    pub fn update(
-        storage: &mut dyn Storage,
+    pub fn update<S>(
+        storage: &mut S,
         lease_interest_rate_margin: Percent,
         lease_position_spec: PositionSpecDTO,
         lease_due_period: Duration,
-    ) -> ContractResult<()> {
+    ) -> ContractResult<()>
+    where
+        S: storage::DynMut + ?Sized,
+    {
         Self::STORAGE
-            .update(storage, |mut c| -> ContractResult<Config> {
+            .update(storage.as_dyn_mut(), |mut c| -> ContractResult<Config> {
                 c.lease_interest_rate_margin = lease_interest_rate_margin;
                 c.lease_position_spec = lease_position_spec;
                 c.lease_due_period = lease_due_period;
@@ -67,9 +79,12 @@ impl Config {
             .map_err(Into::into)
     }
 
-    pub fn update_lease_code(storage: &mut dyn Storage, new_code: CodeId) -> ContractResult<()> {
+    pub fn update_lease_code<S>(storage: &mut S, new_code: CodeId) -> ContractResult<()>
+    where
+        S: storage::DynMut + ?Sized,
+    {
         Self::STORAGE
-            .update(storage, |mut c| -> ContractResult<Config> {
+            .update(storage.as_dyn_mut(), |mut c| -> ContractResult<Config> {
                 c.lease_code_id = new_code;
                 Ok(c)
             })

--- a/protocol/contracts/leaser/src/state/leases.rs
+++ b/protocol/contracts/leaser/src/state/leases.rs
@@ -1,7 +1,8 @@
 use std::collections::{hash_set::IntoIter, HashSet};
 
 use sdk::{
-    cosmwasm_std::{Addr, StdResult, Storage},
+    cosmwasm_ext::as_dyn::storage,
+    cosmwasm_std::{Addr, StdResult},
     cw_storage_plus::{Bound, Item, Map},
 };
 
@@ -16,20 +17,31 @@ impl Leases {
     const PENDING_CUSTOMER: Item<'static, Addr> = Item::new("pending_customer");
     const CUSTOMER_LEASES: Map<'static, Addr, HashSet<Addr>> = Map::new("loans");
 
-    pub fn cache_open_req(storage: &mut dyn Storage, customer: &Addr) -> ContractResult<()> {
+    pub fn cache_open_req<S>(storage: &mut S, customer: &Addr) -> ContractResult<()>
+    where
+        S: storage::DynMut + ?Sized,
+    {
         Self::PENDING_CUSTOMER
-            .save(storage, customer)
+            .save(storage.as_dyn_mut(), customer)
             .map_err(Into::into)
     }
 
     /// Return true if the lease has been stored or false if there has already been the same lease
-    pub fn save(storage: &mut dyn Storage, lease: Addr) -> ContractResult<bool> {
+    pub fn save<S>(storage: &mut S, lease: Addr) -> ContractResult<bool>
+    where
+        S: storage::DynMut + ?Sized,
+    {
         let mut stored = false;
+
         let update_fn = |may_leases: Option<HashSet<Addr>>| -> StdResult<HashSet<Addr>> {
             let mut leases = may_leases.unwrap_or_default();
+
             stored = leases.insert(lease);
+
             Ok(leases)
         };
+
+        let storage = storage.as_dyn_mut();
 
         Self::PENDING_CUSTOMER
             .load(storage)
@@ -42,39 +54,53 @@ impl Leases {
             .map_err(Into::into)
     }
 
-    pub fn load_by_customer(
-        storage: &dyn Storage,
-        customer: Addr,
-    ) -> ContractResult<HashSet<Addr>> {
+    pub fn load_by_customer<S>(storage: &S, customer: Addr) -> ContractResult<HashSet<Addr>>
+    where
+        S: storage::Dyn + ?Sized,
+    {
         Self::CUSTOMER_LEASES
-            .may_load(storage, customer)
+            .may_load(storage.as_dyn(), customer)
             .map(Option::unwrap_or_default)
             .map_err(Into::into)
     }
 
     /// Return whether the lease was present before the removal
-    pub fn remove(storage: &mut dyn Storage, customer: Addr, lease: &Addr) -> ContractResult<bool> {
+    pub fn remove<S>(storage: &mut S, customer: Addr, lease: &Addr) -> ContractResult<bool>
+    where
+        S: storage::DynMut + ?Sized,
+    {
         let mut removed = false;
+
         let update_fn = |may_leases: Option<HashSet<Addr>>| -> StdResult<HashSet<Addr>> {
             let mut leases = may_leases.unwrap_or_default();
+
             removed = leases.remove(lease);
+
             Ok(leases)
         };
 
         Self::CUSTOMER_LEASES
-            .update(storage, customer, update_fn)
+            .update(storage.as_dyn_mut(), customer, update_fn)
             .map(|_| removed)
             .map_err(Into::into)
     }
 
-    pub fn iter(
-        storage: &dyn Storage,
+    pub fn iter<S>(
+        storage: &S,
         next_customer: Option<Addr>,
-    ) -> impl Iterator<Item = MaybeCustomer<IntoIter<Addr>>> + '_ {
+    ) -> impl Iterator<Item = MaybeCustomer<IntoIter<Addr>>> + '_
+    where
+        S: storage::Dyn + ?Sized,
+    {
         let start_bound = next_customer.map(Bound::<Addr>::inclusive);
         Self::CUSTOMER_LEASES
             .prefix(())
-            .range(storage, start_bound, None, cosmwasm_std::Order::Ascending)
+            .range(
+                storage.as_dyn(),
+                start_bound,
+                None,
+                cosmwasm_std::Order::Ascending,
+            )
             .map(|record| {
                 record
                     .map(|(customer, leases)| Customer::from(customer, leases.into_iter()))
@@ -85,7 +111,10 @@ impl Leases {
 
 #[cfg(test)]
 mod test {
-    use sdk::cosmwasm_std::{testing::MockStorage, Addr, Storage};
+    use sdk::{
+        cosmwasm_ext::as_dyn::storage,
+        cosmwasm_std::{testing::MockStorage, Addr, Storage},
+    };
 
     use crate::{state::leases::Leases, ContractError};
 
@@ -158,7 +187,7 @@ mod test {
 
         assert_eq!(
             Ok(true),
-            Leases::remove(&mut storage, test_customer(), &test_lease(),)
+            Leases::remove(&mut storage, test_customer(), &test_lease())
         );
         assert_lease_not_exist(&storage);
     }
@@ -179,16 +208,25 @@ mod test {
     }
 
     #[track_caller]
-    fn assert_lease_exist(storage: &dyn Storage) {
+    fn assert_lease_exist<S>(storage: &S)
+    where
+        S: storage::Dyn + ?Sized,
+    {
         assert!(lease_exist(storage, &test_lease()));
     }
 
     #[track_caller]
-    fn assert_lease_not_exist(storage: &dyn Storage) {
+    fn assert_lease_not_exist<S>(storage: &S)
+    where
+        S: storage::Dyn + ?Sized,
+    {
         assert!(!lease_exist(storage, &test_lease()));
     }
 
-    fn lease_exist(storage: &dyn Storage, lease: &Addr) -> bool {
+    fn lease_exist<S>(storage: &S, lease: &Addr) -> bool
+    where
+        S: storage::Dyn + ?Sized,
+    {
         Leases::load_by_customer(storage, test_customer())
             .unwrap()
             .contains(lease)

--- a/protocol/contracts/leaser/src/state/v1.rs
+++ b/protocol/contracts/leaser/src/state/v1.rs
@@ -1,11 +1,9 @@
+use serde::{Deserialize, Serialize, Serializer};
+
 use finance::percent::Percent;
 use lease::api::open::{ConnectionParams, InterestPaymentSpec, PositionSpecDTO};
 use platform::contract::CodeId;
-use sdk::{
-    cosmwasm_std::{Addr, Storage},
-    cw_storage_plus::Item,
-};
-use serde::{Deserialize, Serialize, Serializer};
+use sdk::{cosmwasm_ext::as_dyn::storage, cosmwasm_std::Addr, cw_storage_plus::Item};
 
 use crate::result::ContractResult;
 
@@ -27,9 +25,12 @@ pub struct Config {
 impl Config {
     const STORAGE: Item<'static, Self> = Item::new("config");
 
-    pub fn migrate(storage: &dyn Storage) -> ContractResult<ConfigNew> {
+    pub fn migrate<S>(storage: &S) -> ContractResult<ConfigNew>
+    where
+        S: storage::Dyn + ?Sized,
+    {
         Self::STORAGE
-            .load(storage)
+            .load(storage.as_dyn())
             .map_err(Into::into)
             .map(|config| ConfigNew {
                 lease_code_id: config.lease_code_id,

--- a/protocol/contracts/lpp/src/contract/borrow.rs
+++ b/protocol/contracts/lpp/src/contract/borrow.rs
@@ -7,7 +7,10 @@ use platform::{
     batch::Batch,
     message::Response as MessageResponse,
 };
-use sdk::cosmwasm_std::{Addr, Deps, DepsMut, Env, MessageInfo, Storage};
+use sdk::{
+    cosmwasm_ext::as_dyn::storage,
+    cosmwasm_std::{Addr, Deps, DepsMut, Env, MessageInfo},
+};
 
 use crate::{
     error::Result,
@@ -80,8 +83,9 @@ where
     }
 }
 
-pub fn query_loan<Lpn>(storage: &dyn Storage, lease_addr: Addr) -> Result<QueryLoanResponse<Lpn>>
+pub fn query_loan<S, Lpn>(storage: &S, lease_addr: Addr) -> Result<QueryLoanResponse<Lpn>>
 where
+    S: storage::Dyn + ?Sized,
     Lpn: 'static + Currency + Serialize + DeserializeOwned,
 {
     Loan::query(storage, lease_addr)

--- a/protocol/contracts/lpp/src/contract/lender.rs
+++ b/protocol/contracts/lpp/src/contract/lender.rs
@@ -8,7 +8,10 @@ use platform::{
     batch::Batch,
     message::Response as MessageResponse,
 };
-use sdk::cosmwasm_std::{Addr, Deps, DepsMut, Env, MessageInfo, Storage, Uint128};
+use sdk::{
+    cosmwasm_ext::as_dyn::storage,
+    cosmwasm_std::{Addr, Deps, DepsMut, Env, MessageInfo, Uint128},
+};
 
 use crate::{
     error::{ContractError, Result},
@@ -113,7 +116,10 @@ where
     })
 }
 
-pub fn query_balance(storage: &dyn Storage, addr: Addr) -> Result<BalanceResponse> {
+pub fn query_balance<S>(storage: &S, addr: Addr) -> Result<BalanceResponse>
+where
+    S: storage::Dyn + ?Sized,
+{
     let balance: u128 = Deposit::query_balance_nlpn(storage, addr)?
         .unwrap_or_default()
         .into();
@@ -134,7 +140,10 @@ mod test {
         percent::{bound::BoundToHundredPercent, Percent},
     };
     use platform::coin_legacy;
-    use sdk::cosmwasm_std::{Addr, Coin as CwCoin, Storage};
+    use sdk::{
+        cosmwasm_ext::as_dyn::storage,
+        cosmwasm_std::{Addr, Coin as CwCoin, Storage},
+    };
 
     use crate::{borrow::InterestRate, state::Config};
 
@@ -147,7 +156,10 @@ mod test {
     const ADDON_OPTIMAL_INTEREST_RATE: Percent = Percent::from_permille(20);
     const DEFAULT_MIN_UTILIZATION: BoundToHundredPercent = BoundToHundredPercent::ZERO;
 
-    fn setup_storage(mut storage: &mut dyn Storage, min_utilization: BoundToHundredPercent) {
+    fn setup_storage<S>(mut storage: &mut S, min_utilization: BoundToHundredPercent)
+    where
+        S: storage::DynMut + ?Sized,
+    {
         ContractOwnerAccess::new(storage.deref_mut())
             .grant_to(&Addr::unchecked("admin"))
             .unwrap();

--- a/protocol/contracts/lpp/src/contract/mod.rs
+++ b/protocol/contracts/lpp/src/contract/mod.rs
@@ -233,9 +233,10 @@ impl<'a> QueryWithLpn<'a> {
 
                 to_json_binary(&borrow::query_quote::<Lpn>(&self.deps, &self.env, quote)?)
             }
-            QueryMsg::Loan { lease_addr } => {
-                to_json_binary(&borrow::query_loan::<Lpn>(self.deps.storage, lease_addr)?)
-            }
+            QueryMsg::Loan { lease_addr } => to_json_binary(&borrow::query_loan::<_, Lpn>(
+                self.deps.storage,
+                lease_addr,
+            )?),
             QueryMsg::LppBalance() => {
                 to_json_binary(&rewards::query_lpp_balance::<Lpn>(self.deps, self.env)?)
             }

--- a/protocol/contracts/lpp/src/contract/rewards.rs
+++ b/protocol/contracts/lpp/src/contract/rewards.rs
@@ -7,7 +7,10 @@ use platform::{
     batch::Batch,
     message::Response as MessageResponse,
 };
-use sdk::cosmwasm_std::{Addr, Deps, DepsMut, Env, MessageInfo, Storage};
+use sdk::{
+    cosmwasm_ext::as_dyn::storage,
+    cosmwasm_std::{Addr, Deps, DepsMut, Env, MessageInfo},
+};
 
 use crate::{
     error::{ContractError, Result},
@@ -60,7 +63,10 @@ where
     LiquidityPool::<Lpn>::load(deps.storage).and_then(|lpp| lpp.query_lpp_balance(&deps, &env))
 }
 
-pub(super) fn query_rewards(storage: &dyn Storage, addr: Addr) -> Result<RewardsResponse> {
+pub(super) fn query_rewards<S>(storage: &S, addr: Addr) -> Result<RewardsResponse>
+where
+    S: storage::Dyn + ?Sized,
+{
     let rewards = Deposit::may_load(storage, addr)?
         .ok_or(ContractError::NoDeposit {})?
         .query_rewards(storage)?;

--- a/protocol/contracts/lpp/src/state/total.rs
+++ b/protocol/contracts/lpp/src/state/total.rs
@@ -11,7 +11,8 @@ use finance::{
     zero::Zero,
 };
 use sdk::{
-    cosmwasm_std::{StdResult, Storage, Timestamp},
+    cosmwasm_ext::as_dyn::storage,
+    cosmwasm_std::{StdResult, Timestamp},
     cw_storage_plus::Item,
     schemars::{self, JsonSchema},
 };
@@ -57,12 +58,18 @@ where
         self.total_principal_due
     }
 
-    pub fn store(&self, storage: &mut dyn Storage) -> StdResult<()> {
-        Self::STORAGE.save(storage, self)
+    pub fn load<S>(storage: &S) -> StdResult<Self>
+    where
+        S: storage::Dyn + ?Sized,
+    {
+        Self::STORAGE.load(storage.as_dyn())
     }
 
-    pub fn load(storage: &dyn Storage) -> StdResult<Self> {
-        Self::STORAGE.load(storage)
+    pub fn store<S>(&self, storage: &mut S) -> StdResult<()>
+    where
+        S: storage::DynMut + ?Sized,
+    {
+        Self::STORAGE.save(storage.as_dyn_mut(), self)
     }
 
     pub fn total_interest_due_by_now(&self, ctime: &Timestamp) -> Coin<Lpn> {

--- a/protocol/contracts/oracle/src/contract/config.rs
+++ b/protocol/contracts/oracle/src/contract/config.rs
@@ -1,9 +1,12 @@
-use sdk::cosmwasm_std::Storage;
+use sdk::cosmwasm_ext::as_dyn::storage;
 
 use crate::{api::Config, ContractError};
 
-pub(super) fn query_config(storage: &dyn Storage) -> Result<Config, ContractError> {
-    Config::load(storage).map_err(ContractError::LoadConfig)
+pub(super) fn query_config<S>(storage: &S) -> Result<Config, ContractError>
+where
+    S: storage::Dyn + ?Sized,
+{
+    Config::load(storage.as_dyn()).map_err(ContractError::LoadConfig)
 }
 
 #[cfg(test)]
@@ -65,7 +68,7 @@ mod tests {
                     Duration::from_secs(5),
                     7,
                     Percent::from_percent(88),
-                )
+                ),
             }
         );
     }

--- a/protocol/contracts/oracle/src/contract/mod.rs
+++ b/protocol/contracts/oracle/src/contract/mod.rs
@@ -7,8 +7,7 @@ use platform::{
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
     cosmwasm_std::{
-        entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Storage,
-        SubMsgResult,
+        entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, SubMsgResult,
     },
 };
 use versioning::{package_version, version, SemVer, Version, VersionSegment};
@@ -147,8 +146,7 @@ pub fn reply(deps: DepsMut<'_>, _env: Env, msg: Reply) -> ContractResult<CwRespo
     const KEY_DELIVERED: &str = "delivered";
     const KEY_DETAILS: &str = "details";
 
-    let mut alarms: MarketAlarms<'_, &mut (dyn Storage + '_), PriceCurrencies> =
-        MarketAlarms::new(deps.storage);
+    let mut alarms: MarketAlarms<_, PriceCurrencies> = MarketAlarms::new(deps.storage);
 
     let emitter: Emitter = Emitter::of_type(EVENT_TYPE);
 

--- a/protocol/contracts/oracle/src/contract/oracle/feed/price_querier.rs
+++ b/protocol/contracts/oracle/src/contract/oracle/feed/price_querier.rs
@@ -3,26 +3,28 @@ use serde::de::DeserializeOwned;
 use currency::{Currency, Group};
 use finance::price::Price;
 use marketprice::{error::PriceFeedsError, market_price::PriceFeeds};
-use sdk::cosmwasm_std::{Storage, Timestamp};
+use sdk::{cosmwasm_ext::as_dyn::storage, cosmwasm_std::Timestamp};
 
 use crate::ContractError;
 
-pub struct FedPrices<'a, G>
+pub struct FedPrices<'a, S, G>
 where
+    S: storage::Dyn + ?Sized,
     G: Group,
 {
-    storage: &'a dyn Storage,
+    storage: &'a S,
     feeds: &'a PriceFeeds<'static, G>,
     at: Timestamp,
     total_feeders: usize,
 }
 
-impl<'a, G> FedPrices<'a, G>
+impl<'a, S, G> FedPrices<'a, S, G>
 where
+    S: storage::Dyn + ?Sized,
     G: Group,
 {
     pub fn new(
-        storage: &'a dyn Storage,
+        storage: &'a S,
         feeds: &'a PriceFeeds<'static, G>,
         at: Timestamp,
         total_feeders: usize,
@@ -43,8 +45,9 @@ pub trait PriceQuerier {
         Q: Currency + DeserializeOwned;
 }
 
-impl<'a, G> PriceQuerier for FedPrices<'a, G>
+impl<'a, S, G> PriceQuerier for FedPrices<'a, S, G>
 where
+    S: storage::Dyn + ?Sized,
     G: Group,
 {
     fn price<B, Q>(&self) -> Result<Option<Price<B, Q>>, ContractError>

--- a/protocol/contracts/oracle/src/contract/oracle/feeder.rs
+++ b/protocol/contracts/oracle/src/contract/oracle/feeder.rs
@@ -3,7 +3,10 @@ use std::collections::HashSet;
 use serde::{Deserialize, Serialize};
 
 use marketprice::feeders::PriceFeeders;
-use sdk::cosmwasm_std::{Addr, DepsMut, StdResult, Storage};
+use sdk::{
+    cosmwasm_ext::as_dyn::storage,
+    cosmwasm_std::{Addr, DepsMut, StdResult},
+};
 
 use crate::{api::Config, result::ContractResult, ContractError};
 
@@ -15,12 +18,18 @@ pub struct Feeders {
 impl Feeders {
     const FEEDERS: PriceFeeders<'static> = PriceFeeders::new("feeders");
 
-    pub(crate) fn get(storage: &dyn Storage) -> StdResult<HashSet<Addr>> {
-        Self::FEEDERS.get(storage)
+    pub(crate) fn get<S>(storage: &S) -> StdResult<HashSet<Addr>>
+    where
+        S: storage::Dyn + ?Sized,
+    {
+        Self::FEEDERS.get(storage.as_dyn())
     }
 
-    pub(crate) fn is_feeder(storage: &dyn Storage, address: &Addr) -> StdResult<bool> {
-        Self::FEEDERS.is_registered(storage, address)
+    pub(crate) fn is_feeder<S>(storage: &S, address: &Addr) -> StdResult<bool>
+    where
+        S: storage::Dyn + ?Sized,
+    {
+        Self::FEEDERS.is_registered(storage.as_dyn(), address)
     }
 
     pub(crate) fn try_register(deps: DepsMut<'_>, address: String) -> ContractResult<()> {
@@ -45,7 +54,10 @@ impl Feeders {
         Self::FEEDERS.remove(deps, &f_address).map_err(Into::into)
     }
 
-    pub(crate) fn total_registered(storage: &dyn Storage) -> StdResult<usize> {
+    pub(crate) fn total_registered<S>(storage: &S) -> StdResult<usize>
+    where
+        S: storage::Dyn + ?Sized,
+    {
         Self::get(storage).map(|c| c.len())
     }
 }

--- a/protocol/contracts/oracle/src/contract/query.rs
+++ b/protocol/contracts/oracle/src/contract/query.rs
@@ -38,8 +38,7 @@ impl<'a> AnyVisitor for QueryWithOracleBase<'a> {
     where
         OracleBase: 'static + Currency + DeserializeOwned + Serialize,
     {
-        type QueryOracle<'storage, S, BaseC> =
-            Oracle<'storage, S, PriceCurrencies, BaseC, StableCurrency>;
+        type QueryOracle<S, BaseC> = Oracle<S, PriceCurrencies, BaseC, StableCurrency>;
 
         match self.msg {
             QueryMsg::SupportedCurrencyPairs {} => to_json_binary(
@@ -48,11 +47,11 @@ impl<'a> AnyVisitor for QueryWithOracleBase<'a> {
                     .collect::<Vec<_>>(),
             ),
             QueryMsg::Price { currency } => to_json_binary(
-                &QueryOracle::<'_, _, OracleBase>::load(self.deps.storage)?
+                &QueryOracle::<_, OracleBase>::load(self.deps.storage)?
                     .try_query_price(self.env.block.time, &currency)?,
             ),
             QueryMsg::Prices {} => {
-                let prices = QueryOracle::<'_, _, OracleBase>::load(self.deps.storage)?
+                let prices = QueryOracle::<_, OracleBase>::load(self.deps.storage)?
                     .try_query_prices(self.env.block.time)?;
 
                 to_json_binary(&PricesResponse { prices })
@@ -67,7 +66,7 @@ impl<'a> AnyVisitor for QueryWithOracleBase<'a> {
                     .into_human_readable(),
             }),
             QueryMsg::AlarmsStatus {} => to_json_binary(
-                &QueryOracle::<'_, _, OracleBase>::load(self.deps.storage)?
+                &QueryOracle::<_, OracleBase>::load(self.deps.storage)?
                     .try_query_alarms(self.env.block.time)?,
             ),
             _ => {

--- a/protocol/contracts/oracle/src/state/config.rs
+++ b/protocol/contracts/oracle/src/state/config.rs
@@ -1,9 +1,6 @@
 use currency::SymbolOwned;
 use marketprice::config::Config as PriceConfig;
-use sdk::{
-    cosmwasm_std::{StdResult, Storage},
-    cw_storage_plus::Item,
-};
+use sdk::{cosmwasm_ext::as_dyn::storage, cosmwasm_std::StdResult, cw_storage_plus::Item};
 
 use crate::{api::Config, ContractError};
 
@@ -17,20 +14,26 @@ impl Config {
         }
     }
 
-    pub fn store(self, storage: &mut dyn Storage) -> StdResult<()> {
-        Self::STORAGE.save(storage, &self)
+    pub fn store<S>(self, storage: &mut S) -> StdResult<()>
+    where
+        S: storage::DynMut + ?Sized,
+    {
+        Self::STORAGE.save(storage.as_dyn_mut(), &self)
     }
 
-    pub fn load(storage: &dyn Storage) -> StdResult<Self> {
-        Self::STORAGE.load(storage)
+    pub fn load<S>(storage: &S) -> StdResult<Self>
+    where
+        S: storage::Dyn + ?Sized,
+    {
+        Self::STORAGE.load(storage.as_dyn())
     }
 
-    pub fn update(
-        storage: &mut dyn Storage,
-        price_config: PriceConfig,
-    ) -> Result<(), ContractError> {
+    pub fn update<S>(storage: &mut S, price_config: PriceConfig) -> Result<(), ContractError>
+    where
+        S: storage::DynMut + ?Sized,
+    {
         Self::STORAGE
-            .update(storage, |mut c| -> StdResult<_> {
+            .update(storage.as_dyn_mut(), |mut c| -> StdResult<_> {
                 c.price_config = price_config;
                 Ok(c)
             })

--- a/protocol/contracts/oracle/src/state/supported_pairs.rs
+++ b/protocol/contracts/oracle/src/state/supported_pairs.rs
@@ -6,7 +6,7 @@ use currencies::PaymentGroup;
 use currency::{
     AnyVisitor, AnyVisitorResult, Currency, GroupVisit, SymbolOwned, SymbolSlice, Tickers,
 };
-use sdk::{cosmwasm_std::Storage, cw_storage_plus::Item};
+use sdk::{cosmwasm_ext::as_dyn::storage, cw_storage_plus::Item};
 use tree::{FindBy as _, NodeRef};
 
 use crate::{
@@ -80,15 +80,21 @@ where
         Ok(self)
     }
 
-    pub fn load(storage: &dyn Storage) -> ContractResult<Self> {
+    pub fn load<S>(storage: &S) -> ContractResult<Self>
+    where
+        S: storage::Dyn + ?Sized,
+    {
         Self::DB_ITEM
-            .load(storage)
+            .load(storage.as_dyn())
             .map_err(ContractError::LoadSupportedPairs)
     }
 
-    pub fn save(&self, storage: &mut dyn Storage) -> ContractResult<()> {
+    pub fn save<S>(&self, storage: &mut S) -> ContractResult<()>
+    where
+        S: storage::DynMut + ?Sized,
+    {
         Self::DB_ITEM
-            .save(storage, self)
+            .save(storage.as_dyn_mut(), self)
             .map_err(ContractError::StoreSupportedPairs)
     }
 
@@ -283,7 +289,7 @@ mod tests {
                 "token5".to_string(),
                 "token1".to_string(),
                 "token2".to_string(),
-                TheCurrency::TICKER.to_string()
+                TheCurrency::TICKER.to_string(),
             ]
         );
     }

--- a/protocol/contracts/profit/src/profit.rs
+++ b/protocol/contracts/profit/src/profit.rs
@@ -5,7 +5,10 @@ use platform::{
     batch::{Emit as _, Emitter},
     message::Response as PlatformResponse,
 };
-use sdk::cosmwasm_std::{Addr, Env, Storage};
+use sdk::{
+    cosmwasm_ext::as_dyn::storage,
+    cosmwasm_std::{Addr, Env},
+};
 
 use crate::{
     msg::ConfigResponse,
@@ -43,7 +46,10 @@ impl Profit {
         }
     }
 
-    pub fn query_config(storage: &dyn Storage) -> ContractResult<ConfigResponse> {
-        State::load(storage).and_then(|state: State| state.try_query_config())
+    pub fn query_config<S>(storage: &S) -> ContractResult<ConfigResponse>
+    where
+        S: storage::Dyn + ?Sized,
+    {
+        State::load(storage.as_dyn()).and_then(|state: State| state.try_query_config())
     }
 }

--- a/protocol/contracts/profit/src/state/mod.rs
+++ b/protocol/contracts/profit/src/state/mod.rs
@@ -1,9 +1,8 @@
 use std::fmt::{Display, Formatter};
 
-use cosmwasm_std::QuerierWrapper;
-use currencies::PaymentGroup;
 use serde::{Deserialize, Serialize};
 
+use currencies::PaymentGroup;
 use dex::{
     ConnectionParams, ContinueResult, Handler, Response as DexResponse, Result as DexResult,
     StateLocalOut,
@@ -13,7 +12,8 @@ use platform::{
     state_machine::{self, Response as StateMachineResponse},
 };
 use sdk::{
-    cosmwasm_std::{Binary, Env, Reply as CwReply, Storage, Timestamp},
+    cosmwasm_ext::as_dyn::storage,
+    cosmwasm_std::{Binary, Env, QuerierWrapper, Reply as CwReply, Timestamp},
     cw_storage_plus::Item,
 };
 use swap::Impl;
@@ -116,12 +116,18 @@ impl State {
         (state, response)
     }
 
-    pub fn load(storage: &dyn Storage) -> ContractResult<Self> {
-        STATE.load(storage).map_err(Into::into)
+    pub fn load<S>(storage: &S) -> ContractResult<Self>
+    where
+        S: storage::Dyn + ?Sized,
+    {
+        STATE.load(storage.as_dyn()).map_err(Into::into)
     }
 
-    pub fn store(&self, storage: &mut dyn Storage) -> ContractResult<()> {
-        STATE.save(storage, self).map_err(Into::into)
+    pub fn store<S>(&self, storage: &mut S) -> ContractResult<()>
+    where
+        S: storage::DynMut + ?Sized,
+    {
+        STATE.save(storage.as_dyn_mut(), self).map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
The reasoning behind this PR is that when `dyn Trait` syntax is used, it implies two things.

1. The reference to the dynamically-sized type (DST) always has a lifetime bound to it, `&'ref_lifetime dyn Trait`.
2. The DST has a lifetime of it's own, `&'ref_lifetime (dyn Trait + 'dst_lifetime)`.

While those are usually don't cause problems, because on references lifetimes can be shortened, this is not the case for situations where `T: Deref<Target = (dyn Trait + 'dst_lifetime)>` is used as it represents a concrete type with it's concrete lifetimes. The `'dst_lifetime` lifetime parameter also pollutes all types it's contained in, e.g. `Marketprice<'storage, G, S>` where `S: Deref<Target = (dyn Storage + 'storage)>`.

The provided solution instead abstracts the reference to the DST, creating one on demand with appropriate lifetime bounds.