### PR TITLE
feat: Extend currency definitions & add definitions query

### DIFF
--- a/platform/packages/currency/src/lib.rs
+++ b/platform/packages/currency/src/lib.rs
@@ -40,6 +40,12 @@ pub trait Currency: Copy + Ord + Default + Debug + 'static {
 
     /// Symbol at the Dex network
     const DEX_SYMBOL: SymbolStatic;
+
+    /// Exponent on which the whole unit was raised to get the currency's base
+    /// unit represented by the trait.
+    ///
+    /// Example: `(10 ^ DECIMAL_DIGITS) uUSDC = 1 USDC`
+    const DECIMAL_DIGITS: u8;
 }
 
 pub fn equal<C1, C2>() -> bool

--- a/platform/packages/currency/src/nls.rs
+++ b/platform/packages/currency/src/nls.rs
@@ -13,17 +13,23 @@ use crate::{AnyVisitor, Currency, Group, Matcher, MaybeAnyVisitResult, SymbolSli
 /// - LP rewards
 /// - Relayers' tips
 pub struct NlsPlatform;
+
 impl Currency for NlsPlatform {
     const TICKER: SymbolStatic = "NLS";
+
     const BANK_SYMBOL: SymbolStatic = "unls";
+
     // TODO Define trait PlatformCurrency as a super trait of Currency and
     // merge NlsPlatform and Nls
     const DEX_SYMBOL: SymbolStatic = "N/A_N/A_N/A";
+
+    const DECIMAL_DIGITS: u8 = 6;
 }
 
 #[derive(Deserialize, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "testing"), derive(Debug))]
 pub struct Native {}
+
 impl Group for Native {
     const DESCR: &'static str = "native";
 

--- a/platform/packages/currency/src/test/group.rs
+++ b/platform/packages/currency/src/test/group.rs
@@ -64,60 +64,90 @@ mod impl_ {
         Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize,
     )]
     pub struct TestC1;
+
     impl Currency for TestC1 {
         const TICKER: SymbolStatic = "ticker#1";
+
         const BANK_SYMBOL: SymbolStatic = "ibc/bank_ticker#1";
+
         const DEX_SYMBOL: SymbolStatic = "ibc/dex_ticker#1";
+
+        const DECIMAL_DIGITS: u8 = 0;
     }
 
     #[derive(
         Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize,
     )]
     pub struct TestC2;
+
     impl Currency for TestC2 {
         const TICKER: SymbolStatic = "ticker#2";
+
         const BANK_SYMBOL: SymbolStatic = "ibc/bank_ticker#2";
+
         const DEX_SYMBOL: SymbolStatic = "ibc/dex_ticker#2";
+
+        const DECIMAL_DIGITS: u8 = 0;
     }
 
     #[derive(
         Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize,
     )]
     pub struct TestC3;
+
     impl Currency for TestC3 {
         const TICKER: SymbolStatic = "ticker#3";
+
         const BANK_SYMBOL: SymbolStatic = "ibc/bank_ticker#3";
+
         const DEX_SYMBOL: SymbolStatic = "ibc/dex_ticker#3";
+
+        const DECIMAL_DIGITS: u8 = 0;
     }
 
     #[derive(
         Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize,
     )]
     pub struct TestC4;
+
     impl Currency for TestC4 {
         const TICKER: SymbolStatic = "ticker#4";
+
         const BANK_SYMBOL: SymbolStatic = "ibc/bank_ticker#4";
+
         const DEX_SYMBOL: SymbolStatic = "ibc/dex_ticker#4";
+
+        const DECIMAL_DIGITS: u8 = 0;
     }
 
     #[derive(
         Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize,
     )]
     pub struct TestC5;
