### PR TITLE
feat(admin): Add arbitrary contract execution endpoint

### DIFF
--- a/platform/Cargo.lock
+++ b/platform/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "schema",
  "sdk",
  "serde",
+ "serde_test",
  "thiserror",
  "versioning",
 ]
@@ -954,6 +955,15 @@ checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.176"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a2f49ace1498612d14f7e0b8245519584db8299541dfe31a06374a828d620ab"
+dependencies = [
  "serde",
 ]
 

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -52,6 +52,9 @@ cosmos-sdk-proto = { version = "0.20", default-features = false }
 prost = { version = "0.12", default-features = false }
 neutron-sdk = { version = "0.8", default-features = false }
 
+# Testing
+serde_test = "1"
+
 [profile.dev.build-override]
 opt-level = 3
 

--- a/platform/contracts/admin/Cargo.toml
+++ b/platform/contracts/admin/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 schema = { workspace = true }
+serde_test = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 sdk = { workspace = true, default-features = false, features = ["testing"] }

--- a/platform/contracts/admin/src/contracts/granular.rs
+++ b/platform/contracts/admin/src/contracts/granular.rs
@@ -1,0 +1,51 @@
+use std::marker::PhantomData;
+
+use serde::{Deserialize, Serialize};
+
+use sdk::schemars::{self, JsonSchema};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct HigherOrderType<StructuralTypeConstructor, GranularUnitWrapperTypeConstructor>(
+    PhantomData<StructuralTypeConstructor>,
+    PhantomData<GranularUnitWrapperTypeConstructor>,
+)
+where
+    StructuralTypeConstructor: super::HigherOrderType,
+    GranularUnitWrapperTypeConstructor: super::HigherOrderType;
+
+impl<StructuralTypeConstructor, GranularUnitWrapperTypeConstructor> super::HigherOrderType
+    for HigherOrderType<StructuralTypeConstructor, GranularUnitWrapperTypeConstructor>
+where
+    StructuralTypeConstructor: super::HigherOrderType,
+    GranularUnitWrapperTypeConstructor: super::HigherOrderType,
+{
+    type Of<T> = Granularity<StructuralTypeConstructor, GranularUnitWrapperTypeConstructor, T>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(
+    rename_all = "snake_case",
+    deny_unknown_fields,
+    untagged,
+    bound(
+        serialize = "StructuralTypeConstructor::Of<GranularUnitWrapperTypeConstructor::Of<Unit>>: Serialize,\
+            GranularUnitWrapperTypeConstructor::Of<StructuralTypeConstructor::Of<Unit>>: Serialize",
+        deserialize = "StructuralTypeConstructor::Of<GranularUnitWrapperTypeConstructor::Of<Unit>>: Deserialize<'de>,\
+            GranularUnitWrapperTypeConstructor::Of<StructuralTypeConstructor::Of<Unit>>: Deserialize<'de>",
+    )
+)]
+#[schemars(bound = "StructuralTypeConstructor: JsonSchema, \
+    StructuralTypeConstructor::Of<GranularUnitWrapperTypeConstructor::Of<Unit>>: JsonSchema, \
+    GranularUnitWrapperTypeConstructor: JsonSchema, \
+    GranularUnitWrapperTypeConstructor::Of<StructuralTypeConstructor::Of<Unit>>: JsonSchema, \
+    Unit: JsonSchema")]
+pub enum Granularity<StructuralTypeConstructor, GranularUnitWrapperTypeConstructor, Unit>
+where
+    StructuralTypeConstructor: super::HigherOrderType,
+    GranularUnitWrapperTypeConstructor: super::HigherOrderType,
+{
+    Some {
+        some: StructuralTypeConstructor::Of<GranularUnitWrapperTypeConstructor::Of<Unit>>,
+    },
+    All(GranularUnitWrapperTypeConstructor::Of<StructuralTypeConstructor::Of<Unit>>),
+}

