### PR TITLE
Move FractionUnit and Zero implementations in sub modules

### DIFF
--- a/platform/packages/finance/src/coin/fraction.rs
+++ b/platform/packages/finance/src/coin/fraction.rs
@@ -1,0 +1,68 @@
+use std::ops::{Div, Rem};
+
+use gcd::Gcd;
+
+use crate::{
+    coin::{Amount, Coin},
+    fraction::Unit as FractionUnit,
+    zero::Zero,
+};
+
+// Used only for average price calculation
+impl FractionUnit for u128 {
+    type Times = Self;
+
+    fn gcd<U>(self, other: U) -> Self::Times
+    where
+        U: FractionUnit<Times = Self::Times>,
+    {
+        Gcd::gcd(self, other.to_primitive())
+    }
+
+    fn scale_down(self, scale: Self::Times) -> Self {
+        debug_assert_ne!(scale, Self::Times::ZERO);
+
+        self.div(scale)
+    }
+
+    fn modulo(self, scale: Self::Times) -> Self::Times {
+        debug_assert_ne!(scale, Self::Times::ZERO);
+
+        self.rem(scale)
+    }
+
+    fn to_primitive(self) -> Self::Times {
+        self
+    }
+}
+
+impl<C> FractionUnit for Coin<C> {
+    type Times = Amount;
+
+    fn gcd<U>(self, other: U) -> Self::Times
+    where
+        U: FractionUnit<Times = Self::Times>,
+    {
+        Gcd::gcd(self.amount, other.to_primitive())
+    }
+
+    fn scale_down(self, scale: Self::Times) -> Self {
+        debug_assert_ne!(scale, Self::Times::ZERO);
+
+        Coin::new(self.amount.div(scale))
+    }
+
+    fn modulo(self, scale: Self::Times) -> Self::Times {
+        debug_assert_ne!(scale, Self::Times::ZERO);
+
+        self.amount.rem(scale)
+    }
+
+    fn to_primitive(self) -> Self::Times {
+        self.amount
+    }
+}
+
+impl<C> Zero for Coin<C> {
+    const ZERO: Self = Self::new(Zero::ZERO);
+}

--- a/platform/packages/finance/src/coin/mod.rs
+++ b/platform/packages/finance/src/coin/mod.rs
@@ -6,15 +6,14 @@ use std::{
     fmt::{Debug, Display, Formatter},
     iter::Sum,
     marker::PhantomData,
-    ops::{Add, AddAssign, Div, Rem, Sub, SubAssign},
+    ops::{Add, AddAssign, Sub, SubAssign},
 };
 
 use ::serde::{Deserialize, Serialize};
-use gcd::Gcd;
 
 use currency::{Currency, CurrencyDef, Group, MemberOf};
 
