### PR TITLE
ci: route jobs to nolus-ci self-hosted runner pool

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         ${{ steps.out.outputs.profiles-json }}
       workspaces-json: |-
         ${{ steps.out.outputs.workspaces-json }}
-    runs-on: "ubuntu-latest"
+    runs-on: ["self-hosted", "nolus-ci"]
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v5"
@@ -97,7 +97,7 @@ jobs:
             >>"${GITHUB_OUTPUT:?}"
   audit-dependencies:
     name: "Audit dependencies"
-    runs-on: "ubuntu-latest"
+    runs-on: ["self-hosted", "nolus-ci"]
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v5"
@@ -127,7 +127,7 @@ jobs:
             "${image_tag:?}"
   check-formatting:
     name: "Check formatting"
-    runs-on: "ubuntu-latest"
+    runs-on: ["self-hosted", "nolus-ci"]
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v5"
@@ -160,7 +160,7 @@ jobs:
       check-dependencies-versions: |-
         ${{ toJSON(github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.check-dependencies-version)) }}
     name: "Check lockfiles"
-    runs-on: "ubuntu-latest"
+    runs-on: ["self-hosted", "nolus-ci"]
     steps:
       - if: |-
           fromJSON(env.check-dependencies-versions)
@@ -202,7 +202,7 @@ jobs:
     name: "Check for unused dependencies"
     needs:
       - "matrix-arguments"
-    runs-on: "ubuntu-latest"
+    runs-on: ["self-hosted", "nolus-ci"]
     strategy:
       matrix:
         workspace: |-
@@ -247,7 +247,7 @@ jobs:
     name: "Lint codebase without tests"
     needs:
       - "matrix-arguments"
-    runs-on: "ubuntu-latest"
+    runs-on: ["self-hosted", "nolus-ci"]
     strategy:
       matrix:
         profile: |-
@@ -298,7 +298,7 @@ jobs:
     name: "Lint codebase with tests"
     needs:
       - "matrix-arguments"
-    runs-on: "ubuntu-latest"
+    runs-on: ["self-hosted", "nolus-ci"]
     strategy:
       matrix:
         profile: |-
@@ -349,7 +349,7 @@ jobs:
     name: "Run tests"
     needs:
       - "matrix-arguments"
-    runs-on: "ubuntu-latest"
+    runs-on: ["self-hosted", "nolus-ci"]
     strategy:
       matrix:
         profile: |-
@@ -402,7 +402,7 @@ jobs:
       upload-artifacts: |-
         ${{ toJSON(github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.upload-artifacts)) }}
     name: "Build contracts"
-    runs-on: "ubuntu-latest"
+    runs-on: ["self-hosted", "nolus-ci"]
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v5"
@@ -596,7 +596,7 @@ jobs:
     name: "Create draft release"
     permissions:
       contents: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: ["self-hosted", "nolus-ci"]
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v5"


### PR DESCRIPTION
## Summary

Switch the 10 jobs in `ci.yaml` from `ubuntu-latest` to the `nolus-ci` self-hosted runner pool. Every job already runs its real work inside a Docker container built from `./ci/Containerfile`, so the host only needs Docker — no toolchain assumptions are made on the runner side. With the shared label, GitHub fans matrix shards out across the pool in parallel rather than queueing on a single hosted slot per job.

## Changes

- `.github/workflows/ci.yaml` — `runs-on: "ubuntu-latest"` → `runs-on: ["self-hosted", "nolus-ci"]` on `matrix-arguments`, `audit-dependencies`, `check-formatting`, `check-lockfiles`, `check-unused-dependencies`, `lint`, `lint_with_tests`, `test`, `build`, `create-draft-release`.

## Out of scope

- `code_coverage.yaml` stays on `ubuntu-latest`. Unlike `ci.yaml` it is **not** containerized — it installs the Rust toolchain on the runner host directly via the custom `./.github/actions/cache-rust` and `./.github/actions/install-tool` composites. Migrating it would need separate work to confirm those composites are self-hosted-safe. The workflow is `workflow_dispatch`-only (its `schedule` cron is commented out), so the slowdown is rarely felt.
- `slack_release.yaml` stays on `ubuntu-latest`. Trivial Slack webhook on release publish — nothing to gain.

## Verification

- Confirmed all runners in the `nolus-ci` pool are online and registered against the org.
- Confirmed `nolus-money-market` is on the `NolusRunners` runner-group allowlist.
- Confirmed `nolus-protocol/actions/setup-docker@v1` short-circuits on self-hosted (gated on `runner.environment == 'github-hosted'`), so the existing workflow steps stay unchanged on the new hosts.
- Verified the existing `runner.environment == 'self-hosted'` gate in the `build` job (the "Clean up build artifacts" step) is intentional and ordered correctly — the cleanup runs **after** the upload-artifact steps, so artifacts are preserved across the workspace wipe.
- Verified `actions/upload-artifact@v4` and `actions/download-artifact@v5` use GitHub-hosted artifact storage as the transport, so the `build` → `create-draft-release` handoff still works when those jobs land on different runners in the pool.