### PR TITLE
refactor(scripts/lint): Deny `let-underscore` lint group.

### DIFF
--- a/scripts/check/lint.sh
+++ b/scripts/check/lint.sh
@@ -35,6 +35,7 @@ append_lint_flags() {
     --forbid "deprecated-safe" \
     --deny "future-incompatible" \
     --deny "keyword-idents" \
+    --deny "let-underscore" \
     --deny "nonstandard-style" \
     --deny "refining-impl-trait" \
     --deny "rust-2018-idioms" \

--- a/scripts/check/lint.sh
+++ b/scripts/check/lint.sh
@@ -34,6 +34,7 @@ append_lint_flags() {
     -- \
     --forbid "deprecated-safe" \
     --deny "future-incompatible" \
+    --deny "keyword-idents" \
     --deny "nonstandard-style" \
     --deny "refining-impl-trait" \
     --deny "rust-2018-idioms" \


### PR DESCRIPTION
Depends on #512 / Edition migration.