### PR TITLE
[show] feat(remote_lease): add shared protocol crate for cross-chain lease ops

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,22 @@
+# RUNBOOK
+
+Discovery-tax patterns. Grouped by domain. Append on first re-encounter.
+
+## Build
+
+### `cargo build` fails in a fresh worktree: missing `build-configuration/protocol.json`
+
+**Symptom:** A fresh `git worktree add` checkout fails at build time because the build script reads `build-configuration/protocol.json` and the file is absent.
+
+**Cause:** `build-configuration/protocol.json` is git-ignored and is populated locally per checkout. New worktrees inherit the workspace but not that file.
+
+**Fix:** Copy it from a working checkout:
+
+```
+cp <main-checkout>/build-configuration/protocol.json \
+   <new-worktree>/build-configuration/protocol.json
+```
+
+Then re-run `SOFTWARE_RELEASE_ID=dev-release cargo build`.
+
+Tried first (did not work): `cargo build` from the bare worktree; setting `SOFTWARE_RELEASE_ID` alone.

--- a/docs/remote-lease-wire-contract.md
+++ b/docs/remote-lease-wire-contract.md
@@ -1,0 +1,30 @@
+# Remote Lease Wire Contract
+
+The `remote_lease` crate defines the IBC packet types exchanged between the Nolus CosmWasm controller and the Solana Remote Lease App. Both sides deserialise the same Rust types via `serde`; the canonical definition lives in `protocol/packages/remote_lease/`.
+
+## Pinned constants
+
+- Protocol version: `nls-remote-lease.v1` (`remote_lease::VERSION`). Encoded on every packet as the `ProtocolVersion` ZST; mismatches are rejected at deserialisation, not in business code.
+- IBC port: `nls-remote-lease.<dex>` — built via `remote_lease::port_id_for`.
+- Callback error payload: max 512 bytes (`OPERATION_ERR_MAX_BYTES`); enforced in the `RemoteErrorMessage` visitor before allocation.
+
+## Envelope
+
+`PacketEnvelope { lease: LeaseAddrOnWire, operation: LeaseOperationsMsg, version: ProtocolVersion }`. `deny_unknown_fields` everywhere. The lease address is wrapped in `LeaseAddrOnWire`; receivers must call `into_validated(api)` (CosmWasm) before treating it as an `Addr`.
+
+## Operations
+
+- `OpenLease { expected_instance_ordinal: u16, downpayment_currency, lpn_currency, asset_currency }` — currencies must be pairwise distinct.
+- `CloseLease {}`
+- `Swap { coin_in, min_out }` — both amounts non-zero, currencies distinct.
+- `TransferOut { amount }` — amount non-zero.
+
+Invariants are enforced both in constructors (`new`) and on the deserialiser path via `try_from` raw shadows.
+
+## Callback
+
+`RemoteLeaseCallback::{OperationOk(OperationResponse), OperationErr(RemoteErrorMessage), OperationTimeout}`. Timeout is structurally separate from error — recovery paths differ.
+
+## Design principle
+
+All policy lives on Nolus. Solana is a passive vault — see ADRs 0001 / 0002 in `nolus-protocol/ibc-solray`.

--- a/docs/remote-lease-wire-contract.md
+++ b/docs/remote-lease-wire-contract.md
@@ -10,7 +10,7 @@ The `remote_lease` crate defines the IBC packet types exchanged between the Nolu
 
 ## Envelope
 
-`PacketEnvelope { lease: LeaseAddrOnWire, operation: LeaseOperationsMsg, version: ProtocolVersion }`. `deny_unknown_fields` everywhere. The lease address is wrapped in `LeaseAddrOnWire`; receivers must call `into_validated(api)` (CosmWasm) before treating it as an `Addr`.
+`PacketEnvelope { lease: LeaseAddrOnWire, operation: Operation, version: ProtocolVersion }`. `deny_unknown_fields` everywhere. The lease address is wrapped in `LeaseAddrOnWire`; receivers must call `into_validated(api)` (CosmWasm) before treating it as an `Addr`.
 
 ## Operations
 

--- a/platform/packages/currency/Cargo.toml
+++ b/platform/packages/currency/Cargo.toml
@@ -17,10 +17,8 @@ combinations = [
 testing = []
 
 [dependencies]
-sdk = { workspace = true }
-
 thiserror = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "std"] }
 
 [dev-dependencies]
 sdk = { workspace = true, features = ["testing"] }

