### PR TITLE
fix(cargo-each): drop redundant .into_iter() flagged by clippy

### DIFF
--- a/tools/cargo-each/src/config.rs
+++ b/tools/cargo-each/src/config.rs
@@ -166,7 +166,7 @@ fn construct_generic_mappings<'r>(
             .is_empty()
             .then(BTreeMap::new)
             .into_iter()
-            .chain(generics_mappings.into_iter())
+            .chain(generics_mappings)
             .flat_map(move |generics_mapping| {
                 generics.iter().map(move |&replacement| {
                     let mut generics_mapping = generics_mapping.clone();


### PR DESCRIPTION
## Summary

`clippy::useless_conversion` fires on the explicit `.into_iter()` call in `tools/cargo-each/src/config.rs:169` — `Iterator::chain` already accepts `IntoIterator`, so the conversion is a no-op. Dropping it fixes `cargo clippy --all-targets -- -D warnings` on the tools workspace.

## Changes

- `tools/cargo-each/src/config.rs:169` — `.chain(generics_mappings.into_iter())` → `.chain(generics_mappings)`.

## Verification

- Ran `cargo clippy --all-targets -- -D warnings` on `tools/` — clean (was failing on `main`).
- Ran `cargo test --all-targets` on `tools/` — 5/5 pass.
- Confirmed the lint was unrelated to PR #614's audit work; flagged as a pre-existing issue at that review.