### PR TITLE
Refactor BalanceResponse

### DIFF
--- a/platform/packages/platform/src/tests.rs
+++ b/platform/packages/platform/src/tests.rs
@@ -49,5 +49,5 @@ pub fn assert_ser_string<T>(obj: &T, expected: &str)
 where
     T: Serialize,
 {
-    assert!(cosmwasm_std::to_json_string(obj).is_ok_and(|inner| inner == expected));
+    assert_eq!(Ok(expected), cosmwasm_std::to_json_string(obj).as_deref())
 }

--- a/platform/packages/platform/src/tests.rs
+++ b/platform/packages/platform/src/tests.rs
@@ -44,3 +44,10 @@ where
 {
     cosmwasm_std::from_json(cosmwasm_std::to_json_vec(obj).expect("serialization succeed"))
 }
+
+pub fn assert_ser_string<T>(obj: &T, expected: &str)
+where
+    T: Serialize,
+{
+    assert!(cosmwasm_std::to_json_string(obj).is_ok_and(|inner| inner == expected));
+}

--- a/protocol/contracts/lpp/src/contract/lender.rs
+++ b/protocol/contracts/lpp/src/contract/lender.rs
@@ -225,7 +225,7 @@ pub fn query_balance(storage: &dyn Storage, addr: Addr) -> Result<BalanceRespons
     TotalRewards::load_or_default(storage)
         .and_then(|total_rewards| Deposit::load_or_default(storage, addr, total_rewards))
         .map(|ref deposit| deposit.receipts())
-        .map(|receipts| BalanceResponse { balance: receipts })
+        .map(|balance| BalanceResponse { balance })
 }
 
 #[cfg(test)]

--- a/protocol/contracts/lpp/src/contract/lender.rs
+++ b/protocol/contracts/lpp/src/contract/lender.rs
@@ -1,8 +1,5 @@
 use currency::{CurrencyDef, platform::Nls};
-use finance::{
-    coin::{Amount, Coin},
-    zero::Zero,
-};
+use finance::{coin::Coin, zero::Zero};
 use lpp_platform::NLpn;
 use platform::{
     bank::{self, BankAccount, BankAccountView},
@@ -228,9 +225,7 @@ pub fn query_balance(storage: &dyn Storage, addr: Addr) -> Result<BalanceRespons
     TotalRewards::load_or_default(storage)
         .and_then(|total_rewards| Deposit::load_or_default(storage, addr, total_rewards))
         .map(|ref deposit| deposit.receipts())
-        .map(|receipts| BalanceResponse {
-            balance: Amount::from(receipts).into(),
-        })
+        .map(|receipts| BalanceResponse { balance: receipts })
 }
 
 #[cfg(test)]

--- a/protocol/contracts/lpp/src/msg.rs
+++ b/protocol/contracts/lpp/src/msg.rs
@@ -8,7 +8,7 @@ use finance::{
 };
 use lpp_platform::NLpn;
 use platform::contract::Code;
-use sdk::cosmwasm_std::{Addr, Uint64, Uint128};
+use sdk::cosmwasm_std::{Addr, Uint64};
 
 use crate::{borrow::InterestRate, config::Config, loan::Loan};
 
@@ -147,8 +147,8 @@ pub type QueryLoanResponse<Lpn> = Option<LoanResponse<Lpn>>;
 #[cfg_attr(any(test, feature = "testing"), derive(Debug))]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct BalanceResponse {
