### PR TITLE
chore(deps): require explicit feature opt-in on every workspace dep

### DIFF
--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -56,7 +56,7 @@ json-value = { path = "../tools/json-value", default-features = false }
 
 # General
 base64 = { version = "0.22", default-features = false }
-gcd = "2"
+gcd = { version = "2", default-features = false }
 serde = { version = "1", default-features = false }
 thiserror = { version = "2", default-features = false }
 
@@ -66,7 +66,7 @@ cosmwasm-std = { version = "3", default-features = false, features = [
     "iterator",
     "std",
 ] }
-cw-storage-plus = "3"
+cw-storage-plus = { version = "3", default-features = false, features = ["iterator"] }
 cw-multi-test = { version = "3", default-features = false, features = [
     "cosmwasm_1_2",
     "staking",
@@ -81,7 +81,7 @@ bnum = { version = "0.13", default-features = false }
 num-integer = {version = "0.1", default-features = false}
 
 # Testing
-serde_test = "1"
+serde_test = { version = "1", default-features = false }
 
 [profile.dev.build-override]
 opt-level = 3

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -73,7 +73,7 @@ base64 = { version = "0.22", default-features = false }
 either = { version = "1", default-features = false }
 enum_dispatch = { version = "0.3", default-features = false }
 gcd = { version = "2", default-features = false }
-prost = { version = "0.13", default-features = false, features = ["derive", "std"] }
+prost = { version = "0.13", default-features = false, features = ["derive"] }
 serde = { version = "1", default-features = false }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 thiserror = { version = "2", default-features = false }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -65,17 +65,17 @@ versioning = { path = "../platform/packages/versioning", default-features = fals
 
 # Tools Packages
 json-value = { path = "../tools/json-value", default-features = false }
-topology = { path = "../tools/topology" }
+topology = { path = "../tools/topology", default-features = false }
 
 # General
-anyhow = "1"
+anyhow = { version = "1", default-features = false }
 base64 = { version = "0.22", default-features = false }
 either = { version = "1", default-features = false }
 enum_dispatch = { version = "0.3", default-features = false }
 gcd = { version = "2", default-features = false }
-prost = "0.13"
+prost = { version = "0.13", default-features = false, features = ["derive", "std"] }
 serde = { version = "1", default-features = false }
-serde_json = "1"
+serde_json = { version = "1", default-features = false, features = ["std"] }
 thiserror = { version = "2", default-features = false }
 
 # CosmWasm

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -3,54 +3,10 @@
 version = 4
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys",
-]
 
 [[package]]
 name = "anyhow"
@@ -155,12 +111,8 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
- "unicase",
- "unicode-width",
 ]
 
 [[package]]
@@ -180,12 +132,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "cpufeatures"
@@ -394,12 +340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,12 +381,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ordered-float"
@@ -607,12 +541,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,22 +676,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -790,31 +706,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "winnow"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -35,16 +35,12 @@ json-value = { path = "json-value", default-features = false }
 topology = { path = "topology", default-features = false }
 
 # General packages
-anyhow = { version = "1", default-features = false, features = ["std"] }
+anyhow = { version = "1", default-features = false }
 cargo_metadata = { version = "0.20", default-features = false }
 clap = { version = "4.5", default-features = false, features = [
-    "color",
     "derive",
-    "error-context",
     "help",
     "std",
-    "suggestions",
-    "unicode",
     "usage",
 ] }
 either = { version = "1", default-features = false }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -31,21 +31,30 @@ warnings = "deny"
 
 [workspace.dependencies]
 # Own packages
-json-value = { path = "json-value" }
-topology = { path = "topology" }
+json-value = { path = "json-value", default-features = false }
+topology = { path = "topology", default-features = false }
 
 # General packages
-anyhow = "1"
-cargo_metadata = "0.20"
-clap = { version = "4.5", features = ["derive", "unicode"] }
+anyhow = { version = "1", default-features = false, features = ["std"] }
+cargo_metadata = { version = "0.20", default-features = false }
+clap = { version = "4.5", default-features = false, features = [
+    "color",
+    "derive",
+    "error-context",
+    "help",
+    "std",
+    "suggestions",
+    "unicode",
+    "usage",
+] }
 either = { version = "1", default-features = false }
-thiserror = "2"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-sha2 = "0.10.8"
+thiserror = { version = "2", default-features = false }
+serde = { version = "1", default-features = false, features = ["derive", "std"] }
+serde_json = { version = "1", default-features = false, features = ["std"] }
+sha2 = { version = "0.10.8", default-features = false }
 
 # Testing packages
-serde_test = "1"
+serde_test = { version = "1", default-features = false }
 
 [profile.dev.build-override]
 opt-level = 3


### PR DESCRIPTION
## Summary

Adopt a new dependency-hygiene rule across the three workspaces: every entry in `[workspace.dependencies]` sets `default-features = false` and lists exactly the features the code requires. Cargo's `default` feature set was a silent compile-time switch — `cargo build` pulled in whatever defaults the deps elected, downstream consumers inherited them, and stripping a no-longer-needed transitive crate from the graph required guessing which dep silently pulled it in. Each workspace dep line now documents what it compiles.

## Changes

Two commits.

1. **`66a96ee3e` — strip `default-features` and re-add documented default sets defensively.**
   - `platform/Cargo.toml` — 3 deps: `gcd`, `cw-storage-plus`, `serde_test`.
   - `protocol/Cargo.toml` — 4 deps: `topology`, `anyhow`, `prost`, `serde_json`.
   - `tools/Cargo.toml` — 9 deps: `json-value`, `topology`, `anyhow`, `cargo_metadata`, `clap`, `thiserror`, `serde`, `serde_json`, `sha2`, `serde_test`.
   - `tests/Cargo.toml` — already fully compliant; not touched.
   - Per-package `Cargo.toml`s — already fully compliant (every dep uses `workspace = true`); not touched.

2. **`25c79c855` — verify each re-added feature against actual code usage and trim what is not required.** Rule 39 says "lists exactly the features the code requires" — not the documented default set in case something might. Each feature was experimentally dropped and rebuilt; kept only those whose removal broke the build, or whose presence documents a real direct dependency the code reads.

   Trims after verification:
   - `protocol/prost`: dropped `std`, kept `derive`. `swap` uses `prost::Message` (trait, no std needed) and `#[derive(Message)]`. The `platform` workspace's `error.rs` consumes `prost::DecodeError` via thiserror's `#[from]`, but that lives in `platform/Cargo.toml`'s `cosmos-sdk-proto = { ..., features = ["std"] }`, not the protocol workspace.
   - `tools/anyhow`: dropped `std`. `cargo-each` only uses `Result`, `Context`, `bail!`, `Error::msg` — all available without `std`.
   - `tools/clap`: dropped `color`, `error-context`, `suggestions`, `unicode`; kept `derive`, `help`, `std`, `usage`. `cargo-each` does not assert colour output, structured parse errors, "did you mean" hints, or non-ASCII help text.

   Side effect: `tools/Cargo.lock` loses 13 transitive crates (`anstream`, `anstyle-parse`, `anstyle-query`, `anstyle-wincon`, `colorchoice`, `is_terminal_polyfill`, `once_cell_polyfill`, `strsim`, `unicase`, `unicode-width`, `utf8parse`, `windows-link`, `windows-sys`) that were only pulled in by the dropped clap features.

Final explicit feature lists where defaults were stripped:

- `cw-storage-plus`: `iterator`
- `prost`: `derive`
- `serde_json` (protocol): `std` (build script uses `from_reader`)
- `clap` (tools): `derive`, `help`, `std`, `usage`
- `serde` (tools): `derive`, `std` (`std` required by topology's `#[serde(untagged)]` deserialiser via cargo feature unification through tools/serde)

Features stripped entirely (no replacement needed):

- `cw-storage-plus/macro`, `cargo_metadata/builder`, `sha2/std`, `serde_test/std`, `gcd` (no features)
- Plus all the deps trimmed in commit 2 above.

## Verification

- Ran `cargo build --all-targets` on each of platform / protocol / tools / tests workspaces after both commits — clean.
- Ran `cargo clippy --all-targets -- -D warnings` on platform and protocol after both commits — clean.
- Ran `cargo clippy` on tools — failed on a pre-existing `useless_conversion` lint in `cargo-each/src/config.rs:169`; verified present on `main`, unrelated to this diff.
- Ran `cargo test --lib` on platform and protocol — all pass.
- Ran `./target/debug/cargo-each --help` after the clap trim — output unchanged for `--help`, parse errors still surface.
- For commit 2 specifically: each dropped feature was verified by removing it and observing a successful rebuild. The `prost/std` case was cross-checked with `cargo tree -p swap -e features --format "{p} {f}"` — `prost` still resolves with `std` via `cosmos-sdk-proto`'s `std` feature, confirming the trim is documentation-only (no runtime behaviour change).
- Walked the Cargo-specific checklist independently after each commit (no dropped `default-features = false`, re-added features cover real usage, no `default = [...]` introduced, `[workspace.lints]` blocks unchanged) — pass with no findings.

## Follow-ups

- The `feat/remote-lease-shared-crate` feature branch carries one rule-39 violation (`default = []` in `protocol/packages/remote_lease/Cargo.toml`). Will be dropped as part of that branch's final cleanup before its own PR.
- Pre-existing `useless_conversion` clippy lint in `tools/cargo-each/src/config.rs:169` should be fixed separately.