--- a/platform/contracts/admin/src/contracts/higher_order_type.rs
+++ b/platform/contracts/admin/src/contracts/higher_order_type.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use sdk::schemars::{self, JsonSchema};
 
 pub trait HigherOrderType {
@@ -12,12 +10,6 @@ pub struct Identity;
 impl HigherOrderType for Identity {
     type Of<T> = T;
 }
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq, JsonSchema)]
-pub struct Composition<Outer, Inner>(PhantomData<Outer>, PhantomData<Inner>)
-where
-    Outer: HigherOrderType,
-    Inner: HigherOrderType;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, JsonSchema)]
 pub struct Option;

--- a/platform/contracts/admin/src/contracts/higher_order_type.rs
+++ b/platform/contracts/admin/src/contracts/higher_order_type.rs
@@ -1,0 +1,27 @@
+use std::marker::PhantomData;
+
+use sdk::schemars::{self, JsonSchema};
+
+pub trait HigherOrderType {
+    type Of<T>;
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, JsonSchema)]
+pub struct Identity;
+
+impl HigherOrderType for Identity {
+    type Of<T> = T;
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, JsonSchema)]
+pub struct Composition<Outer, Inner>(PhantomData<Outer>, PhantomData<Inner>)
+where
+    Outer: HigherOrderType,
+    Inner: HigherOrderType;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, JsonSchema)]
+pub struct Option;
+
+impl HigherOrderType for Option {
+    type Of<T> = core::option::Option<T>;
+}

--- a/platform/contracts/admin/src/contracts/platform/impl_mod.rs
+++ b/platform/contracts/admin/src/contracts/platform/impl_mod.rs
@@ -1,19 +1,22 @@
 use platform::batch::Batch;
 use sdk::cosmwasm_std::Addr;
 