-use crate::{fraction::Unit as FractionUnit, zero::Zero};
+use crate::zero::Zero;
 
 pub use self::{
     dto::{CoinDTO, IntoDTO},
@@ -24,40 +23,13 @@ pub use self::{
 mod amount_serde;
 mod dto;
 mod external;
+mod fraction;
 mod fractionable;
 mod serde;
 
 pub type Amount = u128;
 #[cfg(feature = "testing")]
 pub type NonZeroAmount = NonZeroU128;
-
-// Used only for average price calculation
-impl FractionUnit for u128 {
-    type Times = Self;
-
-    fn gcd<U>(self, other: U) -> Self::Times
-    where
-        U: FractionUnit<Times = Self::Times>,
-    {
-        Gcd::gcd(self, other.to_primitive())
-    }
-
-    fn scale_down(self, scale: Self::Times) -> Self {
-        debug_assert_ne!(scale, Self::Times::ZERO);
-
-        self.div(scale)
-    }
-
-    fn modulo(self, scale: Self::Times) -> Self::Times {
-        debug_assert_ne!(scale, Self::Times::ZERO);
-
-        self.rem(scale)
-    }
-
-    fn to_primitive(self) -> Self::Times {
-        self
-    }
-}
 
 #[derive(Serialize, Deserialize)]
 pub struct Coin<C> {
@@ -152,33 +124,6 @@ impl<C> Default for Coin<C> {
     }
 }
 
-impl<C> FractionUnit for Coin<C> {
-    type Times = Amount;
-
-    fn gcd<U>(self, other: U) -> Self::Times
-    where
-        U: FractionUnit<Times = Self::Times>,
-    {
-        Gcd::gcd(self.amount, other.to_primitive())
-    }
-
-    fn scale_down(self, scale: Self::Times) -> Self {
-        debug_assert_ne!(scale, Self::Times::ZERO);
-
-        Coin::new(self.amount.div(scale))
-    }
-
-    fn modulo(self, scale: Self::Times) -> Self::Times {
-        debug_assert_ne!(scale, Self::Times::ZERO);
-
-        self.amount.rem(scale)
-    }
-
-    fn to_primitive(self) -> Self::Times {
-        self.amount
-    }
-}
-
 impl<C> Eq for Coin<C> {}
 
 impl<C> PartialEq for Coin<C> {
@@ -200,10 +145,6 @@ where
     fn cmp(&self, other: &Self) -> Ordering {
         self.amount.cmp(&other.amount)
     }
-}
-
-impl<C> Zero for Coin<C> {
-    const ZERO: Self = Self::new(Zero::ZERO);
 }
 
 impl<C> Add for Coin<C> {

--- a/platform/packages/finance/src/duration/fraction.rs
+++ b/platform/packages/finance/src/duration/fraction.rs
@@ -1,0 +1,40 @@
+use std::ops::{Div, Rem};
+
+use gcd::Gcd;
+
+use crate::{
+    duration::{Duration, Units},
+    fraction::Unit as FractionUnit,
+    zero::Zero,
+};
+
+impl FractionUnit for Duration {
+    type Times = Units;
+
+    fn gcd<U>(self, other: U) -> Self::Times
+    where
+        U: FractionUnit<Times = Self::Times>,
+    {
+        Gcd::gcd(self.nanos(), other.to_primitive())
+    }
+
+    fn scale_down(self, scale: Self::Times) -> Self {
+        debug_assert_ne!(scale, Self::Times::ZERO);
+
+        Self::from_nanos(self.nanos().div(scale))
+    }
+
+    fn modulo(self, scale: Self::Times) -> Self::Times {
+        debug_assert_ne!(scale, Self::Times::ZERO);
+
+        self.nanos().rem(scale)
+    }
+
+    fn to_primitive(self) -> Self::Times {
+        self.nanos()
+    }
+}
+
+impl Zero for Duration {
+    const ZERO: Self = Self::from_nanos(0);
+}

--- a/platform/packages/finance/src/duration/mod.rs
+++ b/platform/packages/finance/src/duration/mod.rs
@@ -1,9 +1,8 @@
 use std::{
     fmt::{Debug, Display, Formatter, Result as FmtResult},
-    ops::{Add, AddAssign, Div, Rem, Sub, SubAssign},
+    ops::{Add, AddAssign, Sub, SubAssign},
 };
 
-use gcd::Gcd;
 use serde::{Deserialize, Serialize};
 
 use sdk::cosmwasm_std::Timestamp;
@@ -13,9 +12,9 @@ use crate::{
     fractionable::{CommonDoublePrimitive, Fractionable, IntoMax},
     ratio::SimpleFraction,
     rational::Rational,
-    zero::Zero,
 };
 
+mod fraction;
 mod fractionable;
 
 pub type Units = u64;
@@ -108,37 +107,6 @@ impl Duration {
     {
         SimpleFraction::new(amount, annual_amount).of(self)
     }
-}
-
-impl FractionUnit for Duration {
-    type Times = Units;
-
-    fn gcd<U>(self, other: U) -> Self::Times
-    where
-        U: FractionUnit<Times = Self::Times>,
-    {
-        Gcd::gcd(self.nanos(), other.to_primitive())
-    }
-
-    fn scale_down(self, scale: Self::Times) -> Self {
-        debug_assert_ne!(scale, Self::Times::ZERO);
-
-        Self::from_nanos(self.nanos().div(scale))
-    }
-
-    fn modulo(self, scale: Self::Times) -> Self::Times {
-        debug_assert_ne!(scale, Self::Times::ZERO);
-
-        self.nanos().rem(scale)
-    }
-
-    fn to_primitive(self) -> Self::Times {
-        self.nanos()
-    }
-}
-
-impl Zero for Duration {
-    const ZERO: Self = Self::from_nanos(0);
 }
 
 impl Add<Duration> for Timestamp {

--- a/platform/packages/finance/src/percent/bound.rs
+++ b/platform/packages/finance/src/percent/bound.rs
@@ -1,18 +1,12 @@
-use std::{
-    fmt::{Debug, Display, Formatter, Result as FmtResult, Write},
-    ops::{Div, Rem},
-};
+use std::fmt::{Debug, Display, Formatter, Result as FmtResult, Write};
 
 #[cfg(any(test, feature = "testing"))]
 use std::ops::{Add, Sub};
 
 use bnum::types::U256;
-use gcd::Gcd;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    coin::Amount, error::Error, fraction::Unit as FractionUnit, ratio::RatioLegacy, zero::Zero,
-};
+use crate::{coin::Amount, error::Error, ratio::RatioLegacy};
 
 use super::Units;
 
@@ -115,36 +109,6 @@ impl<const UPPER_BOUND: Units> Display for BoundPercent<UPPER_BOUND> {
     }
 }
 
-impl<const UPPER: Units> FractionUnit for BoundPercent<UPPER>
-where
-    BoundPercent<UPPER>: Copy + Debug + Ord + Zero,
-{
-    type Times = Units;
-
-    fn gcd<U>(self, other: U) -> Self::Times
-    where
-        U: FractionUnit<Times = Self::Times>,
-    {
-        Gcd::gcd(self.units(), other.to_primitive())
-    }
-
-    fn scale_down(self, scale: Self::Times) -> Self {
-        debug_assert_ne!(scale, Self::Times::ZERO);
-        Self::try_from_permille(self.units().div(scale))
-            .expect("Units should be less than UPPER_BOUND")
-    }
-
-    fn modulo(self, scale: Self::Times) -> Self::Times {
-        debug_assert_ne!(scale, Self::Times::ZERO);
-
-        self.units().rem(scale)
-    }
-
-    fn to_primitive(self) -> Self::Times {
-        self.units()
-    }
-}
-
 // TODO: Revisit it's usage after refactoring Fractionable
 impl<const UPPER_BOUND: Units> From<BoundPercent<UPPER_BOUND>> for u128 {
     fn from(percent: BoundPercent<UPPER_BOUND>) -> Self {
@@ -167,10 +131,6 @@ impl<const UPPER_BOUND: Units> RatioLegacy<Units> for BoundPercent<UPPER_BOUND> 
     fn total(&self) -> Units {
         Self::HUNDRED.0
     }
-}
-
-impl<const UPPER_BOUND: Units> Zero for BoundPercent<UPPER_BOUND> {
-    const ZERO: Self = Self::ZERO;
 }
 
 #[cfg(any(test, feature = "testing"))]

--- a/platform/packages/finance/src/percent/fraction.rs
+++ b/platform/packages/finance/src/percent/fraction.rs
@@ -1,0 +1,72 @@
+use std::{
+    fmt::Debug,
+    ops::{Div, Rem},
+};
+
+use gcd::Gcd;
+
+use crate::{
+    fraction::Unit as FractionUnit,
+    percent::{Units, bound::BoundPercent},
+    zero::Zero,
+};
+
+impl FractionUnit for Units {
+    type Times = Self;
+
+    fn gcd<U>(self, other: U) -> Self::Times
+    where
+        U: FractionUnit<Times = Self::Times>,
+    {
+        Gcd::gcd(self, other.to_primitive())
+    }
+
+    fn scale_down(self, scale: Self::Times) -> Self {
+        debug_assert_ne!(scale, Self::Times::ZERO);
+
+        self.div(scale)
+    }
+
+    fn modulo(self, scale: Self::Times) -> Self::Times {
+        debug_assert_ne!(scale, Self::Times::ZERO);
+
+        self.rem(scale)
+    }
+
+    fn to_primitive(self) -> Self::Times {
+        self
+    }
+}
+
+impl<const UPPER: Units> FractionUnit for BoundPercent<UPPER>
+where
+    BoundPercent<UPPER>: Copy + Debug + Ord + Zero,
+{
+    type Times = Units;
+
+    fn gcd<U>(self, other: U) -> Self::Times
+    where
+        U: FractionUnit<Times = Self::Times>,
+    {
+        Gcd::gcd(self.units(), other.to_primitive())
+    }
+
+    fn scale_down(self, scale: Self::Times) -> Self {
+        debug_assert_ne!(scale, Self::Times::ZERO);
+        Self::try_from(self.units().div(scale)).expect("Units should be less than UPPER_BOUND")
+    }
+
+    fn modulo(self, scale: Self::Times) -> Self::Times {
+        debug_assert_ne!(scale, Self::Times::ZERO);
+
+        self.units().rem(scale)
+    }
+
+    fn to_primitive(self) -> Self::Times {
+        self.units()
+    }
+}
+
+impl<const UPPER_BOUND: Units> Zero for BoundPercent<UPPER_BOUND> {
+    const ZERO: Self = Self::ZERO;
+}

--- a/platform/packages/finance/src/percent/mod.rs
+++ b/platform/packages/finance/src/percent/mod.rs
@@ -1,7 +1,4 @@
-use std::ops::{Div, Rem};
-
 use bound::BoundPercent;
-use gcd::Gcd;
 
 use crate::{
     error::Error,
@@ -9,10 +6,10 @@ use crate::{
     fractionable::{CommonDoublePrimitive, Fractionable, FractionableLegacy, IntoMax},
     ratio::{Ratio, SimpleFraction},
     rational::{Rational, RationalLegacy},
-    zero::Zero,
 };
 
 pub mod bound;
+mod fraction;
 mod fractionable;
 
 pub type Units = u32;
@@ -20,32 +17,6 @@ pub type Percent100 = BoundPercent<{ Percent::HUNDRED.units() }>;
 pub type Percent = BoundPercent<{ Units::MAX }>;
 
 // TODO revisit it's usage after removing FractionLegacy<Units> for Percent100
-impl FractionUnit for Units {
-    type Times = Self;
-
-    fn gcd<U>(self, other: U) -> Self::Times
-    where
-        U: FractionUnit<Times = Self::Times>,
-    {
-        Gcd::gcd(self, other.to_primitive())
-    }
-
-    fn scale_down(self, scale: Self::Times) -> Self {
-        debug_assert_ne!(scale, Self::Times::ZERO);
-
-        self.div(scale)
-    }
-
-    fn modulo(self, scale: Self::Times) -> Self::Times {
-        debug_assert_ne!(scale, Self::Times::ZERO);
-
-        self.rem(scale)
-    }
-
-    fn to_primitive(self) -> Self::Times {
-        self
-    }
-}
 
 impl Percent100 {
     pub const fn complement(self) -> Self {


### PR DESCRIPTION
As suggested by a comment in  #576 [comment](https://github.com/nolus-protocol/nolus-money-market/pull/576#discussion_r2419116249) the `FractionUnit` implementations have been moved from the main `mod.rs` of each business type into a submodule called `fraction` as suggested. Since the aforementioned trait depends on the `Zero` trait's implementation, the latter has also been added to the `fraction.rs` modules where applicable.

This PR is an extension of #579 