--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -1390,6 +1390,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "remote_lease"
+version = "0.1.0"
+dependencies = [
+ "currencies",
+ "currency",
+ "finance",
+ "platform",
+ "sdk",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "reserve"
 version = "0.2.2"
 dependencies = [

--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -429,7 +429,6 @@ dependencies = [
 name = "currency"
 version = "0.7.0"
 dependencies = [
- "sdk",
  "serde",
  "thiserror 2.0.18",
 ]

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -46,6 +46,7 @@ reserve = { path = "contracts/reserve", default-features = false }
 currencies = { path = "packages/currencies", default-features = false }
 dex = { path = "packages/dex", default-features = false }
 marketprice = { path = "packages/marketprice", default-features = false }
+remote_lease = { path = "packages/remote_lease", default-features = false }
 swap = { path = "packages/swap", default-features = false }
 
 # Platform Contracts

--- a/protocol/packages/remote_lease/Cargo.toml
+++ b/protocol/packages/remote_lease/Cargo.toml
@@ -14,7 +14,6 @@ combinations = [
 ]
 
 [features]
-default = []
 stub = ["dep:platform", "dep:sdk"]
 
 [dependencies]

--- a/protocol/packages/remote_lease/Cargo.toml
+++ b/protocol/packages/remote_lease/Cargo.toml
@@ -31,6 +31,5 @@ thiserror = { workspace = true }
 currencies = { workspace = true, features = ["testing"] }
 currency = { workspace = true, features = ["testing"] }
 finance = { workspace = true, features = ["testing"] }
-platform = { workspace = true, features = ["testing"] }
 sdk = { workspace = true, features = ["testing"] }
 serde_json = { workspace = true }

--- a/protocol/packages/remote_lease/Cargo.toml
+++ b/protocol/packages/remote_lease/Cargo.toml
@@ -1,0 +1,36 @@
+lints = { workspace = true }
+
+[package]
+name = "remote_lease"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[package.metadata.cargo-each]
+combinations = [
+    { tags = ["ci", "@agnostic"], include-rest = true },
+]
+
+[features]
+default = []
+stub = ["dep:platform", "dep:sdk"]
+
+[dependencies]
+currencies = { workspace = true }
+currency = { workspace = true }
+finance = { workspace = true }
+sdk = { workspace = true, optional = true, features = ["contract"] }
+platform = { workspace = true, optional = true }
+
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+currencies = { workspace = true, features = ["testing"] }
+currency = { workspace = true, features = ["testing"] }
+finance = { workspace = true, features = ["testing"] }
+platform = { workspace = true, features = ["testing"] }
+sdk = { workspace = true, features = ["testing"] }
+serde_json = { workspace = true }

--- a/protocol/packages/remote_lease/src/callback.rs
+++ b/protocol/packages/remote_lease/src/callback.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+use crate::response::OperationResponse;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum RemoteLeaseCallback {
+    OperationOk(OperationResponse),
+    OperationErr(String),
+    OperationTimeout,
+}

--- a/protocol/packages/remote_lease/src/callback.rs
+++ b/protocol/packages/remote_lease/src/callback.rs
@@ -1,11 +1,122 @@
-use serde::{Deserialize, Serialize};
+use std::fmt;
 
-use crate::response::OperationResponse;
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
+use crate::{error::Error, response::OperationResponse};
+
+/// Maximum byte length of a [`RemoteLeaseCallback::OperationErr`] payload.
+///
+/// Why a cap: the string is authored by the Solana counterparty and consumed
+/// by Nolus storage / event emission. Without a bound, a hostile or
+/// misbehaving counterparty can inflate event sizes and storage rows
+/// arbitrarily. 512 bytes is enough to carry a structured short message
+/// ("dex error: <code> <reason>") but small enough to forbid abuse.
+pub const OPERATION_ERR_MAX_BYTES: usize = 512;
+
+/// Outcome of a remote operation as reported back to the Nolus controller.
+///
+/// `OperationOk` carries the typed response when Solana confirmed the
+/// requested action. `OperationErr` carries a short error message authored
+/// by the Solana program itself, e.g. a DEX-layer failure or an invariant
+/// rejection in the vault. `OperationTimeout` is emitted by the IBC layer
+/// when the packet was never acknowledged — it is structurally distinct
+/// from `OperationErr` because the recovery path differs (funds may still
+/// be in flight on the Solana side until the channel times out).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum RemoteLeaseCallback {
     OperationOk(OperationResponse),
-    OperationErr(String),
+    OperationErr(RemoteErrorMessage),
     OperationTimeout,
+}
+
+/// Length-capped error string returned by the Solana counterparty.
+///
+/// Serialises as a bare JSON string. Deserialisation rejects payloads above
+/// [`OPERATION_ERR_MAX_BYTES`] so storage writes downstream are bounded by
+/// construction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RemoteErrorMessage(String);
+
+impl RemoteErrorMessage {
+    pub fn new<S>(message: S) -> Result<Self, Error>
+    where
+        S: Into<String>,
+    {
+        let message: String = message.into();
+        let actual = message.len();
+        if actual <= OPERATION_ERR_MAX_BYTES {
+            Ok(Self(message))
+        } else {
+            Err(Error::CallbackErrorTooLong {
+                actual,
+                max: OPERATION_ERR_MAX_BYTES,
+            })
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Serialize for RemoteErrorMessage {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for RemoteErrorMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Rejects payloads above the cap inside the visitor, before any
+        // owned `String` is materialised on our side. With `serde_json`'s
+        // `deserialize_str` the visitor receives a borrowed slice into the
+        // input buffer when no JSON escapes are present, so the over-cap
+        // case allocates nothing beyond the already-bounded IBC packet.
+        deserializer.deserialize_str(RemoteErrorMessageVisitor)
+    }
+}
+
+struct RemoteErrorMessageVisitor;
+
+impl RemoteErrorMessageVisitor {
+    fn take_within_cap<E, F>(&self, len: usize, take: F) -> Result<RemoteErrorMessage, E>
+    where
+        E: de::Error,
+        F: FnOnce() -> String,
+    {
+        (len <= OPERATION_ERR_MAX_BYTES)
+            .then(take)
+            .map(RemoteErrorMessage)
+            .ok_or_else(|| E::invalid_length(len, self))
+    }
+}
+
+impl<'de> de::Visitor<'de> for RemoteErrorMessageVisitor {
+    type Value = RemoteErrorMessage;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "a string of at most {OPERATION_ERR_MAX_BYTES} bytes")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.take_within_cap(value.len(), || value.to_owned())
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let len = value.len();
+        self.take_within_cap(len, || value)
+    }
 }

--- a/protocol/packages/remote_lease/src/envelope.rs
+++ b/protocol/packages/remote_lease/src/envelope.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{msg::LeaseOperationsMsg, version::ProtocolVersion};
+use crate::{msg::Operation, version::ProtocolVersion};
 
 /// IBC packet payload exchanged between the Nolus controller and the Solana
 /// passive vault.
@@ -15,7 +15,7 @@ use crate::{msg::LeaseOperationsMsg, version::ProtocolVersion};
 #[serde(deny_unknown_fields)]
 pub struct PacketEnvelope {
     pub lease: LeaseAddrOnWire,
-    pub operation: LeaseOperationsMsg,
+    pub operation: Operation,
     pub version: ProtocolVersion,
 }
 

--- a/protocol/packages/remote_lease/src/envelope.rs
+++ b/protocol/packages/remote_lease/src/envelope.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+use crate::msg::LeaseOperationsMsg;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PacketEnvelope {
+    // Wire-format only. The consumer (CosmWasm controller) MUST call
+    // `deps.api.addr_validate(&self.lease)` before dispatching, and MUST
+    // additionally verify the address belongs to a registered Lease
+    // instance (`info.sender.code_id == Config.lease_code` at the
+    // ExecuteMsg entry point that produced this packet). Format validation
+    // alone is not authorisation.
+    pub lease: String,
+    pub operation: LeaseOperationsMsg,
+}

--- a/protocol/packages/remote_lease/src/envelope.rs
+++ b/protocol/packages/remote_lease/src/envelope.rs
@@ -1,16 +1,55 @@
 use serde::{Deserialize, Serialize};
 
-use crate::msg::LeaseOperationsMsg;
+use crate::{msg::LeaseOperationsMsg, version::ProtocolVersion};
 
+/// IBC packet payload exchanged between the Nolus controller and the Solana
+/// passive vault.
+///
+/// `version` pins the protocol identifier on the wire so that a mismatched
+/// counterparty is rejected at deserialisation, never by business code.
+/// `lease` carries the Nolus-side lease address as an on-wire string; the
+/// receiver MUST convert it through [`LeaseAddrOnWire::into_validated`] before
+/// using it for dispatch — the type prevents accidental use of the raw string
+/// as a `cosmwasm_std::Addr`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct PacketEnvelope {
-    // Wire-format only. The consumer (CosmWasm controller) MUST call
-    // `deps.api.addr_validate(&self.lease)` before dispatching, and MUST
-    // additionally verify the address belongs to a registered Lease
-    // instance (`info.sender.code_id == Config.lease_code` at the
-    // ExecuteMsg entry point that produced this packet). Format validation
-    // alone is not authorisation.
-    pub lease: String,
+    pub lease: LeaseAddrOnWire,
     pub operation: LeaseOperationsMsg,
+    pub version: ProtocolVersion,
+}
+
+/// On-wire encoding of a Nolus lease address.
+///
+/// Serialises as a bare JSON string (`#[serde(transparent)]`). The inner
+/// string is intentionally inaccessible: the only ways to obtain a usable
+/// address from a received envelope are
+/// [`LeaseAddrOnWire::into_validated`] (CosmWasm consumers, gated by the
+/// `stub` feature) and [`LeaseAddrOnWire::as_str`] (display / logging only).
+/// Format validation alone is not authorisation — the controller still has to
+/// verify the resulting `Addr` belongs to a registered Lease instance before
+/// dispatching state-mutating logic.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct LeaseAddrOnWire(String);
+
+impl LeaseAddrOnWire {
+    pub fn new<S>(addr: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self(addr.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    #[cfg(feature = "stub")]
+    pub fn into_validated(
+        self,
+        api: &dyn sdk::cosmwasm_std::Api,
+    ) -> sdk::cosmwasm_std::StdResult<sdk::cosmwasm_std::Addr> {
+        api.addr_validate(&self.0)
+    }
 }

--- a/protocol/packages/remote_lease/src/error.rs
+++ b/protocol/packages/remote_lease/src/error.rs
@@ -1,0 +1,12 @@
+use thiserror::Error;
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum Error {
+    #[error(
+        "the three remote-lease currencies (downpayment, lpn, asset) must be pairwise distinct"
+    )]
+    DuplicateLeaseCurrencies,
+
+    #[error("swap input and output currencies must differ")]
+    SameSwapCurrency,
+}

--- a/protocol/packages/remote_lease/src/error.rs
+++ b/protocol/packages/remote_lease/src/error.rs
@@ -9,4 +9,19 @@ pub enum Error {
 
     #[error("swap input and output currencies must differ")]
     SameSwapCurrency,
+
+    #[error("swap input amount and minimum output must be greater than zero")]
+    ZeroSwapAmount,
+
+    #[error("transfer-out amount must be greater than zero")]
+    ZeroTransferAmount,
+
+    #[error("callback error message exceeds the {max}-byte cap (was {actual})")]
+    CallbackErrorTooLong { actual: usize, max: usize },
+
+    #[error("protocol version mismatch: expected {expected}, got {actual}")]
+    ProtocolVersionMismatch {
+        expected: &'static str,
+        actual: String,
+    },
 }

--- a/protocol/packages/remote_lease/src/lib.rs
+++ b/protocol/packages/remote_lease/src/lib.rs
@@ -1,0 +1,18 @@
+pub mod callback;
+pub mod envelope;
+pub mod error;
+pub mod msg;
+pub mod response;
+
+#[cfg(feature = "stub")]
+pub mod stub;
+
+#[cfg(test)]
+mod tests;
+
+pub const VERSION: &str = "nls-remote-lease.v1";
+pub const PORT_PREFIX: &str = "nls-remote-lease.";
+
+pub fn port_id_for(dex: &str) -> String {
+    format!("{PORT_PREFIX}{dex}")
+}

--- a/protocol/packages/remote_lease/src/lib.rs
+++ b/protocol/packages/remote_lease/src/lib.rs
@@ -3,6 +3,7 @@ pub mod envelope;
 pub mod error;
 pub mod msg;
 pub mod response;
+pub mod version;
 
 #[cfg(feature = "stub")]
 pub mod stub;

--- a/protocol/packages/remote_lease/src/msg.rs
+++ b/protocol/packages/remote_lease/src/msg.rs
@@ -1,0 +1,156 @@
+use serde::{Deserialize, Serialize};
+
+use currencies::PaymentGroup;
+use currency::CurrencyDTO;
+use finance::coin::CoinDTO;
+
+use crate::error::Error;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum LeaseOperationsMsg {
+    OpenLease(OpenLeaseParams),
+    CloseLease(CloseLeaseParams),
+    Swap(SwapParams),
+    TransferOut(TransferOutParams),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(
+    deny_unknown_fields,
+    rename_all = "snake_case",
+    try_from = "OpenLeaseParamsRaw"
+)]
+pub struct OpenLeaseParams {
+    expected_instance_ordinal: u8,
+    downpayment_currency: CurrencyDTO<PaymentGroup>,
+    lpn_currency: CurrencyDTO<PaymentGroup>,
+    asset_currency: CurrencyDTO<PaymentGroup>,
+}
+
+impl OpenLeaseParams {
+    pub fn new(
+        expected_instance_ordinal: u8,
+        downpayment_currency: CurrencyDTO<PaymentGroup>,
+        lpn_currency: CurrencyDTO<PaymentGroup>,
+        asset_currency: CurrencyDTO<PaymentGroup>,
+    ) -> Result<Self, Error> {
+        let params = Self {
+            expected_instance_ordinal,
+            downpayment_currency,
+            lpn_currency,
+            asset_currency,
+        };
+        params
+            .invariant_held()
+            .then_some(params)
+            .ok_or(Error::DuplicateLeaseCurrencies)
+            .inspect(|p| debug_assert!(p.invariant_held()))
+    }
+
+    pub const fn expected_instance_ordinal(&self) -> u8 {
+        self.expected_instance_ordinal
+    }
+
+    pub const fn downpayment_currency(&self) -> &CurrencyDTO<PaymentGroup> {
+        &self.downpayment_currency
+    }
+
+    pub const fn lpn_currency(&self) -> &CurrencyDTO<PaymentGroup> {
+        &self.lpn_currency
+    }
+
+    pub const fn asset_currency(&self) -> &CurrencyDTO<PaymentGroup> {
+        &self.asset_currency
+    }
+
+    pub fn invariant_held(&self) -> bool {
+        self.downpayment_currency != self.lpn_currency
+            && self.downpayment_currency != self.asset_currency
+            && self.lpn_currency != self.asset_currency
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+struct OpenLeaseParamsRaw {
+    expected_instance_ordinal: u8,
+    downpayment_currency: CurrencyDTO<PaymentGroup>,
+    lpn_currency: CurrencyDTO<PaymentGroup>,
+    asset_currency: CurrencyDTO<PaymentGroup>,
+}
+
+impl TryFrom<OpenLeaseParamsRaw> for OpenLeaseParams {
+    type Error = Error;
+
+    fn try_from(raw: OpenLeaseParamsRaw) -> Result<Self, Self::Error> {
+        OpenLeaseParams::new(
+            raw.expected_instance_ordinal,
+            raw.downpayment_currency,
+            raw.lpn_currency,
+            raw.asset_currency,
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct CloseLeaseParams {}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(
+    deny_unknown_fields,
+    rename_all = "snake_case",
+    try_from = "SwapParamsRaw"
+)]
+pub struct SwapParams {
+    coin_in: CoinDTO<PaymentGroup>,
+    min_out: CoinDTO<PaymentGroup>,
+}
+
+impl SwapParams {
+    pub fn new(
+        coin_in: CoinDTO<PaymentGroup>,
+        min_out: CoinDTO<PaymentGroup>,
+    ) -> Result<Self, Error> {
+        let params = Self { coin_in, min_out };
+        params
+            .invariant_held()
+            .then_some(params)
+            .ok_or(Error::SameSwapCurrency)
+            .inspect(|p| debug_assert!(p.invariant_held()))
+    }
+
+    pub const fn coin_in(&self) -> &CoinDTO<PaymentGroup> {
+        &self.coin_in
+    }
+
+    pub const fn min_out(&self) -> &CoinDTO<PaymentGroup> {
+        &self.min_out
+    }
+
+    pub fn invariant_held(&self) -> bool {
+        self.coin_in.currency() != self.min_out.currency()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+struct SwapParamsRaw {
+    coin_in: CoinDTO<PaymentGroup>,
+    min_out: CoinDTO<PaymentGroup>,
+}
+
+impl TryFrom<SwapParamsRaw> for SwapParams {
+    type Error = Error;
+
+    fn try_from(raw: SwapParamsRaw) -> Result<Self, Self::Error> {
+        SwapParams::new(raw.coin_in, raw.min_out)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct TransferOutParams {
+    pub amount: CoinDTO<PaymentGroup>,
+}

--- a/protocol/packages/remote_lease/src/msg.rs
+++ b/protocol/packages/remote_lease/src/msg.rs
@@ -8,7 +8,7 @@ use crate::error::Error;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub enum LeaseOperationsMsg {
+pub enum Operation {
     OpenLease(OpenLeaseParams),
     CloseLease(CloseLeaseParams),
     Swap(SwapParams),

--- a/protocol/packages/remote_lease/src/msg.rs
+++ b/protocol/packages/remote_lease/src/msg.rs
@@ -22,7 +22,7 @@ pub enum LeaseOperationsMsg {
     try_from = "OpenLeaseParamsRaw"
 )]
 pub struct OpenLeaseParams {
-    expected_instance_ordinal: u8,
+    expected_instance_ordinal: u16,
     downpayment_currency: CurrencyDTO<PaymentGroup>,
     lpn_currency: CurrencyDTO<PaymentGroup>,
     asset_currency: CurrencyDTO<PaymentGroup>,
@@ -30,7 +30,7 @@ pub struct OpenLeaseParams {
 
 impl OpenLeaseParams {
     pub fn new(
-        expected_instance_ordinal: u8,
+        expected_instance_ordinal: u16,
         downpayment_currency: CurrencyDTO<PaymentGroup>,
         lpn_currency: CurrencyDTO<PaymentGroup>,
         asset_currency: CurrencyDTO<PaymentGroup>,
@@ -48,7 +48,7 @@ impl OpenLeaseParams {
             .inspect(|p| debug_assert!(p.invariant_held()))
     }
 
-    pub const fn expected_instance_ordinal(&self) -> u8 {
+    pub const fn expected_instance_ordinal(&self) -> u16 {
         self.expected_instance_ordinal
     }
 
@@ -74,7 +74,7 @@ impl OpenLeaseParams {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 struct OpenLeaseParamsRaw {
-    expected_instance_ordinal: u8,
+    expected_instance_ordinal: u16,
     downpayment_currency: CurrencyDTO<PaymentGroup>,
     lpn_currency: CurrencyDTO<PaymentGroup>,
     asset_currency: CurrencyDTO<PaymentGroup>,
@@ -113,6 +113,9 @@ impl SwapParams {
         coin_in: CoinDTO<PaymentGroup>,
         min_out: CoinDTO<PaymentGroup>,
     ) -> Result<Self, Error> {
+        if coin_in.is_zero() || min_out.is_zero() {
+            return Err(Error::ZeroSwapAmount);
+        }
         let params = Self { coin_in, min_out };
         params
             .invariant_held()
@@ -130,7 +133,9 @@ impl SwapParams {
     }
 
     pub fn invariant_held(&self) -> bool {
-        self.coin_in.currency() != self.min_out.currency()
+        !self.coin_in.is_zero()
+            && !self.min_out.is_zero()
+            && self.coin_in.currency() != self.min_out.currency()
     }
 }
 
@@ -150,7 +155,44 @@ impl TryFrom<SwapParamsRaw> for SwapParams {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(
+    deny_unknown_fields,
+    rename_all = "snake_case",
+    try_from = "TransferOutParamsRaw"
+)]
 pub struct TransferOutParams {
-    pub amount: CoinDTO<PaymentGroup>,
+    amount: CoinDTO<PaymentGroup>,
+}
+
+impl TransferOutParams {
+    pub fn new(amount: CoinDTO<PaymentGroup>) -> Result<Self, Error> {
+        let params = Self { amount };
+        params
+            .invariant_held()
+            .then_some(params)
+            .ok_or(Error::ZeroTransferAmount)
+            .inspect(|p| debug_assert!(p.invariant_held()))
+    }
+
+    pub const fn amount(&self) -> &CoinDTO<PaymentGroup> {
+        &self.amount
+    }
+
+    pub fn invariant_held(&self) -> bool {
+        !self.amount.is_zero()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+struct TransferOutParamsRaw {
+    amount: CoinDTO<PaymentGroup>,
+}
+
+impl TryFrom<TransferOutParamsRaw> for TransferOutParams {
+    type Error = Error;
+
+    fn try_from(raw: TransferOutParamsRaw) -> Result<Self, Self::Error> {
+        TransferOutParams::new(raw.amount)
+    }
 }

--- a/protocol/packages/remote_lease/src/response.rs
+++ b/protocol/packages/remote_lease/src/response.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+
+use currencies::PaymentGroup;
+use finance::coin::CoinDTO;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum OperationResponse {
+    OpenLease(OpenLeaseResponse),
+    CloseLease(CloseLeaseResponse),
+    Swap(SwapResponse),
+    TransferOut(TransferOutResponse),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct OpenLeaseResponse {
+    pub remote_lease_id: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct CloseLeaseResponse {}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct SwapResponse {
+    pub amount_out: CoinDTO<PaymentGroup>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct TransferOutResponse {}

--- a/protocol/packages/remote_lease/src/stub.rs
+++ b/protocol/packages/remote_lease/src/stub.rs
@@ -3,22 +3,20 @@ use serde::Serialize;
 use platform::{batch::Batch, result::Result as PlatformResult};
 use sdk::cosmwasm_std::Addr;
 
-use crate::msg::{
-    CloseLeaseParams, LeaseOperationsMsg, OpenLeaseParams, SwapParams, TransferOutParams,
-};
+use crate::msg::{CloseLeaseParams, OpenLeaseParams, Operation, SwapParams, TransferOutParams};
 
 /// Marker trait the consuming controller must implement on its own
-/// `ExecuteMsg` (or whichever outer enum carries [`LeaseOperationsMsg`]).
+/// `ExecuteMsg` (or whichever outer enum carries [`Operation`]).
 ///
 /// Why a marker: the stub builders accept an `op_to_msg` closure that wraps
-/// a [`LeaseOperationsMsg`] into the controller's outer message before it
+/// a [`Operation`] into the controller's outer message before it
 /// goes onto the wire. Without this bound, any `Serialize` value would work
-/// — including `LeaseOperationsMsg` itself, which would let the controller
+/// — including `Operation` itself, which would let the controller
 /// (or a contributor) accidentally emit a flat-embedded operation that
 /// bypasses the controller's own authorisation layer. By requiring the
 /// closure's output to implement `ControllerInnerMessage` the crate forces
 /// a deliberate one-line opt-in on the consumer side; the orphan rule
-/// prevents the consumer from implementing it on `LeaseOperationsMsg`.
+/// prevents the consumer from implementing it on `Operation`.
 pub trait ControllerInnerMessage: Serialize {}
 
 pub struct Factory<'controller> {
@@ -32,24 +30,18 @@ impl<'controller> Factory<'controller> {
 
     pub fn open<F, M>(&self, params: OpenLeaseParams, op_to_msg: F) -> PlatformResult<Batch>
     where
-        F: FnOnce(LeaseOperationsMsg) -> M,
+        F: FnOnce(Operation) -> M,
         M: ControllerInnerMessage,
     {
-        schedule(
-            self.controller,
-            &op_to_msg(LeaseOperationsMsg::OpenLease(params)),
-        )
+        schedule(self.controller, &op_to_msg(Operation::OpenLease(params)))
     }
 
     pub fn close<F, M>(&self, params: CloseLeaseParams, op_to_msg: F) -> PlatformResult<Batch>
     where
-        F: FnOnce(LeaseOperationsMsg) -> M,
+        F: FnOnce(Operation) -> M,
         M: ControllerInnerMessage,
     {
-        schedule(
-            self.controller,
-            &op_to_msg(LeaseOperationsMsg::CloseLease(params)),
-        )
+        schedule(self.controller, &op_to_msg(Operation::CloseLease(params)))
     }
 }
 
@@ -64,13 +56,10 @@ impl<'controller> Lease<'controller> {
 
     pub fn swap<F, M>(&self, params: SwapParams, op_to_msg: F) -> PlatformResult<Batch>
     where
-        F: FnOnce(LeaseOperationsMsg) -> M,
+        F: FnOnce(Operation) -> M,
         M: ControllerInnerMessage,
     {
-        schedule(
-            self.controller,
-            &op_to_msg(LeaseOperationsMsg::Swap(params)),
-        )
+        schedule(self.controller, &op_to_msg(Operation::Swap(params)))
     }
 
     pub fn transfer_out<F, M>(
@@ -79,13 +68,10 @@ impl<'controller> Lease<'controller> {
         op_to_msg: F,
     ) -> PlatformResult<Batch>
     where
-        F: FnOnce(LeaseOperationsMsg) -> M,
+        F: FnOnce(Operation) -> M,
         M: ControllerInnerMessage,
     {
-        schedule(
-            self.controller,
-            &op_to_msg(LeaseOperationsMsg::TransferOut(params)),
-        )
+        schedule(self.controller, &op_to_msg(Operation::TransferOut(params)))
     }
 }
 
@@ -110,16 +96,14 @@ mod tests {
     use finance::coin::Coin;
     use sdk::cosmwasm_std::Addr;
 
-    use crate::msg::{
-        CloseLeaseParams, LeaseOperationsMsg, OpenLeaseParams, SwapParams, TransferOutParams,
-    };
+    use crate::msg::{CloseLeaseParams, OpenLeaseParams, Operation, SwapParams, TransferOutParams};
 
     use super::{ControllerInnerMessage, Factory, Lease};
 
     #[derive(Serialize)]
     #[serde(rename_all = "snake_case")]
     enum OuterExecuteMsg {
-        LeaseOperations(LeaseOperationsMsg),
+        LeaseOperations(Operation),
     }
 
     impl ControllerInnerMessage for OuterExecuteMsg {}

--- a/protocol/packages/remote_lease/src/stub.rs
+++ b/protocol/packages/remote_lease/src/stub.rs
@@ -1,0 +1,173 @@
+use serde::Serialize;
+
+use platform::{batch::Batch, result::Result as PlatformResult};
+use sdk::cosmwasm_std::Addr;
+
+use crate::msg::{
+    CloseLeaseParams, LeaseOperationsMsg, OpenLeaseParams, SwapParams, TransferOutParams,
+};
+
+pub struct Factory<'controller> {
+    controller: &'controller Addr,
+}
+
+impl<'controller> Factory<'controller> {
+    pub const fn new(controller: &'controller Addr) -> Self {
+        Self { controller }
+    }
+
+    pub fn open<F, M>(&self, params: OpenLeaseParams, op_to_msg: F) -> PlatformResult<Batch>
+    where
+        F: FnOnce(LeaseOperationsMsg) -> M,
+        M: Serialize,
+    {
+        schedule(
+            self.controller,
+            &op_to_msg(LeaseOperationsMsg::OpenLease(params)),
+        )
+    }
+
+    pub fn close<F, M>(&self, params: CloseLeaseParams, op_to_msg: F) -> PlatformResult<Batch>
+    where
+        F: FnOnce(LeaseOperationsMsg) -> M,
+        M: Serialize,
+    {
+        schedule(
+            self.controller,
+            &op_to_msg(LeaseOperationsMsg::CloseLease(params)),
+        )
+    }
+}
+
+pub struct Lease<'controller> {
+    controller: &'controller Addr,
+}
+
+impl<'controller> Lease<'controller> {
+    pub const fn new(controller: &'controller Addr) -> Self {
+        Self { controller }
+    }
+
+    pub fn swap<F, M>(&self, params: SwapParams, op_to_msg: F) -> PlatformResult<Batch>
+    where
+        F: FnOnce(LeaseOperationsMsg) -> M,
+        M: Serialize,
+    {
+        schedule(
+            self.controller,
+            &op_to_msg(LeaseOperationsMsg::Swap(params)),
+        )
+    }
+
+    pub fn transfer_out<F, M>(
+        &self,
+        params: TransferOutParams,
+        op_to_msg: F,
+    ) -> PlatformResult<Batch>
+    where
+        F: FnOnce(LeaseOperationsMsg) -> M,
+        M: Serialize,
+    {
+        schedule(
+            self.controller,
+            &op_to_msg(LeaseOperationsMsg::TransferOut(params)),
+        )
+    }
+}
+
+fn schedule<M>(controller: &Addr, msg: &M) -> PlatformResult<Batch>
+where
+    M: Serialize + ?Sized,
+{
+    let mut batch = Batch::default();
+    batch
+        .schedule_execute_wasm_no_reply_no_funds(controller.clone(), msg)
+        .map(|()| batch)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+
+    use currencies::{
+        PaymentGroup,
+        testing::{PaymentC1, PaymentC2, PaymentC3},
+    };
+    use finance::coin::Coin;
+    use sdk::cosmwasm_std::Addr;
+
+    use crate::msg::{
+        CloseLeaseParams, LeaseOperationsMsg, OpenLeaseParams, SwapParams, TransferOutParams,
+    };
+
+    use super::{Factory, Lease};
+
+    #[derive(Serialize)]
+    #[serde(rename_all = "snake_case")]
+    enum OuterExecuteMsg {
+        LeaseOperations(LeaseOperationsMsg),
+    }
+
+    #[test]
+    fn factory_open_schedules_one_message() {
+        let controller = Addr::unchecked("controller");
+        let factory = Factory::new(&controller);
+        let batch = factory
+            .open(sample_open_lease_params(), OuterExecuteMsg::LeaseOperations)
+            .expect("scheduling must succeed");
+        assert_eq!(1, batch.len());
+    }
+
+    #[test]
+    fn factory_close_schedules_one_message() {
+        let controller = Addr::unchecked("controller");
+        let factory = Factory::new(&controller);
+        let batch = factory
+            .close(CloseLeaseParams {}, OuterExecuteMsg::LeaseOperations)
+            .expect("scheduling must succeed");
+        assert_eq!(1, batch.len());
+    }
+
+    #[test]
+    fn lease_swap_schedules_one_message() {
+        let controller = Addr::unchecked("controller");
+        let lease = Lease::new(&controller);
+        let batch = lease
+            .swap(sample_swap_params(), OuterExecuteMsg::LeaseOperations)
+            .expect("scheduling must succeed");
+        assert_eq!(1, batch.len());
+    }
+
+    #[test]
+    fn lease_transfer_out_schedules_one_message() {
+        let controller = Addr::unchecked("controller");
+        let lease = Lease::new(&controller);
+        let batch = lease
+            .transfer_out(
+                TransferOutParams {
+                    amount: Coin::<PaymentC3>::new(1000).into(),
+                },
+                OuterExecuteMsg::LeaseOperations,
+            )
+            .expect("scheduling must succeed");
+        assert_eq!(1, batch.len());
+    }
+
+    fn sample_open_lease_params() -> OpenLeaseParams {
+        OpenLeaseParams::new(
+            7,
+            currency::dto::<PaymentC1, PaymentGroup>(),
+            currency::dto::<PaymentC2, PaymentGroup>(),
+            currency::dto::<PaymentC3, PaymentGroup>(),
+        )
+        .expect("sample uses three distinct currencies")
+    }
+
+    fn sample_swap_params() -> SwapParams {
+        SwapParams::new(
+            Coin::<PaymentC1>::new(1000).into(),
+            Coin::<PaymentC2>::new(42).into(),
+        )
+        .expect("sample uses two distinct currencies")
+    }
+}

--- a/protocol/packages/remote_lease/src/stub.rs
+++ b/protocol/packages/remote_lease/src/stub.rs
@@ -7,6 +7,20 @@ use crate::msg::{
     CloseLeaseParams, LeaseOperationsMsg, OpenLeaseParams, SwapParams, TransferOutParams,
 };
 
+/// Marker trait the consuming controller must implement on its own
+/// `ExecuteMsg` (or whichever outer enum carries [`LeaseOperationsMsg`]).
+///
+/// Why a marker: the stub builders accept an `op_to_msg` closure that wraps
+/// a [`LeaseOperationsMsg`] into the controller's outer message before it
+/// goes onto the wire. Without this bound, any `Serialize` value would work
+/// — including `LeaseOperationsMsg` itself, which would let the controller
+/// (or a contributor) accidentally emit a flat-embedded operation that
+/// bypasses the controller's own authorisation layer. By requiring the
+/// closure's output to implement `ControllerInnerMessage` the crate forces
+/// a deliberate one-line opt-in on the consumer side; the orphan rule
+/// prevents the consumer from implementing it on `LeaseOperationsMsg`.
+pub trait ControllerInnerMessage: Serialize {}
+
 pub struct Factory<'controller> {
     controller: &'controller Addr,
 }
@@ -19,7 +33,7 @@ impl<'controller> Factory<'controller> {
     pub fn open<F, M>(&self, params: OpenLeaseParams, op_to_msg: F) -> PlatformResult<Batch>
     where
         F: FnOnce(LeaseOperationsMsg) -> M,
-        M: Serialize,
+        M: ControllerInnerMessage,
     {
         schedule(
             self.controller,
@@ -30,7 +44,7 @@ impl<'controller> Factory<'controller> {
     pub fn close<F, M>(&self, params: CloseLeaseParams, op_to_msg: F) -> PlatformResult<Batch>
     where
         F: FnOnce(LeaseOperationsMsg) -> M,
-        M: Serialize,
+        M: ControllerInnerMessage,
     {
         schedule(
             self.controller,
@@ -51,7 +65,7 @@ impl<'controller> Lease<'controller> {
     pub fn swap<F, M>(&self, params: SwapParams, op_to_msg: F) -> PlatformResult<Batch>
     where
         F: FnOnce(LeaseOperationsMsg) -> M,
-        M: Serialize,
+        M: ControllerInnerMessage,
     {
         schedule(
             self.controller,
@@ -66,7 +80,7 @@ impl<'controller> Lease<'controller> {
     ) -> PlatformResult<Batch>
     where
         F: FnOnce(LeaseOperationsMsg) -> M,
-        M: Serialize,
+        M: ControllerInnerMessage,
     {
         schedule(
             self.controller,
@@ -100,13 +114,15 @@ mod tests {
         CloseLeaseParams, LeaseOperationsMsg, OpenLeaseParams, SwapParams, TransferOutParams,
     };
 
-    use super::{Factory, Lease};
+    use super::{ControllerInnerMessage, Factory, Lease};
 
     #[derive(Serialize)]
     #[serde(rename_all = "snake_case")]
     enum OuterExecuteMsg {
         LeaseOperations(LeaseOperationsMsg),
     }
+
+    impl ControllerInnerMessage for OuterExecuteMsg {}
 
     #[test]
     fn factory_open_schedules_one_message() {
@@ -144,9 +160,7 @@ mod tests {
         let lease = Lease::new(&controller);
         let batch = lease
             .transfer_out(
-                TransferOutParams {
-                    amount: Coin::<PaymentC3>::new(1000).into(),
-                },
+                sample_transfer_out_params(),
                 OuterExecuteMsg::LeaseOperations,
             )
             .expect("scheduling must succeed");
@@ -168,6 +182,11 @@ mod tests {
             Coin::<PaymentC1>::new(1000).into(),
             Coin::<PaymentC2>::new(42).into(),
         )
-        .expect("sample uses two distinct currencies")
+        .expect("sample uses two distinct non-zero amounts")
+    }
+
+    fn sample_transfer_out_params() -> TransferOutParams {
+        TransferOutParams::new(Coin::<PaymentC3>::new(1000).into())
+            .expect("sample uses a non-zero amount")
     }
 }

--- a/protocol/packages/remote_lease/src/tests.rs
+++ b/protocol/packages/remote_lease/src/tests.rs
@@ -2,8 +2,9 @@
 //!
 //! Acceptance criterion (ibc-solray#134): round-trip serde tests for every
 //! variant against `cosmwasm_std::to_json_binary` output. The Solana-side
-//! consumer is a foreign codebase, so the literal-JSON pins below are part of
-//! the wire contract — changing them is a breaking protocol change.
+//! consumer is a foreign codebase, so every literal-JSON pin below is part of
+//! the wire contract — **any edit to a literal pin is a breaking protocol
+//! change and MUST bump [`crate::VERSION`]**.
 
 use std::fmt::Debug;
 
@@ -18,14 +19,15 @@ use finance::coin::Coin;
 
 use crate::{
     PORT_PREFIX, VERSION,
-    callback::RemoteLeaseCallback,
-    envelope::PacketEnvelope,
+    callback::{OPERATION_ERR_MAX_BYTES, RemoteErrorMessage, RemoteLeaseCallback},
+    envelope::{LeaseAddrOnWire, PacketEnvelope},
     error::Error,
     msg::{CloseLeaseParams, LeaseOperationsMsg, OpenLeaseParams, SwapParams, TransferOutParams},
     port_id_for,
     response::{
         CloseLeaseResponse, OpenLeaseResponse, OperationResponse, SwapResponse, TransferOutResponse,
     },
+    version::ProtocolVersion,
 };
 
 // ---------------------------------------------------------------------------
@@ -58,9 +60,7 @@ fn swap_msg_serde() {
 
 #[test]
 fn transfer_out_msg_serde() {
-    let value = LeaseOperationsMsg::TransferOut(TransferOutParams {
-        amount: Coin::<PaymentC3>::new(1000).into(),
-    });
+    let value = LeaseOperationsMsg::TransferOut(sample_transfer_out_params());
     assert_round_trip_eq(
         r#"{"transfer_out":{"amount":{"amount":"1000","ticker":"LC1"}}}"#,
         &value,
@@ -118,7 +118,9 @@ fn callback_operation_ok_serde() {
 
 #[test]
 fn callback_operation_err_serde() {
-    let value = RemoteLeaseCallback::OperationErr("dex pool drained".to_owned());
+    let value = RemoteLeaseCallback::OperationErr(
+        RemoteErrorMessage::new("dex pool drained").expect("short message must be accepted"),
+    );
     assert_round_trip_eq(r#"{"operation_err":"dex pool drained"}"#, &value);
 }
 
@@ -128,6 +130,32 @@ fn callback_operation_timeout_serde() {
     assert_round_trip_eq(r#""operation_timeout""#, &value);
 }
 
+#[test]
+fn callback_error_message_at_cap_accepted() {
+    let payload = "x".repeat(OPERATION_ERR_MAX_BYTES);
+    RemoteErrorMessage::new(payload).expect("payload at the cap must be accepted");
+}
+
+#[test]
+fn callback_error_message_over_cap_rejected() {
+    let payload = "x".repeat(OPERATION_ERR_MAX_BYTES + 1);
+    assert!(matches!(
+        RemoteErrorMessage::new(payload),
+        Err(Error::CallbackErrorTooLong {
+            actual,
+            max: OPERATION_ERR_MAX_BYTES,
+        }) if actual == OPERATION_ERR_MAX_BYTES + 1,
+    ));
+}
+
+#[test]
+fn callback_error_message_deserialize_over_cap_rejected() {
+    let payload = "x".repeat(OPERATION_ERR_MAX_BYTES + 1);
+    let bad_wire = format!(r#""{payload}""#);
+    serde_json::from_str::<RemoteErrorMessage>(&bad_wire)
+        .expect_err("over-cap payload must fail deserialization");
+}
+
 // ---------------------------------------------------------------------------
 // 4. PacketEnvelope — round-trip + literal JSON
 // ---------------------------------------------------------------------------
@@ -135,13 +163,34 @@ fn callback_operation_timeout_serde() {
 #[test]
 fn packet_envelope_serde() {
     let value = PacketEnvelope {
-        lease: "nolus1leaseaddr".to_owned(),
+        lease: LeaseAddrOnWire::new("nolus1leaseaddr"),
         operation: LeaseOperationsMsg::CloseLease(CloseLeaseParams {}),
+        version: ProtocolVersion,
     };
     assert_round_trip_eq(
-        r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}}}"#,
+        r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}},"version":"nls-remote-lease.v1"}"#,
         &value,
     );
+}
+
+#[test]
+fn packet_envelope_version_mismatch_rejected() {
+    let bad_wire = r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}},"version":"nls-remote-lease.v2"}"#;
+    serde_json::from_str::<PacketEnvelope>(bad_wire)
+        .expect_err("mismatched protocol version must fail deserialization");
+}
+
+#[test]
+fn packet_envelope_missing_version_rejected() {
+    let bad_wire = r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}}}"#;
+    serde_json::from_str::<PacketEnvelope>(bad_wire)
+        .expect_err("missing version field must fail deserialization");
+}
+
+#[test]
+fn lease_addr_on_wire_round_trip_is_bare_string() {
+    let value = LeaseAddrOnWire::new("nolus1leaseaddr");
+    assert_round_trip_eq(r#""nolus1leaseaddr""#, &value);
 }
 
 // ---------------------------------------------------------------------------
@@ -200,8 +249,27 @@ fn open_lease_params_deserialize_invariant_violation_rejected() {
         .expect_err("invariant violation must fail deserialization");
 }
 
+#[test]
+fn open_lease_params_max_ordinal_accepted() {
+    let params = OpenLeaseParams::new(
+        u16::MAX,
+        currency::dto::<PaymentC1, PaymentGroup>(),
+        currency::dto::<PaymentC2, PaymentGroup>(),
+        currency::dto::<PaymentC3, PaymentGroup>(),
+    )
+    .expect("u16::MAX is a valid ordinal at the protocol layer");
+    assert_eq!(u16::MAX, params.expected_instance_ordinal());
+}
+
+#[test]
+fn open_lease_params_deserialize_above_u16_rejected() {
+    let bad_wire = r#"{"expected_instance_ordinal":65536,"downpayment_currency":"NLS","lpn_currency":"LPN","asset_currency":"LC1"}"#;
+    serde_json::from_str::<OpenLeaseParams>(bad_wire)
+        .expect_err("ordinal above u16 range must fail deserialization");
+}
+
 // ---------------------------------------------------------------------------
-// 6. SwapParams invariant: coin_in and min_out currencies differ
+// 6. SwapParams invariant: coin_in and min_out currencies differ, both > 0
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -210,7 +278,7 @@ fn swap_params_distinct_currencies_ok() {
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC2>::new(42).into(),
     )
-    .expect("distinct currencies must be accepted");
+    .expect("distinct non-zero amounts must be accepted");
     assert!(params.invariant_held());
 }
 
@@ -224,6 +292,24 @@ fn swap_params_same_currency_rejected() {
 }
 
 #[test]
+fn swap_params_zero_coin_in_rejected() {
+    let res = SwapParams::new(
+        Coin::<PaymentC1>::new(0).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    );
+    assert!(matches!(res, Err(Error::ZeroSwapAmount)));
+}
+
+#[test]
+fn swap_params_zero_min_out_rejected() {
+    let res = SwapParams::new(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC2>::new(0).into(),
+    );
+    assert!(matches!(res, Err(Error::ZeroSwapAmount)));
+}
+
+#[test]
 fn swap_params_deserialize_invariant_violation_rejected() {
     let bad_wire =
         r#"{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"NLS"}}"#;
@@ -231,8 +317,40 @@ fn swap_params_deserialize_invariant_violation_rejected() {
         .expect_err("invariant violation must fail deserialization");
 }
 
+#[test]
+fn swap_params_deserialize_zero_amount_rejected() {
+    let bad_wire =
+        r#"{"coin_in":{"amount":"0","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}"#;
+    serde_json::from_str::<SwapParams>(bad_wire)
+        .expect_err("zero coin_in must fail deserialization");
+}
+
 // ---------------------------------------------------------------------------
-// 7. Wire-protocol constants
+// 7. TransferOutParams invariant: amount > 0
+// ---------------------------------------------------------------------------
+
+#[test]
+fn transfer_out_params_non_zero_ok() {
+    let params = TransferOutParams::new(Coin::<PaymentC3>::new(1000).into())
+        .expect("non-zero amount must be accepted");
+    assert!(params.invariant_held());
+}
+
+#[test]
+fn transfer_out_params_zero_rejected() {
+    let res = TransferOutParams::new(Coin::<PaymentC3>::new(0).into());
+    assert!(matches!(res, Err(Error::ZeroTransferAmount)));
+}
+
+#[test]
+fn transfer_out_params_deserialize_zero_rejected() {
+    let bad_wire = r#"{"amount":{"amount":"0","ticker":"LC1"}}"#;
+    serde_json::from_str::<TransferOutParams>(bad_wire)
+        .expect_err("zero amount must fail deserialization");
+}
+
+// ---------------------------------------------------------------------------
+// 8. Wire-protocol constants
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -248,6 +366,11 @@ fn port_prefix_constant_pinned() {
 #[test]
 fn port_id_for_dex_concatenates_prefix() {
     assert_eq!("nls-remote-lease.astroport", port_id_for("astroport"));
+}
+
+#[test]
+fn protocol_version_round_trip_pinned() {
+    assert_round_trip_eq(r#""nls-remote-lease.v1""#, &ProtocolVersion);
 }
 
 // ---------------------------------------------------------------------------
@@ -281,5 +404,10 @@ fn sample_swap_params() -> SwapParams {
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC2>::new(42).into(),
     )
-    .expect("sample uses two distinct currencies")
+    .expect("sample uses two distinct non-zero amounts")
+}
+
+fn sample_transfer_out_params() -> TransferOutParams {
+    TransferOutParams::new(Coin::<PaymentC3>::new(1000).into())
+        .expect("sample uses a non-zero amount")
 }

--- a/protocol/packages/remote_lease/src/tests.rs
+++ b/protocol/packages/remote_lease/src/tests.rs
@@ -1,0 +1,285 @@
+//! Wire-format and invariant tests for the cross-chain `remote_lease` protocol.
+//!
+//! Acceptance criterion (ibc-solray#134): round-trip serde tests for every
+//! variant against `cosmwasm_std::to_json_binary` output. The Solana-side
+//! consumer is a foreign codebase, so the literal-JSON pins below are part of
+//! the wire contract — changing them is a breaking protocol change.
+
+use std::fmt::Debug;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use currencies::{
+    PaymentGroup,
+    testing::{PaymentC1, PaymentC2, PaymentC3},
+};
+use finance::coin::Coin;
+
+use crate::{
+    PORT_PREFIX, VERSION,
+    callback::RemoteLeaseCallback,
+    envelope::PacketEnvelope,
+    error::Error,
+    msg::{CloseLeaseParams, LeaseOperationsMsg, OpenLeaseParams, SwapParams, TransferOutParams},
+    port_id_for,
+    response::{
+        CloseLeaseResponse, OpenLeaseResponse, OperationResponse, SwapResponse, TransferOutResponse,
+    },
+};
+
+// ---------------------------------------------------------------------------
+// 1. LeaseOperationsMsg variants — round-trip + literal JSON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn open_lease_msg_serde() {
+    let value = LeaseOperationsMsg::OpenLease(sample_open_lease_params());
+    assert_round_trip_eq(
+        r#"{"open_lease":{"expected_instance_ordinal":7,"downpayment_currency":"NLS","lpn_currency":"LPN","asset_currency":"LC1"}}"#,
+        &value,
+    );
+}
+
+#[test]
+fn close_lease_msg_serde() {
+    let value = LeaseOperationsMsg::CloseLease(CloseLeaseParams {});
+    assert_round_trip_eq(r#"{"close_lease":{}}"#, &value);
+}
+
+#[test]
+fn swap_msg_serde() {
+    let value = LeaseOperationsMsg::Swap(sample_swap_params());
+    assert_round_trip_eq(
+        r#"{"swap":{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}"#,
+        &value,
+    );
+}
+
+#[test]
+fn transfer_out_msg_serde() {
+    let value = LeaseOperationsMsg::TransferOut(TransferOutParams {
+        amount: Coin::<PaymentC3>::new(1000).into(),
+    });
+    assert_round_trip_eq(
+        r#"{"transfer_out":{"amount":{"amount":"1000","ticker":"LC1"}}}"#,
+        &value,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. OperationResponse variants — round-trip + literal JSON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn open_lease_response_serde() {
+    let value = OperationResponse::OpenLease(OpenLeaseResponse {
+        remote_lease_id: "solray-lease-1".to_owned(),
+    });
+    assert_round_trip_eq(
+        r#"{"open_lease":{"remote_lease_id":"solray-lease-1"}}"#,
+        &value,
+    );
+}
+
+#[test]
+fn close_lease_response_serde() {
+    let value = OperationResponse::CloseLease(CloseLeaseResponse {});
+    assert_round_trip_eq(r#"{"close_lease":{}}"#, &value);
+}
+
+#[test]
+fn swap_response_serde() {
+    let value = OperationResponse::Swap(SwapResponse {
+        amount_out: Coin::<PaymentC2>::new(42).into(),
+    });
+    assert_round_trip_eq(
+        r#"{"swap":{"amount_out":{"amount":"42","ticker":"LPN"}}}"#,
+        &value,
+    );
+}
+
+#[test]
+fn transfer_out_response_serde() {
+    let value = OperationResponse::TransferOut(TransferOutResponse {});
+    assert_round_trip_eq(r#"{"transfer_out":{}}"#, &value);
+}
+
+// ---------------------------------------------------------------------------
+// 3. RemoteLeaseCallback variants — round-trip + literal JSON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn callback_operation_ok_serde() {
+    let value =
+        RemoteLeaseCallback::OperationOk(OperationResponse::CloseLease(CloseLeaseResponse {}));
+    assert_round_trip_eq(r#"{"operation_ok":{"close_lease":{}}}"#, &value);
+}
+
+#[test]
+fn callback_operation_err_serde() {
+    let value = RemoteLeaseCallback::OperationErr("dex pool drained".to_owned());
+    assert_round_trip_eq(r#"{"operation_err":"dex pool drained"}"#, &value);
+}
+
+#[test]
+fn callback_operation_timeout_serde() {
+    let value = RemoteLeaseCallback::OperationTimeout;
+    assert_round_trip_eq(r#""operation_timeout""#, &value);
+}
+
+// ---------------------------------------------------------------------------
+// 4. PacketEnvelope — round-trip + literal JSON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn packet_envelope_serde() {
+    let value = PacketEnvelope {
+        lease: "nolus1leaseaddr".to_owned(),
+        operation: LeaseOperationsMsg::CloseLease(CloseLeaseParams {}),
+    };
+    assert_round_trip_eq(
+        r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}}}"#,
+        &value,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. OpenLeaseParams invariant: three currencies pairwise distinct
+// ---------------------------------------------------------------------------
+
+#[test]
+fn open_lease_params_distinct_currencies_ok() {
+    let params = OpenLeaseParams::new(
+        7,
+        currency::dto::<PaymentC1, PaymentGroup>(),
+        currency::dto::<PaymentC2, PaymentGroup>(),
+        currency::dto::<PaymentC3, PaymentGroup>(),
+    )
+    .expect("three distinct currencies must be accepted");
+    assert!(params.invariant_held());
+}
+
+#[test]
+fn open_lease_params_downpayment_equals_lpn_rejected() {
+    let res = OpenLeaseParams::new(
+        7,
+        currency::dto::<PaymentC1, PaymentGroup>(),
+        currency::dto::<PaymentC1, PaymentGroup>(),
+        currency::dto::<PaymentC3, PaymentGroup>(),
+    );
+    assert!(matches!(res, Err(Error::DuplicateLeaseCurrencies)));
+}
+
+#[test]
+fn open_lease_params_downpayment_equals_asset_rejected() {
+    let res = OpenLeaseParams::new(
+        7,
+        currency::dto::<PaymentC1, PaymentGroup>(),
+        currency::dto::<PaymentC2, PaymentGroup>(),
+        currency::dto::<PaymentC1, PaymentGroup>(),
+    );
+    assert!(matches!(res, Err(Error::DuplicateLeaseCurrencies)));
+}
+
+#[test]
+fn open_lease_params_lpn_equals_asset_rejected() {
+    let res = OpenLeaseParams::new(
+        7,
+        currency::dto::<PaymentC1, PaymentGroup>(),
+        currency::dto::<PaymentC2, PaymentGroup>(),
+        currency::dto::<PaymentC2, PaymentGroup>(),
+    );
+    assert!(matches!(res, Err(Error::DuplicateLeaseCurrencies)));
+}
+
+#[test]
+fn open_lease_params_deserialize_invariant_violation_rejected() {
+    let bad_wire = r#"{"expected_instance_ordinal":7,"downpayment_currency":"NLS","lpn_currency":"NLS","asset_currency":"LC1"}"#;
+    serde_json::from_str::<OpenLeaseParams>(bad_wire)
+        .expect_err("invariant violation must fail deserialization");
+}
+
+// ---------------------------------------------------------------------------
+// 6. SwapParams invariant: coin_in and min_out currencies differ
+// ---------------------------------------------------------------------------
+
+#[test]
+fn swap_params_distinct_currencies_ok() {
+    let params = SwapParams::new(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    )
+    .expect("distinct currencies must be accepted");
+    assert!(params.invariant_held());
+}
+
+#[test]
+fn swap_params_same_currency_rejected() {
+    let res = SwapParams::new(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC1>::new(42).into(),
+    );
+    assert!(matches!(res, Err(Error::SameSwapCurrency)));
+}
+
+#[test]
+fn swap_params_deserialize_invariant_violation_rejected() {
+    let bad_wire =
+        r#"{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"NLS"}}"#;
+    serde_json::from_str::<SwapParams>(bad_wire)
+        .expect_err("invariant violation must fail deserialization");
+}
+
+// ---------------------------------------------------------------------------
+// 7. Wire-protocol constants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_constant_pinned() {
+    assert_eq!("nls-remote-lease.v1", VERSION);
+}
+
+#[test]
+fn port_prefix_constant_pinned() {
+    assert_eq!("nls-remote-lease.", PORT_PREFIX);
+}
+
+#[test]
+fn port_id_for_dex_concatenates_prefix() {
+    assert_eq!("nls-remote-lease.astroport", port_id_for("astroport"));
+}
+
+// ---------------------------------------------------------------------------
+// helpers — expected value first per project rule 17
+// ---------------------------------------------------------------------------
+
+fn assert_round_trip_eq<T>(expected_json: &str, value: &T)
+where
+    T: Serialize + DeserializeOwned + PartialEq + Debug,
+{
+    let encoded = serde_json::to_string(value).expect("serialization must succeed");
+    assert_eq!(expected_json, encoded.as_str());
+
+    let decoded: T =
+        serde_json::from_str(&encoded).expect("decoding the freshly-encoded value must succeed");
+    assert_eq!(value, &decoded);
+}
+
+fn sample_open_lease_params() -> OpenLeaseParams {
+    OpenLeaseParams::new(
+        7,
+        currency::dto::<PaymentC1, PaymentGroup>(),
+        currency::dto::<PaymentC2, PaymentGroup>(),
+        currency::dto::<PaymentC3, PaymentGroup>(),
+    )
+    .expect("sample uses three distinct currencies")
+}
+
+fn sample_swap_params() -> SwapParams {
+    SwapParams::new(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    )
+    .expect("sample uses two distinct currencies")
+}

--- a/protocol/packages/remote_lease/src/tests.rs
+++ b/protocol/packages/remote_lease/src/tests.rs
@@ -22,7 +22,7 @@ use crate::{
     callback::{OPERATION_ERR_MAX_BYTES, RemoteErrorMessage, RemoteLeaseCallback},
     envelope::{LeaseAddrOnWire, PacketEnvelope},
     error::Error,
-    msg::{CloseLeaseParams, LeaseOperationsMsg, OpenLeaseParams, SwapParams, TransferOutParams},
+    msg::{CloseLeaseParams, OpenLeaseParams, Operation, SwapParams, TransferOutParams},
     port_id_for,
     response::{
         CloseLeaseResponse, OpenLeaseResponse, OperationResponse, SwapResponse, TransferOutResponse,
@@ -31,12 +31,12 @@ use crate::{
 };
 
 // ---------------------------------------------------------------------------
-// 1. LeaseOperationsMsg variants — round-trip + literal JSON
+// 1. Operation variants — round-trip + literal JSON
 // ---------------------------------------------------------------------------
 
 #[test]
 fn open_lease_msg_serde() {
-    let value = LeaseOperationsMsg::OpenLease(sample_open_lease_params());
+    let value = Operation::OpenLease(sample_open_lease_params());
     assert_round_trip_eq(
         r#"{"open_lease":{"expected_instance_ordinal":7,"downpayment_currency":"NLS","lpn_currency":"LPN","asset_currency":"LC1"}}"#,
         &value,
@@ -45,13 +45,13 @@ fn open_lease_msg_serde() {
 
 #[test]
 fn close_lease_msg_serde() {
-    let value = LeaseOperationsMsg::CloseLease(CloseLeaseParams {});
+    let value = Operation::CloseLease(CloseLeaseParams {});
     assert_round_trip_eq(r#"{"close_lease":{}}"#, &value);
 }
 
 #[test]
 fn swap_msg_serde() {
-    let value = LeaseOperationsMsg::Swap(sample_swap_params());
+    let value = Operation::Swap(sample_swap_params());
     assert_round_trip_eq(
         r#"{"swap":{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}"#,
         &value,
@@ -60,7 +60,7 @@ fn swap_msg_serde() {
 
 #[test]
 fn transfer_out_msg_serde() {
-    let value = LeaseOperationsMsg::TransferOut(sample_transfer_out_params());
+    let value = Operation::TransferOut(sample_transfer_out_params());
     assert_round_trip_eq(
         r#"{"transfer_out":{"amount":{"amount":"1000","ticker":"LC1"}}}"#,
         &value,
@@ -164,7 +164,7 @@ fn callback_error_message_deserialize_over_cap_rejected() {
 fn packet_envelope_serde() {
     let value = PacketEnvelope {
         lease: LeaseAddrOnWire::new("nolus1leaseaddr"),
-        operation: LeaseOperationsMsg::CloseLease(CloseLeaseParams {}),
+        operation: Operation::CloseLease(CloseLeaseParams {}),
         version: ProtocolVersion,
     };
     assert_round_trip_eq(

--- a/protocol/packages/remote_lease/src/version.rs
+++ b/protocol/packages/remote_lease/src/version.rs
@@ -1,0 +1,50 @@
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+use crate::VERSION;
+
+/// Zero-sized wire-format marker that always serialises as [`crate::VERSION`]
+/// and rejects any other value at deserialisation time.
+///
+/// Why a ZST: every packet on the wire carries the protocol version explicitly,
+/// but the value is fixed at compile time. A mismatched-version packet from
+/// a future counterparty MUST be rejected at the deserialiser, not in the
+/// consumer's business code, so that no callback dispatch can ever observe a
+/// `PacketEnvelope` whose `version` field does not equal the current
+/// `VERSION` constant. Bumping the protocol therefore forces a code change
+/// here — exactly the desired invariant.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ProtocolVersion;
+
+impl fmt::Display for ProtocolVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(VERSION)
+    }
+}
+
+impl Serialize for ProtocolVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(VERSION)
+    }
+}
+
+impl<'de> Deserialize<'de> for ProtocolVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        <&str>::deserialize(deserializer).and_then(|actual| {
+            if actual == VERSION {
+                Ok(Self)
+            } else {
+                Err(de::Error::custom(format!(
+                    "protocol version mismatch: expected {VERSION}, got {actual}",
+                )))
+            }
+        })
+    }
+}

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -430,7 +430,6 @@ dependencies = [
 name = "currency"
 version = "0.7.0"
 dependencies = [
- "sdk",
  "serde",
  "thiserror 2.0.18",
 ]


### PR DESCRIPTION
Implements nolus-protocol/ibc-solray#134.

## Summary

Introduce `protocol/packages/remote_lease`, the wire-format crate for the Nolus↔Solana cross-chain lease protocol (ADR 0001 / ADR 0002 in `nolus-protocol/ibc-solray`). The crate ships the IBC packet payload types and caller-side stubs gated behind a `stub` feature. Two follow-on commits (a) drop `sdk` from `currency`'s production deps and (b) harden the wire types against findings from the security review of the initial commit.

## Default surface (no `stub`)

- `PacketEnvelope` carrying the originating lease address, a `Operation` payload, and a pinned `ProtocolVersion` ZST that rejects mismatched versions at deserialise.
- `LeaseAddrOnWire` newtype around the bech32 lease address — private inner; the only ways out are `as_str()` and `into_validated(&dyn Api)` (the latter gated on `stub`).
- `Operation` with four variants: `OpenLease`, `CloseLease`, `Swap`, `TransferOut`, each with a typed `*Params` struct.
- `OpenLeaseParams` encapsulated with a pairwise-distinct-currency invariant (downpayment ≠ lpn ≠ asset) and an `expected_instance_ordinal: u16` field (widened from `u8` to match the solray program ordinal width).
- `SwapParams` rejects zero `coin_in` / `min_out` and same-currency in/out, with both the constructor and the serde-side `Raw → TryFrom` rejecting violations.
- `TransferOutParams` rejects zero amount on both axes.
- `OperationResponse` with four matching `*Response` variants; `OpenLeaseResponse` carries the Solana-derived `remote_lease_id`.
- `RemoteLeaseCallback` dispatch shape (`OperationOk` / `OperationErr` / `OperationTimeout`) with a doc-comment distinguishing IBC-layer timeout from Solana-program-layer error.
- `RemoteErrorMessage` caps the `OperationErr` payload at 512 bytes via a manual `Visitor` that rejects before any owned `String` is allocated on the receiver side.
- `ControllerInnerMessage` marker trait constrains the `op_to_msg` closure in the stub builders — orphan rule prevents accidental flat embedding of `Operation`.
- Constants `VERSION = "nls-remote-lease.v1"`, `PORT_PREFIX`, `port_id_for`.

## Stub surface (feature `stub`)

- `Factory` and `Lease` wrappers that build a `Batch` with one `WasmMsg::Execute` targeting the controller. The closure return type must implement `ControllerInnerMessage`.
- `LeaseAddrOnWire::into_validated(&dyn Api) -> StdResult<Addr>` for the controller's dispatch path.

## Tests (42 total)

- Round-trip serde + literal-JSON pins for every wire variant. The Solana-side consumer parses these literals, so a silent rename would break the protocol; the pins lock the shape.
- Invariant constructor coverage for `OpenLeaseParams`, `SwapParams`, `TransferOutParams`.
- `try_from` rejection for invariant-violating wire payloads (duplicate currencies, zero amounts, mismatched version, missing version, over-cap callback message).
- `u16` boundary tests for `expected_instance_ordinal` (`u16::MAX` accepted, `65536` rejected).
- Stub message-count verification for all four operations.

## Currency dep cleanup

`platform/packages/currency` no longer pulls `sdk` in production. The only production-source reference to `sdk` was inside a `#[cfg(test)] mod test` block; moved to `[dev-dependencies]` exclusively. Added `serde/std` explicitly to compensate for the `std` feature previously flowing in via `sdk → cosmwasm-std`. This is one of two transitive paths into `cosmwasm-std` from `remote_lease`; closing the second path is queued as issue #616.

## Wire-format coordination with solray

This branch changes three properties relative to the version captured in ADR 0001 §3.5:

- `PacketEnvelope` now carries a required `version` field (rejected at deserialise on mismatch).
- `expected_instance_ordinal` is `u16` (was `u8`).
- Zero amounts in `SwapParams` and `TransferOutParams` are rejected at deserialise; over-cap callback error strings (>512 bytes) are rejected at deserialise.

JSON shape otherwise unchanged. The solray ADRs and the Solana-side implementation need a matching update.

## Verification

- Ran `cargo build -p remote_lease --all-features --tests` — clean.
- Ran `cargo fmt -p remote_lease -- --check` — clean.
- Ran `cargo clippy -p remote_lease --all-features --tests -- -D warnings` — clean.
- Ran `cargo test -p remote_lease --all-features --lib` — 42 tests pass; also `--no-default-features` — 38 tests pass.
- Ran `cargo build` / `cargo test` on `currency` after the dep cleanup — clean.
- Walked the bug + Cargo + project-specific checklists independently after each substantive commit — pass with no findings.
- Rebased onto `main` after #614 (rule 39 audit) merged — no conflicts.

## Follow-ups

- Issue #616 — replace `cosmwasm_std::Timestamp` with a finance-owned `Instant` and drop `sdk` from `finance` production deps. Closes the remaining transitive path from `remote_lease` into `cosmwasm-std`.
- Update solray ADR 0001 §3.5 and ADR 0002 §3.1 to reflect the wire-format changes listed above.
- `RemoteErrorMessage::deserialize` doc-comment slightly overclaims the "no owned String materialised" property — strictly true only on the `visit_str` path; tighten the wording in a follow-up.
- `Error::ProtocolVersionMismatch` variant carries a typed payload but is currently unreachable (`ProtocolVersion::deserialize` uses `de::Error::custom(...)`); either wire it up via a non-serde validator or remove until needed.