-use crate::{
-    contracts::{impl_mod::migrate_contract, MigrationSpec},
-    validate::Validate,
+use crate::validate::Validate;
+
+use super::{
+    super::{
+        impl_mod::{execute_contract, migrate_contract},
+        MigrationSpec,
+    },
+    PlatformContracts,
 };
 
-use super::PlatformTemplate;
-
-impl PlatformTemplate<Addr> {
+impl PlatformContracts<Addr> {
     pub(in crate::contracts) fn migrate(
         self,
         migration_batch: &mut Batch,
         post_migration_execute_batch: &mut Batch,
-        migration_msgs: PlatformTemplate<MigrationSpec>,
+        migration_msgs: PlatformContracts<MigrationSpec>,
     ) {
         migrate_contract(
             migration_batch,
@@ -36,9 +39,73 @@ impl PlatformTemplate<Addr> {
             migration_msgs.treasury,
         );
     }
+
+    pub(in crate::contracts) fn maybe_migrate(
+        self,
+        migration_batch: &mut Batch,
+        post_migration_execute_batch: &mut Batch,
+        migration_msgs: PlatformContracts<Option<MigrationSpec>>,
+    ) {
+        () = migration_msgs.dispatcher.map_or((), |migration_spec| {
+            migrate_contract(
+                migration_batch,
+                post_migration_execute_batch,
+                self.dispatcher,
+                migration_spec,
+            )
+        });
+
+        () = migration_msgs.timealarms.map_or((), |migration_spec| {
+            migrate_contract(
+                migration_batch,
+                post_migration_execute_batch,
+                self.timealarms,
+                migration_spec,
+            )
+        });
+
+        () = migration_msgs.treasury.map_or((), |migration_spec| {
+            migrate_contract(
+                migration_batch,
+                post_migration_execute_batch,
+                self.treasury,
+                migration_spec,
+            )
+        });
+    }
+
+    pub(in crate::contracts) fn execute(
+        self,
+        batch: &mut Batch,
+        execute_messages: PlatformContracts<String>,
+    ) {
+        execute_contract(batch, self.dispatcher, execute_messages.dispatcher);
+
+        execute_contract(batch, self.timealarms, execute_messages.timealarms);
+
+        execute_contract(batch, self.treasury, execute_messages.treasury);
+    }
+
+    pub(in crate::contracts) fn maybe_execute(
+        self,
+        batch: &mut Batch,
+        execute_messages: PlatformContracts<Option<String>>,
+    ) {
+        () = execute_messages.dispatcher.map_or((), |execute_message| {
+            execute_contract(batch, self.dispatcher, execute_message)
+        });
+
+        () = execute_messages.timealarms.map_or((), |execute_message| {
+            execute_contract(batch, self.timealarms, execute_message)
+        });
+
+        () = execute_messages.treasury.map_or((), |execute_message| {
+            execute_contract(batch, self.treasury, execute_message)
+        });
+    }
 }
 
-impl<T> Validate for PlatformTemplate<T>
+impl<T> Validate for PlatformContracts<T>
 where
     T: Validate,
 {

--- a/platform/contracts/admin/src/contracts/platform/mod.rs
+++ b/platform/contracts/admin/src/contracts/platform/mod.rs
@@ -5,9 +5,16 @@ use sdk::schemars::{self, JsonSchema};
 #[cfg(feature = "contract")]
 mod impl_mod;
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct HigherOrderType;
+
+impl super::HigherOrderType for HigherOrderType {
+    type Of<T> = PlatformContracts<T>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
-pub struct PlatformTemplate<T> {
+pub struct PlatformContracts<T> {
     pub dispatcher: T,
     pub timealarms: T,
     pub treasury: T,

--- a/platform/contracts/admin/src/contracts/protocol/higher_order_type.rs
+++ b/platform/contracts/admin/src/contracts/protocol/higher_order_type.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+use sdk::schemars::{self, JsonSchema};
+
+use super::super::HigherOrderType;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ProtocolContracts;
+
+impl HigherOrderType for ProtocolContracts {
+    type Of<T> = super::ProtocolContracts<T>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct Protocol;
+
+impl HigherOrderType for Protocol {
+    type Of<T> = super::Protocol<T>;
+}

--- a/platform/contracts/admin/src/contracts/protocol/impl_mod.rs
+++ b/platform/contracts/admin/src/contracts/protocol/impl_mod.rs
@@ -1,19 +1,22 @@
 use platform::batch::Batch;
 use sdk::cosmwasm_std::Addr;
 
-use crate::{
-    contracts::{impl_mod::migrate_contract, MigrationSpec},
-    validate::Validate,
+use crate::validate::Validate;
+
+use super::{
+    super::{
+        impl_mod::{execute_contract, migrate_contract},
+        MigrationSpec,
+    },
+    Protocol, ProtocolContracts,
 };
 
-use super::{Protocol, ProtocolTemplate};
-
-impl ProtocolTemplate<Addr> {
+impl ProtocolContracts<Addr> {
     pub(in crate::contracts) fn migrate(
         self,
         migration_batch: &mut Batch,
         post_migration_execute_batch: &mut Batch,
-        migration_msgs: ProtocolTemplate<MigrationSpec>,
+        migration_msgs: ProtocolContracts<MigrationSpec>,
     ) {
         migrate_contract(
             migration_batch,
@@ -50,9 +53,103 @@ impl ProtocolTemplate<Addr> {
             migration_msgs.reserve,
         );
     }
+
+    pub(in crate::contracts) fn maybe_migrate(
+        self,
+        migration_batch: &mut Batch,
+        post_migration_execute_batch: &mut Batch,
+        migration_msgs: ProtocolContracts<Option<MigrationSpec>>,
+    ) {
+        () = migration_msgs.leaser.map_or((), |migration_spec| {
+            migrate_contract(
+                migration_batch,
+                post_migration_execute_batch,
+                self.leaser,
+                migration_spec,
+            )
+        });
+
+        () = migration_msgs.lpp.map_or((), |migration_spec| {
+            migrate_contract(
+                migration_batch,
+                post_migration_execute_batch,
+                self.lpp,
+                migration_spec,
+            )
+        });
+
+        () = migration_msgs.oracle.map_or((), |migration_spec| {
+            migrate_contract(
+                migration_batch,
+                post_migration_execute_batch,
+                self.oracle,
+                migration_spec,
+            )
+        });
+
+        () = migration_msgs.profit.map_or((), |migration_spec| {
+            migrate_contract(
+                migration_batch,
+                post_migration_execute_batch,
+                self.profit,
+                migration_spec,
+            )
+        });
+
+        () = migration_msgs.reserve.map_or((), |migration_spec| {
+            migrate_contract(
+                migration_batch,
+                post_migration_execute_batch,
+                self.reserve,
+                migration_spec,
+            )
+        });
+    }
+
+    pub(in crate::contracts) fn execute(
+        self,
+        batch: &mut Batch,
+        execute_messages: ProtocolContracts<String>,
+    ) {
+        execute_contract(batch, self.leaser, execute_messages.leaser);
+
+        execute_contract(batch, self.lpp, execute_messages.lpp);
+
+        execute_contract(batch, self.oracle, execute_messages.oracle);
+
+        execute_contract(batch, self.profit, execute_messages.profit);
+
+        execute_contract(batch, self.reserve, execute_messages.reserve);
+    }
+
+    pub(in crate::contracts) fn maybe_execute(
+        self,
+        batch: &mut Batch,
+        execute_messages: ProtocolContracts<Option<String>>,
+    ) {
+        () = execute_messages.leaser.map_or((), |execute_message| {
+            execute_contract(batch, self.leaser, execute_message)
+        });
+
+        () = execute_messages.lpp.map_or((), |execute_message| {
+            execute_contract(batch, self.lpp, execute_message)
+        });
+
+        () = execute_messages.oracle.map_or((), |execute_message| {
+            execute_contract(batch, self.oracle, execute_message)
+        });
+
+        () = execute_messages.profit.map_or((), |execute_message| {
+            execute_contract(batch, self.profit, execute_message)
+        });
+
+        () = execute_messages.reserve.map_or((), |execute_message| {
+            execute_contract(batch, self.reserve, execute_message)
+        });
+    }
 }
 
-impl<T> Validate for ProtocolTemplate<T>
+impl<T> Validate for ProtocolContracts<T>
 where
     T: Validate,
 {
@@ -60,7 +157,7 @@ where
 
     type Error = T::Error;
 
-    fn validate(&self, ctx: Self::Context<'_>) -> ::std::result::Result<(), Self::Error> {
+    fn validate(&self, ctx: Self::Context<'_>) -> Result<(), Self::Error> {
         self.leaser
             .validate(ctx)
             .and_then(|()| self.lpp.validate(ctx))
@@ -70,13 +167,16 @@ where
     }
 }
 
-impl Validate for Protocol {
-    type Context<'r> = <Addr as Validate>::Context<'r>;
+impl<T> Validate for Protocol<T>
+where
+    T: Validate,
+{
+    type Context<'r> = T::Context<'r>;
 
-    type Error = <Addr as Validate>::Error;
+    type Error = T::Error;
 
     #[inline]
-    fn validate(&self, ctx: Self::Context<'_>) -> ::std::result::Result<(), Self::Error> {
+    fn validate(&self, ctx: Self::Context<'_>) -> Result<(), Self::Error> {
         self.contracts.validate(ctx)
     }
 }

--- a/platform/contracts/admin/src/contracts/protocol/mod.rs
+++ b/platform/contracts/admin/src/contracts/protocol/mod.rs
@@ -1,16 +1,14 @@
 use serde::{Deserialize, Serialize};
 
-use sdk::{
-    cosmwasm_std::Addr,
-    schemars::{self, JsonSchema},
-};
+use sdk::schemars::{self, JsonSchema};
 
+pub(super) mod higher_order_type;
 #[cfg(feature = "contract")]
 mod impl_mod;
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
-pub struct ProtocolTemplate<T> {
+pub struct ProtocolContracts<T> {
     pub leaser: T,
     pub lpp: T,
     pub oracle: T,
@@ -18,15 +16,15 @@ pub struct ProtocolTemplate<T> {
     pub reserve: T,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
-pub struct Protocol {
+pub struct Protocol<T> {
     pub network: Network,
     pub dex: Dex,
-    pub contracts: ProtocolTemplate<Addr>,
+    pub contracts: ProtocolContracts<T>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(
     rename_all = "PascalCase",
     rename_all_fields = "snake_case",
@@ -40,7 +38,7 @@ pub enum Network {
     Osmosis,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(
     rename_all = "PascalCase",
     rename_all_fields = "snake_case",

--- a/platform/contracts/admin/src/endpoints.rs
+++ b/platform/contracts/admin/src/endpoints.rs
@@ -167,6 +167,10 @@ pub fn sudo(deps: DepsMut<'_>, env: Env, msg: SudoMsg) -> ContractResult<CwRespo
             crate::contracts::migrate(deps.storage, env.contract.address, release, migration_spec)
                 .map(response::response_only_messages)
         }
+        SudoMsg::ExecuteContracts(execute_messages) => {
+            crate::contracts::execute(deps.storage, execute_messages)
+                .map(response::response_only_messages)
+        }
     }
 }
 
@@ -262,7 +266,7 @@ fn register_protocol(
     storage: &mut dyn Storage,
     querier: QuerierWrapper<'_>,
     name: String,
-    protocol: &Protocol,
+    protocol: &Protocol<Addr>,
 ) -> ContractResult<CwResponse> {
     protocol.validate(querier)?;
 

--- a/platform/contracts/admin/src/msg.rs
+++ b/platform/contracts/admin/src/msg.rs
@@ -10,7 +10,10 @@ use sdk::{
 use versioning::ReleaseLabel;
 
 pub use crate::contracts::{
-    Contracts, ContractsMigration, Dex, Network, PlatformTemplate, Protocol, ProtocolTemplate,
+    Contracts, ContractsExecute, ContractsMigration, Dex, Granularity, HigherOrderGranularity,
+    HigherOrderOption, HigherOrderPlatformContracts, HigherOrderProtocol,
+    HigherOrderProtocolContracts, HigherOrderType, Network, PlatformContracts, Protocol,
+    ProtocolContracts,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -43,11 +46,11 @@ where
     },
     RegisterProtocol {
         name: String,
-        protocol: Protocol,
+        protocol: Protocol<Addr>,
     },
     /// A message for **internal purposes only**.
     ///
-    /// It is meant to clean-up any temporary storage changes.
+    /// It is meant to clean up any temporary storage changes.
     ///
     /// Manual execution by an outside sender is considered an
     /// error, thus execution has to fail.
@@ -62,7 +65,7 @@ pub enum SudoMsg {
     },
     RegisterProtocol {
         name: String,
-        protocol: Protocol,
+        protocol: Protocol<Addr>,
     },
     /// Trigger a migration of contracts
     ///
@@ -71,6 +74,7 @@ pub enum SudoMsg {
     /// it should start as Admin contract migration which would then
     /// continue with the migration of the other contracts.
     MigrateContracts(MigrateContracts),
+    ExecuteContracts(ContractsExecute),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -95,8 +99,8 @@ where
 
 pub type ProtocolsQueryResponse = Vec<String>;
 
-pub type PlatformQueryResponse = PlatformTemplate<Addr>;
+pub type PlatformQueryResponse = PlatformContracts<Addr>;
 
-pub type ProtocolQueryResponse = Protocol;
+pub type ProtocolQueryResponse = Protocol<Addr>;
 
-pub type ProtocolContracts = ProtocolTemplate<Addr>;
+pub type ProtocolContractAddresses = ProtocolContracts<Addr>;

--- a/platform/contracts/admin/src/state/contracts.rs
+++ b/platform/contracts/admin/src/state/contracts.rs
@@ -9,14 +9,14 @@ use sdk::{
 
 use crate::{
     contracts::{
-        Contracts, ContractsTemplate, Dex, Network, PlatformTemplate, Protocol, ProtocolTemplate,
+        Contracts, ContractsTemplate, Dex, Network, PlatformContracts, Protocol, ProtocolContracts,
     },
     error::Error,
     result::Result,
 };
 
-const PLATFORM: Item<'_, PlatformTemplate<Addr>> = Item::new("platform_contracts");
-const PROTOCOL: Map<'_, String, Protocol> = Map::new("protocol_contracts");
+const PLATFORM: Item<'_, PlatformContracts<Addr>> = Item::new("platform_contracts");
+const PROTOCOL: Map<'_, String, Protocol<Addr>> = Map::new("protocol_contracts");
 
 pub(crate) fn store(storage: &mut dyn Storage, contracts: Contracts) -> Result<()> {
     PLATFORM
@@ -35,7 +35,7 @@ pub(crate) fn store(storage: &mut dyn Storage, contracts: Contracts) -> Result<(
 pub(crate) fn add_protocol(
     storage: &mut dyn Storage,
     name: String,
-    protocol: &Protocol,
+    protocol: &Protocol<Addr>,
 ) -> Result<()> {
     if PROTOCOL.has(storage, name.clone()) {
         Err(Error::ProtocolSetAlreadyExists(name))
@@ -51,11 +51,11 @@ pub(crate) fn protocols(storage: &dyn Storage) -> Result<Vec<String>> {
         .map_err(Into::into)
 }
 
-pub(crate) fn load_platform(storage: &dyn Storage) -> Result<PlatformTemplate<Addr>> {
+pub(crate) fn load_platform(storage: &dyn Storage) -> Result<PlatformContracts<Addr>> {
     PLATFORM.load(storage).map_err(Into::into)
 }
 
-pub(crate) fn load_protocol(storage: &dyn Storage, name: String) -> Result<Protocol> {
+pub(crate) fn load_protocol(storage: &dyn Storage, name: String) -> Result<Protocol<Addr>> {
     PROTOCOL.load(storage, name).map_err(Into::into)
 }
 
@@ -96,11 +96,11 @@ pub(super) fn migrate_protocols(
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 struct OldProtocol {
     pub network: Network,
-    pub contracts: ProtocolTemplate<Addr>,
+    pub contracts: ProtocolContracts<Addr>,
 }
 
 impl OldProtocol {
-    fn migrate(self, dex: Dex) -> Protocol {
+    fn migrate(self, dex: Dex) -> Protocol<Addr> {
         Protocol {
             network: self.network,
             dex,

--- a/platform/contracts/admin/tests/serde.rs
+++ b/platform/contracts/admin/tests/serde.rs
@@ -1,0 +1,206 @@
+use std::collections::BTreeMap;
+
+use serde_test::{assert_tokens, Token};
+
+use admin_contract::msg::{ContractsExecute, Granularity, PlatformContracts, ProtocolContracts};
+
+#[test]
+fn contracts_execute() {
+    const CONTRACTS_STRUCT_NAME: &str = "ContractsTemplate";
+    const PLATFORM_FIELD_NAME: &str = "platform";
+    const PROTOCOL_FIELD_NAME: &str = "protocol";
+    const PLATFORM_STRUCT_NAME: &str = "PlatformContracts";
+    const DISPATCHER_FIELD_NAME: &str = "dispatcher";
+    const TIME_ALARMS_FIELD_NAME: &str = "timealarms";
+    const TREASURY_FIELD_NAME: &str = "treasury";
+    const PROTOCOL_STRUCT_NAME: &str = "ProtocolContracts";
+    const GRANULARITY_ENUM_NAME: &str = "Granularity";
+    const GRANULARITY_FIELD_NAME: &str = "some";
+    const LEASER_FIELD_NAME: &str = "leaser";
+    const LPP_FIELD_NAME: &str = "lpp";
+    const ORACLE_FIELD_NAME: &str = "oracle";
+    const PROFIT_FIELD_NAME: &str = "profit";
+    const RESERVE_FIELD_NAME: &str = "reserve";
+
+    const DISPATCHER_MSG: &str = r#"{"dispatcher": 0}"#;
+    const TIME_ALARMS_MSG: &str = r#"{"timealarms": 0}"#;
+    const TREASURY_MSG: &str = r#"{"treasury": 0}"#;
+
+    const SOME_PROTOCOL: &str = "1-some";
+    const SOME_PROTOCOL_LEASER_MSG: &str = r#"{"leaser": 1}"#;
+    const SOME_PROTOCOL_ORACLE_MSG: &str = r#"{"oracle": 1}"#;
+    const SOME_PROTOCOL_PROFIT_MSG: &str = r#"{"profit": 1}"#;
+    const SOME_PROTOCOL_RESERVE_MSG: &str = r#"{"reserve": 1}"#;
+
+    const ALL_PROTOCOL: &str = "2-all";
+    const ALL_PROTOCOL_LEASER_MSG: &str = r#"{"leaser": 2}"#;
+    const ALL_PROTOCOL_LPP_MSG: &str = r#"{"lpp": 2}"#;
+    const ALL_PROTOCOL_ORACLE_MSG: &str = r#"{"oracle": 2}"#;
+    const ALL_PROTOCOL_PROFIT_MSG: &str = r#"{"profit": 2}"#;
+    const ALL_PROTOCOL_RESERVE_MSG: &str = r#"{"reserve": 2}"#;
+
+    const NULL_PROTOCOL: &str = "3-null";
+
+    let value = ContractsExecute {
+        platform: Granularity::All(Some(PlatformContracts {
+            dispatcher: DISPATCHER_MSG.into(),
+            timealarms: TIME_ALARMS_MSG.into(),
+            treasury: TREASURY_MSG.into(),
+        })),
+        protocol: BTreeMap::from([
+            (
+                SOME_PROTOCOL.into(),
+                Granularity::Some {
+                    some: ProtocolContracts {
+                        leaser: Some(SOME_PROTOCOL_LEASER_MSG.into()),
+                        lpp: None,
+                        oracle: Some(SOME_PROTOCOL_ORACLE_MSG.into()),
+                        profit: Some(SOME_PROTOCOL_PROFIT_MSG.into()),
+                        reserve: Some(SOME_PROTOCOL_RESERVE_MSG.into()),
+                    },
+                },
+            ),
+            (
+                ALL_PROTOCOL.into(),
+                Granularity::All(Some(ProtocolContracts {
+                    leaser: ALL_PROTOCOL_LEASER_MSG.into(),
+                    lpp: ALL_PROTOCOL_LPP_MSG.into(),
+                    oracle: ALL_PROTOCOL_ORACLE_MSG.into(),
+                    profit: ALL_PROTOCOL_PROFIT_MSG.into(),
+                    reserve: ALL_PROTOCOL_RESERVE_MSG.into(),
+                })),
+            ),
+            (NULL_PROTOCOL.into(), Granularity::All(None)),
+        ]),
+    };
+
+    assert_tokens(
+        &value,
+        &r#struct(
+            CONTRACTS_STRUCT_NAME,
+            vec![
+                (
+                    PLATFORM_FIELD_NAME,
+                    some(r#struct(
+                        PLATFORM_STRUCT_NAME,
+                        vec![
+                            (DISPATCHER_FIELD_NAME, str(DISPATCHER_MSG)),
+                            (TIME_ALARMS_FIELD_NAME, str(TIME_ALARMS_MSG)),
+                            (TREASURY_FIELD_NAME, str(TREASURY_MSG)),
+                        ],
+                    )),
+                ),
+                (
+                    PROTOCOL_FIELD_NAME,
+                    map(vec![
+                        (
+                            SOME_PROTOCOL,
+                            r#struct(
+                                GRANULARITY_ENUM_NAME,
+                                vec![(
+                                    GRANULARITY_FIELD_NAME,
+                                    r#struct(
+                                        PROTOCOL_STRUCT_NAME,
+                                        vec![
+                                            (
+                                                LEASER_FIELD_NAME,
+                                                some(str(SOME_PROTOCOL_LEASER_MSG)),
+                                            ),
+                                            (LPP_FIELD_NAME, none()),
+                                            (
+                                                ORACLE_FIELD_NAME,
+                                                some(str(SOME_PROTOCOL_ORACLE_MSG)),
+                                            ),
+                                            (
+                                                PROFIT_FIELD_NAME,
+                                                some(str(SOME_PROTOCOL_PROFIT_MSG)),
+                                            ),
+                                            (
+                                                RESERVE_FIELD_NAME,
+                                                some(str(SOME_PROTOCOL_RESERVE_MSG)),
+                                            ),
+                                        ],
+                                    ),
+                                )],
+                            ),
+                        ),
+                        (
+                            ALL_PROTOCOL,
+                            some(r#struct(
+                                PROTOCOL_STRUCT_NAME,
+                                vec![
+                                    (LEASER_FIELD_NAME, str(ALL_PROTOCOL_LEASER_MSG)),
+                                    (LPP_FIELD_NAME, str(ALL_PROTOCOL_LPP_MSG)),
+                                    (ORACLE_FIELD_NAME, str(ALL_PROTOCOL_ORACLE_MSG)),
+                                    (PROFIT_FIELD_NAME, str(ALL_PROTOCOL_PROFIT_MSG)),
+                                    (RESERVE_FIELD_NAME, str(ALL_PROTOCOL_RESERVE_MSG)),
+                                ],
+                            )),
+                        ),
+                        (NULL_PROTOCOL, none()),
+                    ]),
+                ),
+            ],
+        ),
+    );
+
+    assert_eq!(
+        value,
+        sdk::cosmwasm_std::from_json(sdk::cosmwasm_std::to_json_string(&value).unwrap()).unwrap()
+    );
+}
+
+fn r#struct(name: &'static str, fields: Vec<(&'static str, Vec<Token>)>) -> Vec<Token> {
+    let mut v = vec![Token::Struct {
+        name,
+        len: fields.len(),
+    }];
+
+    fields
+        .into_iter()
+        .for_each(|(name, value)| v.append(&mut field(name, value)));
+
+    v.push(Token::StructEnd);
+
+    v
+}
+
+fn map(fields: Vec<(&'static str, Vec<Token>)>) -> Vec<Token> {
+    let mut v = vec![Token::Map {
+        len: Some(fields.len()),
+    }];
+
+    fields
+        .into_iter()
+        .for_each(|(name, value)| v.append(&mut field(name, value)));
+
+    v.push(Token::MapEnd);
+
+    v
+}
+
+fn field(name: &'static str, mut value: Vec<Token>) -> Vec<Token> {
+    assert!(!value.is_empty());
+
+    let mut v = vec![Token::Str(name)];
+
+    v.append(&mut value);
+
+    v
+}
+
+fn none() -> Vec<Token> {
+    vec![Token::None]
+}
+
+fn some(mut value: Vec<Token>) -> Vec<Token> {
+    let mut v = vec![Token::Some];
+
+    v.append(&mut value);
+
+    v
+}
+
+fn r#str(s: &'static str) -> Vec<Token> {
+    vec![Token::Str(s)]
+}

--- a/tests/src/common/protocols.rs
+++ b/tests/src/common/protocols.rs
@@ -1,6 +1,7 @@
 use admin_contract::{
     msg::{
-        Dex, Network, ProtocolContracts, ProtocolQueryResponse, ProtocolsQueryResponse, QueryMsg,
+        Dex, Network, ProtocolContractAddresses, ProtocolQueryResponse, ProtocolsQueryResponse,
+        QueryMsg,
     },
     result::Result as ContractResult,
 };
@@ -93,7 +94,7 @@ fn protocols_repo_query(
             to_json_binary(&ProtocolQueryResponse {
                 network: NETWORK,
                 dex: DEX,
-                contracts: ProtocolContracts {
+                contracts: ProtocolContractAddresses {
                     leaser: addr("DEADCODE"),
                     lpp: addr("contract0"),
                     oracle: addr("contract1"),


### PR DESCRIPTION
The endpoint is unified while there are two types of granularity, selected on per set basis, platform set and protocol sets.  

The fine-grain one is to be used when execute messages should be sent only to a subset of contracts.  
The coarse-grain one, for use when execute messages should be sent to the whole set, either platform contracts or a given protocol.

Coarse-grain granularity is to be preferred when possible, in order to mitigate applicable classes of human-errors.