-    // TODO: Migrate to `balance: Coin<NLpn>
-    pub balance: Uint128,
+    #[serde(flatten)]
+    pub balance: Coin<NLpn>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -184,9 +184,12 @@ pub struct RewardsResponse {
 
 #[cfg(test)]
 mod test {
-    use super::QueryMsg;
     use currencies::Lpns;
-    use platform::tests as platform_tests;
+    use finance::coin::Coin;
+    use platform::tests::{self as platform_tests};
+
+    use super::QueryMsg;
+    use crate::msg::BalanceResponse;
 
     #[test]
     fn release() {
@@ -199,5 +202,14 @@ mod test {
             &versioning::query::PlatformPackage::Release {},
         )
         .unwrap_err();
+    }
+
+    #[test]
+    fn balance_response_string() {
+        let response = BalanceResponse {
+            balance: Coin::new(1_000),
+        };
+
+        platform_tests::assert_ser_string(&response, "{\"amount\":\"1000\"}");
     }
 }

--- a/protocol/contracts/lpp/src/msg.rs
+++ b/protocol/contracts/lpp/src/msg.rs
@@ -190,8 +190,9 @@ mod test {
     use finance::coin::Coin;
     use platform::tests::{self as platform_tests};
 
-    use super::QueryMsg;
     use crate::msg::BalanceResponse;
+
+    use super::QueryMsg;
 
     #[test]
     fn release() {

--- a/protocol/contracts/lpp/src/msg.rs
+++ b/protocol/contracts/lpp/src/msg.rs
@@ -105,7 +105,8 @@ where
         lease_addr: Addr,
     },
     // Deposit
-    /// CW20 interface\
+    /// CW20 interface
+    /// 
     /// Return the lender's deposit balance in NLpn [BalanceResponse]
     Balance {
         address: Addr,

--- a/protocol/contracts/lpp/src/msg.rs
+++ b/protocol/contracts/lpp/src/msg.rs
@@ -143,6 +143,8 @@ pub type QueryLoanResponse<Lpn> = Option<LoanResponse<Lpn>>;
 // Deposit query responses
 
 // CW20 interface
+/// A response to `QueryMsg::Balance`\
+/// Returns the lender's total balance in NLpn
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "testing"), derive(Debug))]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]

--- a/protocol/contracts/lpp/src/msg.rs
+++ b/protocol/contracts/lpp/src/msg.rs
@@ -105,7 +105,8 @@ where
         lease_addr: Addr,
     },
     // Deposit
-    /// CW20 interface, lender deposit balance
+    /// CW20 interface\
+    /// Return the lender's deposit balance in NLpn [BalanceResponse]
     Balance {
         address: Addr,
     },
@@ -143,8 +144,6 @@ pub type QueryLoanResponse<Lpn> = Option<LoanResponse<Lpn>>;
 // Deposit query responses
 
 // CW20 interface
-/// A response to `QueryMsg::Balance`\
-/// Returns the lender's total balance in NLpn
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "testing"), derive(Debug))]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]

--- a/protocol/contracts/lpp/src/msg.rs
+++ b/protocol/contracts/lpp/src/msg.rs
@@ -106,7 +106,7 @@ where
     },
     // Deposit
     /// CW20 interface
-    /// 
+    ///
     /// Return the lender's deposit balance in NLpn [BalanceResponse]
     Balance {
         address: Addr,

--- a/tests/src/lpp_tests.rs
+++ b/tests/src/lpp_tests.rs
@@ -447,7 +447,7 @@ fn deposit_and_withdraw() {
             &LppQueryMsg::Balance { address: lender2 },
         )
         .unwrap();
-    assert_eq!(balance_nlpn.balance, Coin::new(Amount::ZERO));
+    assert_eq!(balance_nlpn.balance, Coin::ZERO);
 }
 
 #[test]