+
     impl Currency for TestC5 {
         const TICKER: SymbolStatic = "ticker#5";
+
         const BANK_SYMBOL: SymbolStatic = "ibc/bank_ticker#5";
+
         const DEX_SYMBOL: SymbolStatic = "ibc/dex_ticker#5";
+
+        const DECIMAL_DIGITS: u8 = 0;
     }
 
     #[derive(
         Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize,
     )]
     pub struct TestC6;
+
     impl Currency for TestC6 {
         const TICKER: SymbolStatic = "ticker#6";
+
         const BANK_SYMBOL: SymbolStatic = "ibc/bank_ticker#6";
+
         const DEX_SYMBOL: SymbolStatic = "ibc/dex_ticker#6";
+
+        const DECIMAL_DIGITS: u8 = 0;
     }
 
     #[derive(
@@ -126,7 +156,11 @@ mod impl_ {
     pub struct TestC10;
     impl Currency for TestC10 {
         const TICKER: SymbolStatic = "ticker#10";
+
         const BANK_SYMBOL: SymbolStatic = "ibc/bank_ticker#10";
+
         const DEX_SYMBOL: SymbolStatic = "ibc/dex_ticker#10";
+
+        const DECIMAL_DIGITS: u8 = 0;
     }
 }

--- a/platform/packages/finance/src/coin/dto/mod.rs
+++ b/platform/packages/finance/src/coin/dto/mod.rs
@@ -249,8 +249,12 @@ mod test {
 
     impl Currency for MyTestCurrency {
         const TICKER: SymbolStatic = "qwerty";
+
         const BANK_SYMBOL: SymbolStatic = "ibc/1";
+
         const DEX_SYMBOL: SymbolStatic = "ibc/2";
+
+        const DECIMAL_DIGITS: u8 = 0;
     }
 
     #[derive(PartialEq)]

--- a/platform/packages/finance/src/price/mod.rs
+++ b/platform/packages/finance/src/price/mod.rs
@@ -296,8 +296,12 @@ mod test {
     struct QuoteQuoteCurrency {}
     impl Currency for QuoteQuoteCurrency {
         const TICKER: SymbolStatic = "mycutecoin";
+
         const BANK_SYMBOL: SymbolStatic = "ibc/dcnqweuio2938fh2f";
+
         const DEX_SYMBOL: SymbolStatic = "ibc/cme72hr2";
+
+        const DECIMAL_DIGITS: u8 = 0;
     }
     type QuoteQuoteCoin = CoinT<QuoteQuoteCurrency>;
     type QuoteCoin = CoinT<SuperGroupTestC1>;

--- a/platform/packages/lpp/src/nlpn.rs
+++ b/platform/packages/lpp/src/nlpn.rs
@@ -10,6 +10,10 @@ pub struct NLpn;
 impl Currency for NLpn {
     // TODO the Currency abstraction has since evolved. Remove this impl.
     const TICKER: SymbolStatic = "NLpn";
+
     const BANK_SYMBOL: SymbolStatic = "N/A_N/A_N/A";
+
     const DEX_SYMBOL: SymbolStatic = "N/A_N/A_N/A";
+
+    const DECIMAL_DIGITS: u8 = 0;
 }

--- a/platform/packages/lpp/src/usd.rs
+++ b/platform/packages/lpp/src/usd.rs
@@ -10,11 +10,16 @@ use sdk::schemars::{self, JsonSchema};
     Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Serialize, Deserialize, JsonSchema,
 )]
 pub struct Usd;
+
 impl Currency for Usd {
     // should not be visible
     const TICKER: SymbolStatic = "USD";
+
     const BANK_SYMBOL: SymbolStatic = "N/A_N/A_N/A";
+
     const DEX_SYMBOL: SymbolStatic = "N/A_N/A_N/A";
+
+    const DECIMAL_DIGITS: u8 = 6;
 }
 
 pub type CoinUsd = Coin<Usd>;

