### PR TITLE
fix(lpp): `state::config` refers to feature-gated typedef

### DIFF
--- a/protocol/contracts/lpp/src/lib.rs
+++ b/protocol/contracts/lpp/src/lib.rs
@@ -10,6 +10,7 @@ pub mod loan;
 #[cfg(feature = "contract")]
 mod lpp;
 pub mod msg;
+#[cfg(feature = "contract")]
 pub mod state;
 #[cfg(feature = "stub")]
 pub mod stub;


### PR DESCRIPTION
Fixes ec2819b44f0ebb9dfc26b3900c518ad665d3d739