@@ -758,7 +758,7 @@ fn loan_open_and_repay() {
     assert_eq!(loan1_resp.principal_due, (loan1 - repay_due_part).into());
     assert_eq!(
         loan1_resp.interest_due(&crate::block_time(&test_case)),
-        Coin::new(Amount::ZERO)
+        Coin::ZERO
     );
 
     // repay interest + due part, close the loan
@@ -1082,7 +1082,7 @@ fn compare_lpp_states() {
     assert_eq!(loan1_resp.principal_due, (loan1 - repay_due_part).into());
     assert_eq!(
         loan1_resp.interest_due(&crate::block_time(&test_case)),
-        Coin::new(Amount::ZERO)
+        Coin::ZERO
     );
 
     // repay interest + due part, close the loan
@@ -1409,7 +1409,7 @@ fn test_rewards() {
         )
         .unwrap();
 
-    assert_eq!(resp.rewards, Coin::new(Amount::ZERO));
+    assert_eq!(resp.rewards, Coin::ZERO);
     let balance = bank::balance(&recipient, test_case.app.query()).unwrap();
     assert_eq!(balance, Coin::<Nls>::from(lender_reward2));
 }

--- a/tests/src/lpp_tests.rs
+++ b/tests/src/lpp_tests.rs
@@ -291,7 +291,7 @@ fn deposit_and_withdraw() {
 
     let amount: Amount = 1_000;
     assert_eq!(
-        price::total(coin(amount), price.0),
+        price::total(Coin::new(amount), price.0),
         Coin::<Lpn>::new(1_000 * pushed_price)
     );
 
@@ -315,7 +315,7 @@ fn deposit_and_withdraw() {
         .query_wasm_smart(test_case.address_book.lpp().clone(), &LppQueryMsg::Price())
         .unwrap();
     assert_eq!(
-        price::total(coin(balance_nlpn.balance), price.0),
+        price::total(balance_nlpn.balance, price.0),
         Coin::<Lpn>::new(test_deposit - rounding_error)
     );
 
@@ -338,7 +338,7 @@ fn deposit_and_withdraw() {
         .query_wasm_smart(test_case.address_book.lpp().clone(), &LppQueryMsg::Price())
         .unwrap();
     assert_eq!(
-        price::total(coin(balance_nlpn.balance), price.0),
+        price::total(balance_nlpn.balance, price.0),
         Coin::<Lpn>::new(test_deposit - rounding_error)
     );
 
@@ -379,12 +379,12 @@ fn deposit_and_withdraw() {
         .query_wasm_smart(test_case.address_book.lpp().clone(), &LppQueryMsg::Price())
         .unwrap();
     assert_eq!(
-        price::total(coin(balance_nlpn2.balance), price.0),
+        price::total(balance_nlpn2.balance, price.0),
         Coin::<Lpn>::new(test_deposit - rounding_error)
     );
 
     // try to withdraw with overdraft
-    let to_burn: u128 = balance_nlpn.balance.u128() - rounding_error + overdraft;
+    let to_burn = Amount::from(balance_nlpn.balance) - rounding_error + overdraft;
     _ = test_case
         .app
         .execute(
@@ -422,7 +422,7 @@ fn deposit_and_withdraw() {
             },
         )
         .unwrap();
-    assert_eq!(balance_nlpn.balance.u128(), rest_nlpn);
+    assert_eq!(balance_nlpn.balance, Coin::new(rest_nlpn));
 
     // full withdraw, should close lender's account
     () = test_case
@@ -447,7 +447,7 @@ fn deposit_and_withdraw() {
             &LppQueryMsg::Balance { address: lender2 },
         )
         .unwrap();
-    assert_eq!(balance_nlpn.balance.u128(), 0);
+    assert_eq!(balance_nlpn.balance, Coin::new(Amount::ZERO));
 }
 
 #[test]
@@ -758,7 +758,7 @@ fn loan_open_and_repay() {
     assert_eq!(loan1_resp.principal_due, (loan1 - repay_due_part).into());
     assert_eq!(
         loan1_resp.interest_due(&crate::block_time(&test_case)),
-        coin(Amount::ZERO)
+        Coin::new(Amount::ZERO)
     );
 
     // repay interest + due part, close the loan
@@ -1082,7 +1082,7 @@ fn compare_lpp_states() {
     assert_eq!(loan1_resp.principal_due, (loan1 - repay_due_part).into());
     assert_eq!(
         loan1_resp.interest_due(&crate::block_time(&test_case)),
-        coin(Amount::ZERO)
+        Coin::new(Amount::ZERO)
     );
 
     // repay interest + due part, close the loan
@@ -1409,7 +1409,7 @@ fn test_rewards() {
         )
         .unwrap();
 
-    assert_eq!(resp.rewards, coin(Amount::ZERO));
+    assert_eq!(resp.rewards, Coin::new(Amount::ZERO));
     let balance = bank::balance(&recipient, test_case.app.query()).unwrap();
     assert_eq!(balance, Coin::<Nls>::from(lender_reward2));
 }
@@ -1530,11 +1530,4 @@ where
     A: Into<Coin<Lpn>>,
 {
     cwcoin(amount)
-}
-
-fn coin<A, C>(amount: A) -> Coin<C>
-where
-    A: Into<Amount>,
-{
-    Coin::<C>::new(amount.into())
 }


### PR DESCRIPTION
Refactor `BalanceResponse` to hold the balance in Coin type instead of the more general numeric type (Uint128).
Past temporary functions were removed.