--- a/platform/packages/platform/src/bank.rs
+++ b/platform/packages/platform/src/bank.rs
@@ -466,8 +466,12 @@ mod test {
         struct MyNiceCurrency {}
         impl Currency for MyNiceCurrency {
             const BANK_SYMBOL: SymbolStatic = "wdd";
+
             const DEX_SYMBOL: SymbolStatic = "dex3rdf";
+
             const TICKER: SymbolStatic = "ticedc";
+
+            const DECIMAL_DIGITS: u8 = 0;
         }
         let in_coin_2 = coin_legacy::to_cosmwasm(Coin::<MyNiceCurrency>::new(AMOUNT));
 

--- a/protocol/contracts/oracle/Cargo.toml
+++ b/protocol/contracts/oracle/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 [package.metadata.cargo-each]
 combinations = [
     { tags = ["build", "$net", "$protocol"], always-on = ["contract", "$net", "$protocol"], include-rest = false, generics = { "$net" = "net", "$protocol" = "protocol" } },
-    { tags = ["ci", "$net", "$protocol"], feature-groups = ["net", "protocol", "$[contract-and-testing]-or-stubs"], always-on = ["$net", "$protocol"], include-rest = true, generics = { "$net" = "net", "$protocol" = "protocol", "$[contract-and-testing]-or-stubs" = ["contract-and-testing", "stubs"] } }
+    { tags = ["ci", "$net", "$protocol"], feature-groups = ["net", "protocol", "$[contract-and-testing]-or-stubs"], always-on = ["$net", "$protocol"], include-rest = false, generics = { "$net" = "net", "$protocol" = "protocol", "$[contract-and-testing]-or-stubs" = ["contract-and-testing", "stubs"] } }
 ]
 
 [package.metadata.cargo-each.feature-groups.net]

--- a/protocol/contracts/oracle/src/api/contract.rs
+++ b/protocol/contracts/oracle/src/api/contract.rs
@@ -76,8 +76,10 @@ pub enum QueryMsg {
     Price {
         currency: SymbolOwned,
     },
-    // returns a list of supported denom pairs
+    /// Lists configured swap pairs
     SupportedCurrencyPairs {},
+    /// Lists configured currencies
+    Currencies {},
     /// Provides a path in the swap tree between two arbitrary currencies
     ///
     /// Returns `oracle::api::swap::SwapPath`
@@ -112,6 +114,44 @@ pub enum ExecuteAlarmMsg {
 pub struct DispatchAlarmsResponse(pub AlarmsCount);
 
 pub type SupportedCurrencyPairsResponse = Vec<SwapLeg>;
+
+pub type CurrenciesResponse = Vec<Currency>;
+
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "testing"), derive(Debug, PartialEq, Eq))]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct Currency {
+    pub ticker: String,
+    pub bank_symbol: String,
+    pub dex_symbol: String,
+    pub decimal_digits: u8,
+    pub group: CurrencyGroup,
+}
+
+impl Currency {
+    pub fn new<C>(group: CurrencyGroup) -> Self
+    where
+        C: currency::Currency,
+    {
+        Self {
+            ticker: C::TICKER.into(),
+            bank_symbol: C::BANK_SYMBOL.into(),
+            dex_symbol: C::DEX_SYMBOL.into(),
+            decimal_digits: C::DECIMAL_DIGITS,
+            group,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "testing"), derive(Debug, PartialEq, Eq))]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum CurrencyGroup {
+    Native,
+    Lpn,
+    Lease,
+    PaymentOnly,
+}
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
 #[cfg_attr(any(test, feature = "testing"), derive(Debug))]

--- a/protocol/contracts/oracle/src/contract/query.rs
+++ b/protocol/contracts/oracle/src/contract/query.rs
@@ -45,6 +45,11 @@ impl<'a> AnyVisitor for QueryWithOracleBase<'a> {
                     .swap_pairs_df()
                     .collect::<Vec<_>>(),
             ),
+            QueryMsg::Currencies {} => to_json_binary(
+                &SupportedPairs::<OracleBase>::load(self.deps.storage)?
+                    .currencies()
+                    .collect::<Vec<_>>(),
+            ),
             QueryMsg::Price { currency } => to_json_binary(
                 &QueryOracle::<'_, _, OracleBase>::load(self.deps.storage)?
                     .try_query_price(self.env.block.time, &currency)?,

--- a/protocol/packages/currencies/src/currency_macro.rs
+++ b/protocol/packages/currencies/src/currency_macro.rs
@@ -8,7 +8,8 @@ pub use currency::{Currency, SymbolStatic};
 macro_rules! define_currency {
     (
         $ident:ident,
-        $ticker:path $(,)?
+        $ticker:path,
+        $decimal_digits:literal $(,)?
     ) => {
         #[derive(
             Debug,
@@ -32,6 +33,8 @@ macro_rules! define_currency {
             const BANK_SYMBOL: $crate::currency_macro::SymbolStatic = $ticker.bank;
 
             const DEX_SYMBOL: $crate::currency_macro::SymbolStatic = $ticker.dex;
+
+            const DECIMAL_DIGITS: u8 = $decimal_digits;
         }
     };
 }

--- a/protocol/packages/currencies/src/lease/astroport.rs
+++ b/protocol/packages/currencies/src/lease/astroport.rs
@@ -32,7 +32,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Atom, ATOM);
+define_currency!(Atom, ATOM, 6);
 
 define_symbol! {
     ST_ATOM {
@@ -50,7 +50,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(StAtom, ST_ATOM);
+define_currency!(StAtom, ST_ATOM, 6);
 
 define_symbol! {
     NTRN {
@@ -71,7 +71,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Ntrn, NTRN);
+define_currency!(Ntrn, NTRN, 6);
 
 define_symbol! {
     DYDX {
@@ -89,7 +89,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Dydx, DYDX);
+define_currency!(Dydx, DYDX, 18);
 
 define_symbol! {
     TIA {
@@ -107,7 +107,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Tia, TIA);
+define_currency!(Tia, TIA, 6);
 
 define_symbol! {
     ST_TIA {
@@ -125,7 +125,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(StTia, ST_TIA);
+define_currency!(StTia, ST_TIA, 6);
 
 define_symbol! {
     STK_ATOM {
@@ -143,7 +143,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(StkAtom, STK_ATOM);
+define_currency!(StkAtom, STK_ATOM, 6);
 
 #[cfg(feature = "testing")]
 mod testing_currencies {
@@ -159,7 +159,7 @@ mod testing_currencies {
             },
         }
     }
-    define_currency!(TestC1, TEST_C1);
+    define_currency!(TestC1, TEST_C1, 6);
 }
 
 pub(super) fn maybe_visit<M, V>(

--- a/protocol/packages/currencies/src/lease/osmosis.rs
+++ b/protocol/packages/currencies/src/lease/osmosis.rs
@@ -54,7 +54,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Atom, ATOM);
+define_currency!(Atom, ATOM, 6);
 
 define_symbol! {
     ST_ATOM {
@@ -78,7 +78,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(StAtom, ST_ATOM);
+define_currency!(StAtom, ST_ATOM, 6);
 
 define_symbol! {
     OSMO {
@@ -94,7 +94,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Osmo, OSMO);
+define_currency!(Osmo, OSMO, 6);
 
 define_symbol! {
     ST_OSMO {
@@ -118,7 +118,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(StOsmo, ST_OSMO);
+define_currency!(StOsmo, ST_OSMO, 6);
 
 define_symbol! {
     WETH {
@@ -146,7 +146,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Weth, WETH);
+define_currency!(Weth, WETH, 18);
 
 define_symbol! {
     WBTC {
@@ -174,7 +174,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Wbtc, WBTC);
+define_currency!(Wbtc, WBTC, 8);
 
 define_symbol! {
     AKT {
@@ -198,7 +198,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Akt, AKT);
+define_currency!(Akt, AKT, 6);
 
 define_symbol! {
     AXL {
@@ -226,7 +226,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Axl, AXL);
+define_currency!(Axl, AXL, 6);
 
 define_symbol! {
     Q_ATOM {
@@ -250,7 +250,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(QAtom, Q_ATOM);
+define_currency!(QAtom, Q_ATOM, 6);
 
 define_symbol! {
     STK_ATOM {
@@ -274,7 +274,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(StkAtom, STK_ATOM);
+define_currency!(StkAtom, STK_ATOM, 6);
 
 define_symbol! {
     STRD {
@@ -298,7 +298,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Strd, STRD);
+define_currency!(Strd, STRD, 6);
 
 define_symbol! {
     INJ {
@@ -322,7 +322,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Inj, INJ);
+define_currency!(Inj, INJ, 18);
 
 define_symbol! {
     SCRT {
@@ -346,7 +346,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Secret, SCRT);
+define_currency!(Secret, SCRT, 6);
 
 define_symbol! {
     STARS {
@@ -370,7 +370,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Stars, STARS);
+define_currency!(Stars, STARS, 6);
 
 define_symbol! {
     CRO {
@@ -394,7 +394,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Cro, CRO);
+define_currency!(Cro, CRO, 8);
 
 define_symbol! {
     JUNO {
@@ -418,7 +418,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Juno, JUNO);
+define_currency!(Juno, JUNO, 6);
 
 define_symbol! {
     EVMOS {
@@ -442,7 +442,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Evmos, EVMOS);
+define_currency!(Evmos, EVMOS, 18);
 
 define_symbol! {
     MARS {
@@ -466,7 +466,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Mars, MARS);
+define_currency!(Mars, MARS, 6);
 
 define_symbol! {
     TIA {
@@ -490,7 +490,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Tia, TIA);
+define_currency!(Tia, TIA, 6);
 
 define_symbol! {
     ST_TIA {
@@ -514,7 +514,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(StTia, ST_TIA);
+define_currency!(StTia, ST_TIA, 6);
 
 define_symbol! {
     JKL {
@@ -538,7 +538,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Jkl, JKL);
+define_currency!(Jkl, JKL, 6);
 
 define_symbol! {
     MILK_TIA {
@@ -559,7 +559,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(MilkTia, MILK_TIA);
+define_currency!(MilkTia, MILK_TIA, 6);
 
 define_symbol! {
     LVN {
@@ -580,7 +580,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Lvn, LVN);
+define_currency!(Lvn, LVN, 6);
 
 define_symbol! {
     QSR {
@@ -604,7 +604,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Qsr, QSR);
+define_currency!(Qsr, QSR, 6);
 
 define_symbol! {
     PICA {
@@ -628,7 +628,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Pica, PICA);
+define_currency!(Pica, PICA, 12);
 
 define_symbol! {
     DYM {
@@ -652,7 +652,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(Dym, DYM);
+define_currency!(Dym, DYM, 18);
 
 pub(super) fn maybe_visit<M, V>(
     matcher: &M,

--- a/protocol/packages/currencies/src/lib.rs
+++ b/protocol/packages/currencies/src/lib.rs
@@ -8,6 +8,11 @@ compile_error!("No protocol selected!");
 #[cfg(not(any(feature = "net_dev", feature = "net_test", feature = "net_main")))]
 compile_error!("No net selected!");
 
+pub use lease::LeaseGroup;
+pub use lpn::{Lpn, Lpns};
+pub use native::{Native, Nls};
+pub use payment::{PaymentGroup, PaymentOnlyGroup};
+
 mod currency_macro;
 mod lease;
 mod lpn;
@@ -20,8 +25,3 @@ pub mod test;
 
 #[cfg(test)]
 mod test_impl;
-
-pub use lease::LeaseGroup;
-pub use lpn::{Lpn, Lpns};
-pub use native::{Native, Nls};
-pub use payment::PaymentGroup;

--- a/protocol/packages/currencies/src/lpn/neutron_astroport_usdc_axelar.rs
+++ b/protocol/packages/currencies/src/lpn/neutron_astroport_usdc_axelar.rs
@@ -24,4 +24,4 @@ define_symbol! {
         },
     }
 }
-define_currency!(UsdcAxelar, USDC_AXELAR);
+define_currency!(UsdcAxelar, USDC_AXELAR, 6);

--- a/protocol/packages/currencies/src/lpn/osmosis_osmosis_usdc_axelar.rs
+++ b/protocol/packages/currencies/src/lpn/osmosis_osmosis_usdc_axelar.rs
@@ -24,4 +24,4 @@ define_symbol! {
         },
     }
 }
-define_currency!(Usdc, USDC);
+define_currency!(Usdc, USDC, 6);

--- a/protocol/packages/currencies/src/lpn/osmosis_osmosis_usdc_noble.rs
+++ b/protocol/packages/currencies/src/lpn/osmosis_osmosis_usdc_noble.rs
@@ -24,4 +24,4 @@ define_symbol! {
         },
     }
 }
-define_currency!(UsdcNoble, USDC_NOBLE);
+define_currency!(UsdcNoble, USDC_NOBLE, 6);

--- a/protocol/packages/currencies/src/native/astroport.rs
+++ b/protocol/packages/currencies/src/native/astroport.rs
@@ -21,4 +21,4 @@ define_symbol! {
         },
     }
 }
-define_currency!(Nls, NLS);
+define_currency!(Nls, NLS, 6);

--- a/protocol/packages/currencies/src/native/osmosis.rs
+++ b/protocol/packages/currencies/src/native/osmosis.rs
@@ -21,4 +21,4 @@ define_symbol! {
         },
     }
 }
-define_currency!(Nls, NLS);
+define_currency!(Nls, NLS, 6);

--- a/protocol/packages/currencies/src/payment/mod.rs
+++ b/protocol/packages/currencies/src/payment/mod.rs
@@ -6,7 +6,7 @@ use currency::{AnyVisitor, Group, Matcher, MaybeAnyVisitResult, SymbolSlice};
 
 use super::{lease::LeaseGroup, lpn::Lpns, native::Native};
 
-use self::only::PaymentOnlyGroup;
+pub use self::only::PaymentOnlyGroup;
 
 mod only;
 mod osmosis_tests;

--- a/protocol/packages/currencies/src/payment/only/neutron_astroport_usdc_axelar.rs
+++ b/protocol/packages/currencies/src/payment/only/neutron_astroport_usdc_axelar.rs
@@ -19,7 +19,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(UsdcNoble, USDC_NOBLE);
+define_currency!(UsdcNoble, USDC_NOBLE, 6);
 
 pub(super) fn maybe_visit<M, V>(
     matcher: &M,

--- a/protocol/packages/currencies/src/payment/only/osmosis_osmosis_usdc_axelar.rs
+++ b/protocol/packages/currencies/src/payment/only/osmosis_osmosis_usdc_axelar.rs
@@ -25,7 +25,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(UsdcNoble, USDC_NOBLE);
+define_currency!(UsdcNoble, USDC_NOBLE, 6);
 
 pub(super) fn maybe_visit<M, V>(
     matcher: &M,

--- a/protocol/packages/currencies/src/payment/only/osmosis_osmosis_usdc_noble.rs
+++ b/protocol/packages/currencies/src/payment/only/osmosis_osmosis_usdc_noble.rs
@@ -25,7 +25,7 @@ define_symbol! {
         },
     }
 }
-define_currency!(UsdcAxelar, USDC_AXELAR);
+define_currency!(UsdcAxelar, USDC_AXELAR, 6);
 
 pub(super) fn maybe_visit<M, V>(
     matcher: &M,


### PR DESCRIPTION
Note: Implementation only lists currently configured currencies rather than all software supported.

Closes #228