### PR TITLE
refactor(finance): replace Timestamp with Instant; drop cosmwasm-std dependency

### DIFF
--- a/platform/Cargo.lock
+++ b/platform/Cargo.lock
@@ -508,6 +508,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-time"
+version = "0.1.0"
+dependencies = [
+ "finance",
+ "sdk",
+]
+
+[[package]]
 name = "cw-utils"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +747,7 @@ dependencies = [
  "platform",
  "sdk",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
 ]
 
@@ -1061,6 +1070,7 @@ version = "0.4.0"
 dependencies = [
  "base64",
  "currency",
+ "cw-time",
  "finance",
  "sdk",
  "serde",
@@ -1615,6 +1625,7 @@ dependencies = [
 name = "time-oracle"
 version = "0.2.2"
 dependencies = [
+ "finance",
  "sdk",
  "serde",
  "thiserror 2.0.18",
@@ -1626,6 +1637,8 @@ version = "0.5.2"
 dependencies = [
  "access-control",
  "cosmwasm-std",
+ "cw-time",
+ "finance",
  "platform",
  "sdk",
  "serde",
@@ -1642,6 +1655,7 @@ dependencies = [
  "admin_contract",
  "cosmwasm-std",
  "currency",
+ "cw-time",
  "finance",
  "lpp-platform",
  "oracle-platform",

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -54,10 +54,14 @@ versioning = { path = "packages/versioning", default-features = false }
 # Tools Packages
 json-value = { path = "../tools/json-value", default-features = false }
 
+# Own Bridge Packages
+cw-time = { path = "packages/cw-time", default-features = false }
+
 # General
 base64 = { version = "0.22", default-features = false }
 gcd = { version = "2", default-features = false }
 serde = { version = "1", default-features = false }
+serde_json = { version = "1", default-features = false, features = ["std"] }
 thiserror = { version = "2", default-features = false }
 
 # CosmWasm

--- a/platform/contracts/timealarms/Cargo.toml
+++ b/platform/contracts/timealarms/Cargo.toml
@@ -25,6 +25,8 @@ testing = []
 
 [dependencies]
 access-control = { workspace = true }
+cw-time = { workspace = true }
+finance = { workspace = true }
 platform = { workspace = true }
 sdk = { workspace = true, features = ["contract"] }
 time-oracle = { workspace = true, optional = true }

--- a/platform/contracts/timealarms/src/alarms.rs
+++ b/platform/contracts/timealarms/src/alarms.rs
@@ -117,10 +117,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::Instant;
-    use sdk::cosmwasm_std::{Addr, testing};
+    use sdk::cosmwasm_std::{Addr, Timestamp, testing};
 
-    use super::TimeAlarms;
+    use super::{Instant, TimeAlarms};
 
     #[test]
     fn try_add_valid_contract_address() {

--- a/platform/contracts/timealarms/src/alarms.rs
+++ b/platform/contracts/timealarms/src/alarms.rs
@@ -1,10 +1,12 @@
 use std::ops::{Deref, DerefMut};
 
+use cw_time::IntoInstant;
+use finance::instant::Instant;
 use platform::{
     dispatcher::{AlarmsDispatcher, Id},
     message::Response as MessageResponse,
 };
-use sdk::cosmwasm_std::{Addr, Env, Storage, Timestamp};
+use sdk::cosmwasm_std::{Addr, Env, Storage};
 use time_oracle::Alarms;
 
 use crate::{
@@ -41,7 +43,7 @@ where
         }
     }
 
-    pub fn try_any_alarm(&self, ctime: Timestamp) -> Result<AlarmsStatusResponse, ContractError> {
+    pub fn try_any_alarm(&self, ctime: Instant) -> Result<AlarmsStatusResponse, ContractError> {
         let remaining_alarms = self
             .time_alarms
             .alarms_selection(ctime)
@@ -63,9 +65,9 @@ where
         &mut self,
         env: &Env,
         subscriber: Addr,
-        time: Timestamp,
+        time: Instant,
     ) -> ContractResult<MessageResponse> {
-        if time < env.block.time {
+        if time < env.block.time.into_instant() {
             return Err(ContractError::InvalidAlarm(time));
         }
         self.time_alarms
@@ -76,7 +78,7 @@ where
 
     pub fn try_notify(
         &mut self,
-        ctime: Timestamp,
+        ctime: Instant,
         max_count: AlarmsCount,
     ) -> ContractResult<(AlarmsCount, MessageResponse)> {
         self.time_alarms
@@ -108,14 +110,15 @@ where
         self.time_alarms.last_delivered().map_err(Into::into)
     }
 
-    pub fn last_failed(&mut self, now: Timestamp) -> ContractResult<()> {
+    pub fn last_failed(&mut self, now: Instant) -> ContractResult<()> {
         self.time_alarms.last_failed(now).map_err(Into::into)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use sdk::cosmwasm_std::{Addr, Timestamp, testing};
+    use super::Instant;
+    use sdk::cosmwasm_std::{Addr, testing};
 
     use super::TimeAlarms;
 
@@ -129,7 +132,7 @@ mod tests {
         let msg_sender = Addr::unchecked("some address");
         assert!(
             TimeAlarms::new(deps.storage)
-                .try_add(&env, msg_sender, Timestamp::from_nanos(4),)
+                .try_add(&env, msg_sender, Instant::from_nanos(4),)
                 .is_ok()
         );
     }
@@ -144,7 +147,7 @@ mod tests {
 
         let msg_sender = Addr::unchecked("some address");
         TimeAlarms::new(deps.storage)
-            .try_add(&env, msg_sender, Timestamp::from_nanos(4))
+            .try_add(&env, msg_sender, Instant::from_nanos(4))
             .unwrap_err();
     }
 }

--- a/platform/contracts/timealarms/src/contract.rs
+++ b/platform/contracts/timealarms/src/contract.rs
@@ -1,3 +1,4 @@
+use cw_time::IntoInstant;
 use platform::{
     batch::{Emit, Emitter},
     contract::{self, Validator},
@@ -74,7 +75,7 @@ pub fn execute(
                 .map(response::response_only_messages)
         }
         ExecuteMsg::DispatchAlarms { max_count } => time_alarms
-            .try_notify(env.block.time, max_count)
+            .try_notify(env.block.time.into_instant(), max_count)
             .and_then(|(total, resp)| {
                 response::response_with_messages(DispatchAlarmsResponse(total), resp)
             }),
@@ -94,7 +95,7 @@ pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> 
             Ok(cosmwasm_std::to_json_binary(&CURRENT_RELEASE.version())?)
         }
         QueryMsg::AlarmsStatus {} => Ok(cosmwasm_std::to_json_binary(
-            &TimeAlarms::new(deps.storage).try_any_alarm(env.block.time)?,
+            &TimeAlarms::new(deps.storage).try_any_alarm(env.block.time.into_instant())?,
         )?),
         QueryMsg::PlatformPackageRelease {} => {
             cosmwasm_std::to_json_binary(&CURRENT_RELEASE).map_err(Into::into)
@@ -120,7 +121,7 @@ pub fn reply(deps: DepsMut<'_>, env: Env, msg: Reply) -> ContractResult<CwRespon
             emitter.emit(KEY_DELIVERED, "success")
         }
         SubMsgResult::Err(err) => {
-            time_alarms.last_failed(env.block.time)?;
+            time_alarms.last_failed(env.block.time.into_instant())?;
 
             emitter.emit(KEY_DELIVERED, "error").emit(KEY_DETAILS, err)
         }

--- a/platform/contracts/timealarms/src/error.rs
+++ b/platform/contracts/timealarms/src/error.rs
@@ -2,7 +2,8 @@ use std::num::TryFromIntError;
 
 use thiserror::Error;
 
-use sdk::cosmwasm_std::{Addr, StdError, Timestamp};
+use finance::instant::Instant;
+use sdk::cosmwasm_std::{Addr, StdError};
 use time_oracle::AlarmError;
 
 #[derive(Error, Debug)]
@@ -20,7 +21,7 @@ pub enum ContractError {
     InvalidAlarmAddress(Addr),
 
     #[error("[TimeAlarms] Alarm is in the past: {0:?}")]
-    InvalidAlarm(Timestamp),
+    InvalidAlarm(Instant),
 
     #[error("[TimeAlarms] {0}")]
     Platform(#[from] platform::error::Error),

--- a/platform/contracts/timealarms/src/msg.rs
+++ b/platform/contracts/timealarms/src/msg.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use sdk::cosmwasm_std::Timestamp;
+use finance::instant::Instant;
 
 pub type AlarmsCount = platform::dispatcher::AlarmsCount;
 
@@ -18,7 +18,7 @@ pub struct MigrateMsg {}
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum ExecuteMsg {
     AddAlarm {
-        time: Timestamp,
+        time: Instant,
     },
     /// Returns [`DispatchAlarmsResponse`] as response data.
     DispatchAlarms {

--- a/platform/contracts/timealarms/src/stub.rs
+++ b/platform/contracts/timealarms/src/stub.rs
@@ -3,8 +3,9 @@ use std::result::Result as StdResult;
 use serde::{Deserialize, Serialize};
 
 use access_control::{AccessPermission, error::Error as AccessControlError, user::User};
+use finance::instant::Instant;
 use platform::{batch::Batch, contract::Validator};
-use sdk::cosmwasm_std::{self, Addr, StdError as SdkError, Timestamp};
+use sdk::cosmwasm_std::{self, Addr, StdError as SdkError};
 
 use crate::msg::ExecuteMsg;
 
@@ -14,7 +15,7 @@ pub trait TimeAlarms
 where
     Self: Into<Batch>,
 {
-    fn add_alarm(&mut self, time: Timestamp) -> Result<()>;
+    fn add_alarm(&mut self, time: Instant) -> Result<()>;
 }
 
 pub trait WithTimeAlarms {
@@ -56,7 +57,7 @@ impl TimeAlarmsRef {
         self.addr == addr
     }
 
-    pub fn setup_alarm(&self, when: Timestamp) -> Result<Batch> {
+    pub fn setup_alarm(&self, when: Instant) -> Result<Batch> {
         let mut stub = self.as_stub();
         stub.add_alarm(when)?;
         Ok(stub.into())
@@ -95,7 +96,7 @@ impl TimeAlarmsStub<'_> {
 }
 
 impl TimeAlarms for TimeAlarmsStub<'_> {
-    fn add_alarm(&mut self, time: Timestamp) -> Result<()> {
+    fn add_alarm(&mut self, time: Instant) -> Result<()> {
         self.batch
             .schedule_execute_no_reply(cosmwasm_std::wasm_execute(
                 self.addr().clone(),

--- a/platform/contracts/treasury/Cargo.toml
+++ b/platform/contracts/treasury/Cargo.toml
@@ -25,6 +25,7 @@ timealarms = { workspace = true, features = ["stub"] }
 
 access-control = { workspace = true }
 currency = { workspace = true }
+cw-time = { workspace = true }
 finance = { workspace = true }
 platform = { workspace = true }
 sdk = { workspace = true, features = ["contract"] }

--- a/platform/contracts/treasury/src/contract.rs
+++ b/platform/contracts/treasury/src/contract.rs
@@ -4,7 +4,8 @@ use access_control::SingleUserAccess;
 use admin_contract::msg::{
     ProtocolQueryResponse, ProtocolsQueryResponse, QueryMsg as ProtocolsRegistry,
 };
-use finance::{duration::Duration, percent::Percent100};
+use cw_time::IntoInstant;
+use finance::{duration::Duration, instant::Instant, percent::Percent100};
 use platform::{
     batch::Batch,
     contract::{self, Validator},
@@ -15,8 +16,7 @@ use platform::{
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
     cosmwasm_std::{
-        Addr, Api, Binary, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, Storage, Timestamp,
-        entry_point,
+        Addr, Api, Binary, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, Storage, entry_point,
     },
 };
 use timealarms::stub::TimeAlarmsRef;
@@ -171,7 +171,7 @@ fn try_dispatch(
     env: &Env,
     timealarm: Addr,
 ) -> ContractResult<MessageResponse> {
-    let now = env.block.time;
+    let now = env.block.time.into_instant();
 
     let config = try_load_config(storage)?;
     let setup_alarm = setup_alarm(
@@ -182,7 +182,7 @@ fn try_dispatch(
     )?;
 
     let last_dispatch = DispatchLog::last_dispatch(storage);
-    DispatchLog::update(storage, env.block.time)?;
+    DispatchLog::update(storage, env.block.time.into_instant())?;
     let rewards_span = Duration::between(&last_dispatch, &now);
 
     try_build_reward(config, querier, env)
@@ -214,7 +214,7 @@ fn protocols(
 
 fn setup_alarm<V>(
     timealarm: Addr,
-    now: &Timestamp,
+    now: &Instant,
     alarm_in: Duration,
     validator: &V,
 ) -> ContractResult<Batch>
@@ -250,11 +250,11 @@ fn setup_dispatching(
     Config::new(msg.cadence_hours, msg.protocols_registry, msg.tvl_to_apr)
         .store(storage)
         .map_err(ContractError::SaveConfig)?;
-    DispatchLog::update(storage, env.block.time)?;
+    DispatchLog::update(storage, env.block.time.into_instant())?;
 
     setup_alarm(
         msg.timealarms,
-        &env.block.time,
+        &env.block.time.into_instant(),
         Duration::from_hours(msg.cadence_hours),
         &contract::validator(querier),
     )

--- a/platform/contracts/treasury/src/state/dispatch_log.rs
+++ b/platform/contracts/treasury/src/state/dispatch_log.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+use finance::instant::Instant;
 use sdk::{
-    cosmwasm_std::{StdResult, Storage, Timestamp},
+    cosmwasm_std::{StdResult, Storage},
     cw_storage_plus::Item,
 };
 
@@ -9,18 +10,18 @@ use crate::ContractError;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct DispatchLog {
-    pub last_dispatch: Timestamp,
+    pub last_dispatch: Instant,
 }
 
 impl DispatchLog {
     const STORAGE: Item<Self> = Item::new("dispatch_log");
 
-    pub fn new(last_dispatch: Timestamp) -> Self {
+    pub fn new(last_dispatch: Instant) -> Self {
         DispatchLog { last_dispatch }
     }
 
     // TODO merge the functionality of this and `update`
-    pub fn last_dispatch(storage: &dyn Storage) -> Timestamp {
+    pub fn last_dispatch(storage: &dyn Storage) -> Instant {
         Self::STORAGE
             .load(storage)
             .map(|log| log.last_dispatch)
@@ -29,7 +30,7 @@ impl DispatchLog {
 
     pub fn update(
         storage: &mut dyn Storage,
-        current_dispatch: Timestamp,
+        current_dispatch: Instant,
     ) -> Result<(), ContractError> {
         Self::STORAGE
             .may_load(storage)

--- a/platform/packages/cw-time/Cargo.toml
+++ b/platform/packages/cw-time/Cargo.toml
@@ -1,0 +1,18 @@
+lints = { workspace = true }
+
+[package]
+name = "cw-time"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[package.metadata.cargo-each]
+combinations = [
+    { tags = ["ci", "@agnostic"], include-rest = true },
+]
+
+[dependencies]
+finance = { workspace = true }
+sdk = { workspace = true }

--- a/platform/packages/cw-time/src/lib.rs
+++ b/platform/packages/cw-time/src/lib.rs
@@ -1,0 +1,71 @@
+//! Bridge between `finance::Instant` (the project-owned time type) and
+//! `cosmwasm_std::Timestamp` (the cosmwasm-API time type).
+//!
+//! `finance` no longer depends on `cosmwasm-std` so it cannot define
+//! conversions to / from `Timestamp` directly without re-introducing the
+//! dependency. The orphan rule also prevents writing the `From` impls in any
+//! third crate that owns neither type. Two extension traits — owned by this
+//! crate — fill the gap.
+//!
+//! Import them where the cosmwasm boundary meets finance time arithmetic:
+//!
+//! ```ignore
+//! use cw_time::{IntoInstant, IntoTimestamp};
+//!
+//! let now = env.block.time.into_instant();          // boundary in
+//! let ibc_timeout = (now + duration).into_timestamp(); // boundary out
+//! ```
+
+use finance::instant::Instant;
+use sdk::cosmwasm_std::Timestamp;
+
+pub trait IntoInstant {
+    fn into_instant(self) -> Instant;
+}
+
+impl IntoInstant for Timestamp {
+    fn into_instant(self) -> Instant {
+        Instant::from_nanos(self.nanos())
+    }
+}
+
+pub trait IntoTimestamp {
+    fn into_timestamp(self) -> Timestamp;
+}
+
+impl IntoTimestamp for Instant {
+    fn into_timestamp(self) -> Timestamp {
+        Timestamp::from_nanos(self.nanos())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use finance::instant::Instant;
+    use sdk::cosmwasm_std::Timestamp;
+
+    use super::{IntoInstant, IntoTimestamp};
+
+    #[test]
+    fn timestamp_round_trip() {
+        let ts = Timestamp::from_nanos(1_234_567_890);
+        let back = ts.into_instant().into_timestamp();
+        assert_eq!(ts, back);
+    }
+
+    #[test]
+    fn instant_round_trip() {
+        let inst = Instant::from_nanos(7_777_777_777);
+        let back = inst.into_timestamp().into_instant();
+        assert_eq!(inst, back);
+    }
+
+    #[test]
+    fn both_directions_preserve_nanos() {
+        let ts = Timestamp::from_seconds(60);
+        assert_eq!(60 * 1_000_000_000, ts.into_instant().nanos());
+
+        let inst = Instant::from_seconds(60);
+        assert_eq!(60 * 1_000_000_000, inst.into_timestamp().nanos());
+    }
+}

--- a/platform/packages/finance/Cargo.toml
+++ b/platform/packages/finance/Cargo.toml
@@ -18,7 +18,6 @@ testing = ["currency/testing"]
 
 [dependencies]
 currency = { workspace = true }
-sdk = { workspace = true }
 
 #`numtraits` required for calling `num_integer::gcd` in custom gcd impl
 bnum = { workspace = true, features = ["numtraits"] }

--- a/platform/packages/finance/Cargo.toml
+++ b/platform/packages/finance/Cargo.toml
@@ -29,4 +29,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 currency = { workspace = true, features = ["testing"] }
-platform = { workspace = true, features = ["testing"]}
+platform = { workspace = true, features = ["testing"] }
+sdk = { workspace = true }
+serde_json = { workspace = true, default-features = false, features = ["std"] }

--- a/platform/packages/finance/src/duration/mod.rs
+++ b/platform/packages/finance/src/duration/mod.rs
@@ -5,11 +5,10 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use sdk::cosmwasm_std::Timestamp;
-
 use crate::{
     fraction::Unit as FractionUnit,
     fractionable::{CommonDoublePrimitive, Fractionable, IntoMax},
+    instant::Instant,
     ratio::SimpleFraction,
     rational::Rational,
 };
@@ -22,7 +21,7 @@ pub type Units = u64;
 pub type Seconds = u32;
 
 /// A more storage and compute optimal version of its counterpart in the std::time.
-/// Designed to represent a timespan between cosmwasm_std::Timestamp-s.
+/// Designed to represent a timespan between Instant-s.
 ///
 /// Implementation note: We use `as` safely for numeric upcasts instead of `from/into`
 /// in order to get const result.
@@ -66,7 +65,7 @@ impl Duration {
     }
 
     #[track_caller]
-    pub fn between(start: &Timestamp, end: &Timestamp) -> Self {
+    pub fn between(start: &Instant, end: &Instant) -> Self {
         debug_assert!(start <= end);
         Self(end.nanos() - start.nanos())
     }
@@ -109,7 +108,7 @@ impl Duration {
     }
 }
 
-impl Add<Duration> for Timestamp {
+impl Add<Duration> for Instant {
     type Output = Self;
 
     #[track_caller]
@@ -118,8 +117,8 @@ impl Add<Duration> for Timestamp {
     }
 }
 
-impl Add<Duration> for &Timestamp {
-    type Output = Timestamp;
+impl Add<Duration> for &Instant {
+    type Output = Instant;
 
     #[track_caller]
     fn add(self, rhs: Duration) -> Self::Output {
@@ -127,7 +126,7 @@ impl Add<Duration> for &Timestamp {
     }
 }
 
-impl AddAssign<Duration> for Timestamp {
+impl AddAssign<Duration> for Instant {
     #[track_caller]
     fn add_assign(&mut self, rhs: Duration) {
         *self = self.add(rhs);
@@ -143,7 +142,7 @@ impl Add<Duration> for Duration {
     }
 }
 
-impl Sub<Duration> for Timestamp {
+impl Sub<Duration> for Instant {
     type Output = Self;
 
     #[track_caller]
@@ -152,8 +151,8 @@ impl Sub<Duration> for Timestamp {
     }
 }
 
-impl Sub<Duration> for &Timestamp {
-    type Output = Timestamp;
+impl Sub<Duration> for &Instant {
+    type Output = Instant;
 
     #[track_caller]
     fn sub(self, rhs: Duration) -> Self::Output {
@@ -161,7 +160,7 @@ impl Sub<Duration> for &Timestamp {
     }
 }
 
-impl SubAssign<Duration> for Timestamp {
+impl SubAssign<Duration> for Instant {
     #[track_caller]
     fn sub_assign(&mut self, rhs: Duration) {
         *self = self.sub(rhs);
@@ -186,11 +185,11 @@ impl Display for Duration {
 #[cfg(test)]
 mod tests {
     use currency::test::SubGroupTestC10;
-    use sdk::cosmwasm_std::Timestamp as T;
 
     use crate::{
         coin::{Amount, Coin},
         duration::{Duration as D, Seconds, Units},
+        instant::Instant as T,
         zero::Zero,
     };
 

--- a/platform/packages/finance/src/instant.rs
+++ b/platform/packages/finance/src/instant.rs
@@ -1,0 +1,160 @@
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+const NANOS_PER_SECOND: u64 = 1_000_000_000;
+
+/// Wall-clock instant denominated in nanoseconds since the Unix epoch.
+///
+/// Owned by `finance`. Replaces `cosmwasm_std::Timestamp` for any code path
+/// that does not directly meet the cosmwasm API. The serialised form is a
+/// stringified `u64` (e.g. `"1234567890"`) — identical to `Timestamp`'s wire
+/// shape — so `Item<Timestamp>` storage and inter-contract message fields
+/// can be migrated to `Instant` without touching persisted state.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Instant(u64);
+
+impl Instant {
+    pub const fn from_nanos(nanos: u64) -> Self {
+        Self(nanos)
+    }
+
+    pub const fn from_seconds(secs: u64) -> Self {
+        Self(secs * NANOS_PER_SECOND)
+    }
+
+    pub const fn nanos(&self) -> u64 {
+        self.0
+    }
+
+    pub const fn seconds(&self) -> u64 {
+        self.0 / NANOS_PER_SECOND
+    }
+
+    pub const fn plus_nanos(&self, nanos: u64) -> Self {
+        Self(self.0 + nanos)
+    }
+
+    pub const fn minus_nanos(&self, nanos: u64) -> Self {
+        Self(self.0 - nanos)
+    }
+}
+
+impl Serialize for Instant {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Instant {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(InstantVisitor)
+    }
+}
+
+struct InstantVisitor;
+
+impl<'de> de::Visitor<'de> for InstantVisitor {
+    type Value = Instant;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "a u64 nanos value, accepted as either a JSON string or a JSON integer (matching cosmwasm_std::Timestamp / Uint64 leniency)")
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Instant(value))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        value.parse::<u64>().map(Instant).map_err(E::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::Instant;
+
+    #[test]
+    fn round_trip_wire_string_pin() {
+        let value = Instant::from_nanos(1_234_567_890);
+        let encoded = serde_json::to_string(&value).expect("serialize");
+        assert_eq!(r#""1234567890""#, encoded);
+        let decoded: Instant = serde_json::from_str(&encoded).expect("decode own output");
+        assert_eq!(value, decoded);
+    }
+
+    #[test]
+    fn cross_format_deserialise_string_and_integer() {
+        let stringified: Instant =
+            serde_json::from_str(r#""1234567890""#).expect("stringified u64 accepted");
+        let raw_integer: Instant =
+            serde_json::from_str(r#"1234567890"#).expect("raw integer accepted");
+        assert_eq!(stringified, raw_integer);
+        assert_eq!(Instant::from_nanos(1_234_567_890), stringified);
+    }
+
+    #[test]
+    fn cosmwasm_timestamp_wire_compatibility() {
+        let ts = sdk::cosmwasm_std::Timestamp::from_nanos(7_777_777_777);
+        let ts_encoded = serde_json::to_string(&ts).expect("serialize Timestamp");
+        let inst: Instant =
+            serde_json::from_str(&ts_encoded).expect("decode Timestamp wire bytes as Instant");
+        assert_eq!(Instant::from_nanos(7_777_777_777), inst);
+
+        let inst_encoded = serde_json::to_string(&inst).expect("serialize Instant");
+        assert_eq!(ts_encoded, inst_encoded);
+    }
+
+    #[test]
+    fn default_is_epoch_zero() {
+        assert_eq!(Instant::from_nanos(0), Instant::default());
+        assert_eq!(Instant::from_seconds(0), Instant::default());
+        assert_eq!(0, Instant::default().nanos());
+    }
+
+    #[test]
+    fn from_seconds_matches_from_nanos_times_1e9() {
+        assert_eq!(
+            Instant::from_nanos(60 * 1_000_000_000),
+            Instant::from_seconds(60),
+        );
+        assert_eq!(60, Instant::from_seconds(60).seconds());
+    }
+
+    #[test]
+    fn plus_minus_nanos_round_trip() {
+        let base = Instant::from_seconds(100);
+        assert_eq!(base, base.plus_nanos(42).minus_nanos(42));
+        assert_eq!(
+            Instant::from_nanos(100 * 1_000_000_000 + 42),
+            base.plus_nanos(42),
+        );
+    }
+
+    #[test]
+    fn ordering_is_total_and_consistent() {
+        let a = Instant::from_nanos(10);
+        let b = Instant::from_nanos(20);
+        let c = Instant::from_nanos(30);
+        assert!(a < b);
+        assert!(b < c);
+        assert!(a < c);
+        let set: BTreeSet<_> = [c, a, b].into_iter().collect();
+        let ordered: Vec<_> = set.iter().copied().collect();
+        assert_eq!(vec![a, b, c], ordered);
+    }
+}

--- a/platform/packages/finance/src/instant.rs
+++ b/platform/packages/finance/src/instant.rs
@@ -38,6 +38,25 @@ impl Instant {
     pub const fn minus_nanos(&self, nanos: u64) -> Self {
         Self(self.0 - nanos)
     }
+
+    pub const fn plus_seconds(&self, secs: u64) -> Self {
+        self.plus_nanos(secs * NANOS_PER_SECOND)
+    }
+
+    pub const fn plus_days(&self, days: u64) -> Self {
+        self.plus_seconds(days * 86_400)
+    }
+}
+
+impl fmt::Display for Instant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}.{:09}",
+            self.0 / NANOS_PER_SECOND,
+            self.0 % NANOS_PER_SECOND
+        )
+    }
 }
 
 impl Serialize for Instant {
@@ -64,7 +83,10 @@ impl<'de> de::Visitor<'de> for InstantVisitor {
     type Value = Instant;
 
     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "a u64 nanos value, accepted as either a JSON string or a JSON integer (matching cosmwasm_std::Timestamp / Uint64 leniency)")
+        write!(
+            f,
+            "a u64 nanos value, accepted as either a JSON string or a JSON integer (matching cosmwasm_std::Timestamp / Uint64 leniency)"
+        )
     }
 
     fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>

--- a/platform/packages/finance/src/lib.rs
+++ b/platform/packages/finance/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod flatten;
 pub mod fraction;
 pub mod fractionable;
+pub mod instant;
 pub mod interest;
 pub mod liability;
 pub mod percent;

--- a/platform/packages/finance/src/period.rs
+++ b/platform/packages/finance/src/period.rs
@@ -2,36 +2,36 @@ use std::ops::{Add, Sub};
 
 use serde::{Deserialize, Serialize};
 
-use sdk::cosmwasm_std::Timestamp;
+use crate::instant::Instant;
 
 use crate::duration::Duration;
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Period {
-    start: Timestamp,
+    start: Instant,
     length: Duration,
 }
 
 impl Period {
-    pub fn from_till(start: Timestamp, till: &Timestamp) -> Self {
+    pub fn from_till(start: Instant, till: &Instant) -> Self {
         debug_assert!(&start <= till);
         Self::from_length(start, Duration::between(&start, till))
     }
 
-    pub fn from_length(start: Timestamp, length: Duration) -> Self {
+    pub fn from_length(start: Instant, length: Duration) -> Self {
         Self { start, length }
     }
 
-    pub fn till_length(till: &Timestamp, max_length: Duration) -> Self {
-        let start = if till < &Timestamp::default().add(max_length) {
-            Timestamp::default()
+    pub fn till_length(till: &Instant, max_length: Duration) -> Self {
+        let start = if till < &Instant::default().add(max_length) {
+            Instant::default()
         } else {
             till.sub(max_length)
         };
         Self::from_till(start, till)
     }
 
-    pub fn start(&self) -> Timestamp {
+    pub fn start(&self) -> Instant {
         self.start
     }
 
@@ -43,7 +43,7 @@ impl Period {
         self.length() == Duration::default()
     }
 
-    pub fn till(&self) -> Timestamp {
+    pub fn till(&self) -> Instant {
         self.start + self.length
     }
 
@@ -76,14 +76,14 @@ impl Period {
         )
     }
 
-    fn move_within(&self, timestamp: Timestamp) -> Timestamp {
+    fn move_within(&self, timestamp: Instant) -> Instant {
         timestamp.clamp(self.start, self.till())
     }
 }
 
 #[cfg(test)]
 mod test {
-    use sdk::cosmwasm_std::Timestamp;
+    use crate::instant::Instant;
 
     use crate::duration::Duration;
 
@@ -97,18 +97,18 @@ mod test {
 
     #[test]
     fn till_length() {
-        let p = Period::till_length(&Timestamp::from_seconds(1000), Duration::from_secs(200));
+        let p = Period::till_length(&Instant::from_seconds(1000), Duration::from_secs(200));
 
         assert_eq!(from_till(800, 1000), p);
         assert!(!p.zero_length());
         assert!(
-            Period::till_length(&Timestamp::from_seconds(1000), Duration::default()).zero_length()
+            Period::till_length(&Instant::from_seconds(1000), Duration::default()).zero_length()
         );
     }
 
     #[test]
     fn till_length_max() {
-        let p = Period::till_length(&Timestamp::from_seconds(1000), Duration::from_secs(1000));
+        let p = Period::till_length(&Instant::from_seconds(1000), Duration::from_secs(1000));
 
         assert_eq!(from_till(0, 1000), p);
         assert!(!p.zero_length());
@@ -116,7 +116,7 @@ mod test {
 
     #[test]
     fn till_length_underflow() {
-        let p = Period::till_length(&Timestamp::from_seconds(200), Duration::from_secs(1000));
+        let p = Period::till_length(&Instant::from_seconds(200), Duration::from_secs(1000));
 
         assert_eq!(from_till(0, 200), p);
         assert!(!p.zero_length());
@@ -156,8 +156,8 @@ mod test {
 
     fn from_till(from_sec: u64, till_sec: u64) -> Period {
         Period::from_till(
-            Timestamp::from_seconds(from_sec),
-            &Timestamp::from_seconds(till_sec),
+            Instant::from_seconds(from_sec),
+            &Instant::from_seconds(till_sec),
         )
     }
 }

--- a/platform/packages/finance/src/zero.rs
+++ b/platform/packages/finance/src/zero.rs
@@ -1,5 +1,3 @@
-use sdk::cosmwasm_std::{Uint64, Uint128, Uint256, Uint512};
-
 pub trait Zero {
     const ZERO: Self;
 }
@@ -14,18 +12,6 @@ macro_rules! impl_zero {
     };
 }
 
-macro_rules! impl_cw_zero {
-    ($($type: ty),+ $(,)?) => {
-        $(
-            impl Zero for $type {
-                const ZERO: Self = Self::zero();
-            }
-        )+
-    };
-}
-
 impl_zero!(
     i8, u8, i16, u16, i32, u32, i64, u64, i128, u128, isize, usize
 );
-
-impl_cw_zero!(Uint64, Uint128, Uint256, Uint512);

--- a/platform/packages/platform/Cargo.toml
+++ b/platform/packages/platform/Cargo.toml
@@ -16,6 +16,7 @@ testing = ["currency/testing", "finance/testing", "sdk/testing"]
 
 [dependencies]
 currency = { workspace = true }
+cw-time = { workspace = true }
 finance = { workspace = true }
 sdk = { workspace = true, features = ["cosmos_ibc", "cosmos_proto"] }
 

--- a/platform/packages/platform/src/emit.rs
+++ b/platform/packages/platform/src/emit.rs
@@ -1,10 +1,12 @@
 use currency::{CurrencyDTO, CurrencyDef, Group};
+use cw_time::IntoInstant;
 use finance::{
     coin::{Amount, Coin, CoinDTO},
     fraction::Unit as FractionUnit,
+    instant::Instant,
     percent::Percent100,
 };
-use sdk::cosmwasm_std::{Env, Event, Timestamp};
+use sdk::cosmwasm_std::{Env, Event};
 
 pub trait Emit
 where
@@ -15,8 +17,8 @@ where
         K: Into<String>,
         V: Into<String>;
 
-    /// Specialization of [`emit`](Self::emit) for [`Timestamp`].
-    fn emit_timestamp<K>(self, event_key: K, timestamp: &Timestamp) -> Self
+    /// Specialization of [`emit`](Self::emit) for [`Instant`].
+    fn emit_timestamp<K>(self, event_key: K, timestamp: &Instant) -> Self
     where
         K: Into<String>,
     {
@@ -85,7 +87,7 @@ where
 
     fn emit_tx_info(self, env: &Env) -> Self {
         self.emit_to_string_value("height", env.block.height)
-            .emit_timestamp("at", &env.block.time)
+            .emit_timestamp("at", &env.block.time.into_instant())
             .emit_to_string_value(
                 "idx",
                 // TODO use `.expect(...)` when layer 1 upgrades to `wasmd` v0.29

--- a/platform/packages/time-oracle/Cargo.toml
+++ b/platform/packages/time-oracle/Cargo.toml
@@ -14,6 +14,7 @@ combinations = [
 ]
 
 [dependencies]
+finance = { workspace = true }
 sdk = { workspace = true, features = ["storage"] }
 
 thiserror = { workspace = true }

--- a/platform/packages/time-oracle/src/alarms.rs
+++ b/platform/packages/time-oracle/src/alarms.rs
@@ -1,7 +1,8 @@
 use std::ops::{Deref, DerefMut};
 
+use finance::instant::Instant;
 use sdk::{
-    cosmwasm_std::{Addr, Order, Storage, Timestamp},
+    cosmwasm_std::{Addr, Order, Storage},
     cw_storage_plus::{Bound, Deque, Index, IndexList, IndexedMap as CwIndexedMap, MultiIndex},
 };
 
@@ -9,7 +10,7 @@ use crate::AlarmError;
 
 type TimeSeconds = u64;
 
-fn as_seconds(from: Timestamp) -> TimeSeconds {
+fn as_seconds(from: Instant) -> TimeSeconds {
     from.seconds()
 }
 
@@ -63,7 +64,7 @@ where
 
     pub fn alarms_selection(
         &self,
-        ctime: Timestamp,
+        ctime: Instant,
     ) -> impl Iterator<Item = Result<Addr, AlarmError>> + use<'_, S> {
         self.alarms
             .idx
@@ -85,7 +86,7 @@ impl<'storage, S> Alarms<'storage, S>
 where
     S: Deref<Target = dyn Storage + 'storage> + DerefMut,
 {
-    pub fn add(&mut self, subscriber: Addr, time: Timestamp) -> Result<(), AlarmError> {
+    pub fn add(&mut self, subscriber: Addr, time: Instant) -> Result<(), AlarmError> {
         self.add_internal(subscriber, as_seconds(time))
     }
 
@@ -122,7 +123,7 @@ where
             })
     }
 
-    pub fn last_failed(&mut self, now: Timestamp) -> Result<(), AlarmError> {
+    pub fn last_failed(&mut self, now: Instant) -> Result<(), AlarmError> {
         self.in_delivery
             .pop_front(self.storage.deref_mut())
             .map_err(Into::into)
@@ -157,7 +158,7 @@ pub mod tests {
         S: Deref<Target = dyn Storage + 'r>,
     {
         alarms
-            .alarms_selection(Timestamp::from_seconds(t_sec))
+            .alarms_selection(Instant::from_seconds(t_sec))
             .map(Result::unwrap)
             .collect()
     }
@@ -167,8 +168,8 @@ pub mod tests {
         let mut storage = MockStorage::new();
         let mut alarms = alarms(&mut storage);
 
-        let t1 = Timestamp::from_seconds(1);
-        let t2 = Timestamp::from_seconds(3);
+        let t1 = Instant::from_seconds(1);
+        let t2 = Instant::from_seconds(3);
         let addr1 = Addr::unchecked("addr1");
         let addr2 = Addr::unchecked("addr2");
 
@@ -191,10 +192,10 @@ pub mod tests {
         let mut storage = MockStorage::new();
         let mut alarms = alarms(&mut storage);
 
-        let t1 = Timestamp::from_seconds(1);
-        let t2 = Timestamp::from_seconds(2);
+        let t1 = Instant::from_seconds(1);
+        let t2 = Instant::from_seconds(2);
         let t3_sec = 3;
-        let t4 = Timestamp::from_seconds(4);
+        let t4 = Instant::from_seconds(4);
         let addr1 = Addr::unchecked("addr1");
         let addr2 = Addr::unchecked("addr2");
         let addr3 = Addr::unchecked("addr3");

--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -519,6 +519,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-time"
+version = "0.1.0"
+dependencies = [
+ "finance",
+ "sdk",
+]
+
+[[package]]
 name = "cw-utils"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +620,7 @@ version = "0.2.3"
 dependencies = [
  "access-control",
  "currency",
+ "cw-time",
  "finance",
  "oracle",
  "oracle-platform",
@@ -775,7 +784,6 @@ dependencies = [
  "currency",
  "gcd",
  "num-integer",
- "sdk",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -998,6 +1006,7 @@ dependencies = [
  "cosmwasm-std",
  "currencies",
  "currency",
+ "cw-time",
  "dex",
  "enum_dispatch",
  "finance",
@@ -1052,6 +1061,7 @@ dependencies = [
  "cosmwasm-std",
  "currencies",
  "currency",
+ "cw-time",
  "finance",
  "lpp-platform",
  "oracle",
@@ -1141,6 +1151,7 @@ dependencies = [
  "cosmwasm-std",
  "currencies",
  "currency",
+ "cw-time",
  "finance",
  "marketprice",
  "oracle-platform",
@@ -1196,6 +1207,7 @@ name = "platform"
 version = "0.4.0"
 dependencies = [
  "currency",
+ "cw-time",
  "finance",
  "sdk",
  "serde",
@@ -1243,6 +1255,7 @@ dependencies = [
  "cosmwasm-std",
  "currencies",
  "currency",
+ "cw-time",
  "dex",
  "finance",
  "oracle",
@@ -1812,6 +1825,8 @@ name = "timealarms"
 version = "0.5.2"
 dependencies = [
  "access-control",
+ "cw-time",
+ "finance",
  "platform",
  "sdk",
  "serde",

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -56,6 +56,7 @@ timealarms = { path = "../platform/contracts/timealarms", default-features = fal
 # Platform Packages
 access-control = { path = "../platform/packages/access-control", default-features = false }
 currency = { path = "../platform/packages/currency", default-features = false }
+cw-time = { path = "../platform/packages/cw-time", default-features = false }
 finance = { path = "../platform/packages/finance", default-features = false }
 lpp-platform = { path = "../platform/packages/lpp", default-features = false }
 oracle-platform = { path = "../platform/packages/oracle", default-features = false }

--- a/protocol/contracts/lease/Cargo.toml
+++ b/protocol/contracts/lease/Cargo.toml
@@ -69,6 +69,7 @@ skel_testing = [
 ]
 
 [dependencies]
+cw-time = { workspace = true }
 profit = { workspace = true, optional = true, features = ["stub"] }
 reserve = { workspace = true, optional = true, features = ["stub"] }
 timealarms = { workspace = true, optional = true, features = ["stub"] }

--- a/protocol/contracts/lease/src/api/query.rs
+++ b/protocol/contracts/lease/src/api/query.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
 
 use currency::CurrencyDTO;
+use finance::instant::Instant;
 use finance::{
     duration::{Duration, Seconds},
     percent::Percent100,
 };
-use sdk::cosmwasm_std::Timestamp;
 
 use crate::finance::LpnCoinDTO;
 
@@ -60,7 +60,7 @@ pub enum StateResponse {
         #[serde(rename = "due_projection_ns")]
         due_projection: Duration,
         close_policy: ClosePolicy,
-        validity: Timestamp,
+        validity: Instant,
         status: opened::Status,
     },
     Closing {

--- a/protocol/contracts/lease/src/contract/api.rs
+++ b/protocol/contracts/lease/src/contract/api.rs
@@ -1,8 +1,9 @@
 use enum_dispatch::enum_dispatch;
 
 use finance::duration::Duration;
+use finance::instant::Instant;
 use platform::ica::ErrorResponse as ICAErrorResponse;
-use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply, Timestamp};
+use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply};
 
 use crate::{
     api::{
@@ -91,7 +92,7 @@ where
 
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> ContractResult<StateResponse>;

--- a/protocol/contracts/lease/src/contract/cmd/close_full.rs
+++ b/protocol/contracts/lease/src/contract/cmd/close_full.rs
@@ -1,8 +1,8 @@
 use currency::{CurrencyDef, MemberOf};
+use finance::instant::Instant;
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
 use platform::{bank::FixedAddressSender, message::Response as MessageResponse};
-use sdk::cosmwasm_std::Timestamp;
 
 use crate::{
     api::{LeaseAssetCurrencies, LeasePaymentCurrencies},
@@ -15,7 +15,7 @@ use super::repayable::Emitter;
 
 pub(crate) struct Close<ProfitSender, ChangeSender, EmitterT> {
     payment: LpnCoinDTO,
-    now: Timestamp,
+    now: Instant,
     profit: ProfitSender,
     reserve: ReserveRef,
     change: ChangeSender,
@@ -25,7 +25,7 @@ pub(crate) struct Close<ProfitSender, ChangeSender, EmitterT> {
 impl<ProfitSender, ChangeSender, EmitterT> Close<ProfitSender, ChangeSender, EmitterT> {
     pub fn new(
         payment: LpnCoinDTO,
-        now: Timestamp,
+        now: Instant,
         profit: ProfitSender,
         reserve: ReserveRef,
         change: ChangeSender,

--- a/protocol/contracts/lease/src/contract/cmd/close_partial.rs
+++ b/protocol/contracts/lease/src/contract/cmd/close_partial.rs
@@ -1,8 +1,8 @@
 use currency::{CurrencyDef, MemberOf};
+use finance::instant::Instant;
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
 use platform::bank::FixedAddressSender;
-use sdk::cosmwasm_std::Timestamp;
 
 use crate::{
     api::{LeaseAssetCurrencies, LeaseCoin, LeasePaymentCurrencies},
@@ -27,7 +27,7 @@ impl RepayFn for CloseFn {
         self,
         lease: &mut Lease<Asset, Lpp, Oracle>,
         payment: LpnCoin,
-        now: &Timestamp,
+        now: &Instant,
         profit: &mut Profit,
     ) -> ContractResult<RepayReceipt>
     where

--- a/protocol/contracts/lease/src/contract/cmd/close_policy/change.rs
+++ b/protocol/contracts/lease/src/contract/cmd/close_policy/change.rs
@@ -1,8 +1,8 @@
 use currency::{CurrencyDef, MemberOf};
+use finance::instant::Instant;
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
 use profit::stub::ProfitRef;
-use sdk::cosmwasm_std::Timestamp;
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
@@ -17,7 +17,7 @@ use super::CloseStatusDTO;
 
 pub(crate) struct ChangeCmd<'now, 'price_alarms> {
     change: ClosePolicyChange,
-    now: &'now Timestamp,
+    now: &'now Instant,
     // LeaseDTO attributes
     profit: ProfitRef,
     reserve: ReserveRef,
@@ -31,7 +31,7 @@ pub(crate) type ChangePolicyResult = LeaseDTOResult<CloseStatusDTO>;
 impl<'now, 'price_alarms> ChangeCmd<'now, 'price_alarms> {
     pub fn new(
         change: ClosePolicyChange,
-        now: &'now Timestamp,
+        now: &'now Instant,
         // LeaseDTO attributes follow
         profit: ProfitRef,
         time_alarms: TimeAlarmsRef,

--- a/protocol/contracts/lease/src/contract/cmd/close_policy/check.rs
+++ b/protocol/contracts/lease/src/contract/cmd/close_policy/check.rs
@@ -1,7 +1,7 @@
 use currency::{CurrencyDef, MemberOf};
+use finance::instant::Instant;
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
-use sdk::cosmwasm_std::Timestamp;
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
@@ -15,7 +15,7 @@ use super::CloseStatusDTO;
 
 pub(crate) fn check<Asset, Lpp, Oracle>(
     lease: &LeaseDO<Asset, Lpp, Oracle>,
-    when: &Timestamp,
+    when: &Instant,
     time_alarms: &TimeAlarmsRef,
     price_alarms: &OracleRef,
 ) -> ContractResult<CloseStatusDTO>
@@ -32,14 +32,14 @@ where
 }
 
 pub(crate) struct CheckCmd<'a> {
-    now: &'a Timestamp,
+    now: &'a Instant,
     time_alarms: &'a TimeAlarmsRef,
     price_alarms: &'a OracleRef,
 }
 
 impl<'a> CheckCmd<'a> {
     pub fn new(
-        now: &'a Timestamp,
+        now: &'a Instant,
         time_alarms: &'a TimeAlarmsRef,
         price_alarms: &'a OracleRef,
     ) -> Self {

--- a/protocol/contracts/lease/src/contract/cmd/close_policy/mod.rs
+++ b/protocol/contracts/lease/src/contract/cmd/close_policy/mod.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 use currency::{CurrencyDef, MemberOf};
+use finance::instant::Instant;
 use finance::liability::Zone;
 use platform::batch::Batch;
-use sdk::cosmwasm_std::Timestamp;
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
@@ -46,7 +46,7 @@ pub(crate) struct FullLiquidationDTO {
 impl CloseStatusDTO {
     fn try_from_do<Asset>(
         status: CloseStatus<Asset>,
-        when: &Timestamp,
+        when: &Instant,
         time_alarms: &TimeAlarmsRef,
         price_alarms: &OracleRef,
     ) -> ContractResult<Self>

--- a/protocol/contracts/lease/src/contract/cmd/open.rs
+++ b/protocol/contracts/lease/src/contract/cmd/open.rs
@@ -1,8 +1,9 @@
 use currency::{CurrencyDef, MemberOf};
+use finance::instant::Instant;
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
 use profit::stub::ProfitRef;
-use sdk::cosmwasm_std::{Addr, Timestamp};
+use sdk::cosmwasm_std::Addr;
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
@@ -24,8 +25,8 @@ pub struct LeaseFactory<'a> {
     reserve: ReserveRef,
     time_alarms: TimeAlarmsRef,
     price_alarms: OracleRef,
-    start_at: Timestamp,
-    now: &'a Timestamp,
+    start_at: Instant,
+    now: &'a Instant,
 }
 
 pub type OpenLeaseResult = LeaseDTOResult<CloseStatusDTO>;
@@ -37,8 +38,8 @@ impl<'a> LeaseFactory<'a> {
         profit: ProfitRef,
         reserve: ReserveRef,
         alarms: (TimeAlarmsRef, OracleRef),
-        start_at: Timestamp,
-        now: &'a Timestamp,
+        start_at: Instant,
+        now: &'a Instant,
     ) -> Self {
         Self {
             form,

--- a/protocol/contracts/lease/src/contract/cmd/repay.rs
+++ b/protocol/contracts/lease/src/contract/cmd/repay.rs
@@ -1,8 +1,8 @@
 use currency::{Currency, MemberOf};
+use finance::instant::Instant;
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
 use platform::bank::FixedAddressSender;
-use sdk::cosmwasm_std::Timestamp;
 
 use crate::{
     api::{LeaseAssetCurrencies, LeasePaymentCurrencies},
@@ -20,7 +20,7 @@ impl RepayFn for RepayLeaseFn {
         self,
         lease: &mut Lease<Asset, Lpp, Oracle>,
         payment: LpnCoin,
-        now: &Timestamp,
+        now: &Instant,
         profit: &mut Profit,
     ) -> ContractResult<RepayReceipt>
     where

--- a/protocol/contracts/lease/src/contract/cmd/repayable.rs
+++ b/protocol/contracts/lease/src/contract/cmd/repayable.rs
@@ -1,4 +1,5 @@
 use currency::{CurrencyDef, MemberOf};
+use finance::instant::Instant;
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
 use platform::{
@@ -6,7 +7,7 @@ use platform::{
     message::Response as MessageResponse,
 };
 use profit::stub::ProfitRef;
-use sdk::cosmwasm_std::{Addr, Timestamp};
+use sdk::cosmwasm_std::Addr;
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
@@ -29,7 +30,7 @@ pub(crate) trait RepayFn {
         self,
         lease: &mut LeaseDO<Asset, Lpp, Oracle>,
         amount: LpnCoin,
-        now: &Timestamp,
+        now: &Instant,
         profit: &mut Profit,
     ) -> ContractResult<RepayReceipt>
     where
@@ -52,7 +53,7 @@ where
 {
     repay_fn: RepayableT,
     amount: LpnCoinDTO,
-    now: &'now Timestamp,
+    now: &'now Instant,
     emitter_fn: EmitterT,
     profit: ProfitRef,
     alarms: (TimeAlarmsRef, &'price_alarm OracleRef),
@@ -67,7 +68,7 @@ where
     pub fn new(
         repay_fn: RepayableT,
         amount: LpnCoinDTO,
-        now: &'now Timestamp,
+        now: &'now Instant,
         emitter_fn: EmitterT,
         profit: ProfitRef,
         alarms: (TimeAlarmsRef, &'price_alarm OracleRef),
@@ -87,7 +88,7 @@ where
     fn check_close_with_init<'time_alarm, Asset, Lpp, Oracle>(
         lease: &mut LeaseDO<Asset, Lpp, Oracle>,
         receipt_close: bool,
-        now: &'now Timestamp,
+        now: &'now Instant,
         time_alarm: &'time_alarm TimeAlarmsRef,
         price_alarm: &'price_alarm OracleRef,
     ) -> ContractResult<CloseStatusDTO>
@@ -208,7 +209,7 @@ mod test {
     use lpp::msg::LoanResponse;
     use platform::batch::Emitter as PlatformEmitter;
     use profit::stub::ProfitRef;
-    use sdk::cosmwasm_std::{Addr, Timestamp};
+    use sdk::cosmwasm_std::Addr;
     use timealarms::stub::TimeAlarmsRef;
 
     use crate::{
@@ -230,7 +231,7 @@ mod test {
     }
     #[test]
     fn reset_take_profit() {
-        let now = Timestamp::from_seconds(24412515);
+        let now = Instant::from_seconds(24412515);
         let lease_amount = Coin::new(1000);
         let lease_lpn = price::total(lease_amount, Price::identity()).unwrap();
         let current_ltv = Percent::from_percent(30);
@@ -269,7 +270,7 @@ mod test {
         }
     }
 
-    fn repay(lease: TestLease, payment: Coin<TestLpn>, now: &Timestamp) -> CloseStatusDTO {
+    fn repay(lease: TestLease, payment: Coin<TestLpn>, now: &Instant) -> CloseStatusDTO {
         let oracle = OracleRef::unchecked(Addr::unchecked("price_alarms_addr"));
 
         let cmd = Repay::new(

--- a/protocol/contracts/lease/src/contract/cmd/repayable.rs
+++ b/protocol/contracts/lease/src/contract/cmd/repayable.rs
@@ -201,6 +201,7 @@ mod test {
     use finance::{
         coin::Coin,
         fraction::Fraction,
+        instant::Instant,
         liability::Zone,
         percent::{Percent, Percent100},
         price::{self, Price},

--- a/protocol/contracts/lease/src/contract/cmd/state.rs
+++ b/protocol/contracts/lease/src/contract/cmd/state.rs
@@ -1,8 +1,8 @@
 use currency::{CurrencyDef, MemberOf};
 use finance::duration::Duration;
+use finance::instant::Instant;
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
-use sdk::cosmwasm_std::Timestamp;
 
 use crate::{
     api::{
@@ -15,13 +15,13 @@ use crate::{
 };
 
 pub struct LeaseState {
-    now: Timestamp,
+    now: Instant,
     due_projection: Duration,
     status: Status,
 }
 
 impl LeaseState {
-    pub fn new(now: Timestamp, due_projection: Duration, status: Status) -> Self {
+    pub fn new(now: Instant, due_projection: Duration, status: Status) -> Self {
         Self {
             now,
             due_projection,

--- a/protocol/contracts/lease/src/contract/endpoins.rs
+++ b/protocol/contracts/lease/src/contract/endpoins.rs
@@ -25,6 +25,7 @@ use crate::{
 };
 
 use super::state::{self, Response, State};
+use cw_time::IntoInstant;
 
 const CONTRACT_STORAGE_VERSION: VersionSegment = 9;
 const CURRENT_RELEASE: ProtocolPackageRelease = ProtocolPackageRelease::current(
@@ -109,7 +110,7 @@ pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> 
         QueryMsg::State { due_projection } => state::load(deps.storage)
             .and_then(|state| {
                 state.state(
-                    env.block.time,
+                    env.block.time.into_instant(),
                     Duration::from_secs(due_projection),
                     deps.querier,
                 )

--- a/protocol/contracts/lease/src/contract/state/closed.rs
+++ b/protocol/contracts/lease/src/contract/state/closed.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use finance::duration::Duration;
-use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper, Timestamp};
+use finance::instant::Instant;
+use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper};
 
 use crate::{api::query::StateResponse, error::ContractResult};
 
@@ -13,7 +14,7 @@ pub struct Closed {}
 impl Handler for Closed {
     fn state(
         self,
-        _now: Timestamp,
+        _now: Instant,
         _due_projection: Duration,
         _querier: QuerierWrapper<'_>,
     ) -> ContractResult<StateResponse> {

--- a/protocol/contracts/lease/src/contract/state/dex.rs
+++ b/protocol/contracts/lease/src/contract/state/dex.rs
@@ -2,8 +2,9 @@ use serde::{Deserialize, Serialize};
 
 use dex::{Contract as DexContract, Handler as DexHandler};
 use finance::duration::Duration;
+use finance::instant::Instant;
 use platform::{ica::ErrorResponse as ICAErrorResponse, state_machine};
-use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply, Timestamp};
+use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply};
 
 use crate::{
     api::query::StateResponse as QueryStateResponse,
@@ -95,7 +96,7 @@ where
 
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> ContractResult<ContractStateResponse> {

--- a/protocol/contracts/lease/src/contract/state/handler.rs
+++ b/protocol/contracts/lease/src/contract/state/handler.rs
@@ -1,8 +1,9 @@
 use enum_dispatch::enum_dispatch;
 
 use finance::duration::Duration;
+use finance::instant::Instant;
 use platform::state_machine::Response as StateMachineResponse;
-use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper, Reply, Timestamp};
+use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper, Reply};
 
 use crate::{
     api::{
@@ -27,7 +28,7 @@ where
 {
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> ContractResult<StateResponse>;

--- a/protocol/contracts/lease/src/contract/state/lease.rs
+++ b/protocol/contracts/lease/src/contract/state/lease.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use finance::duration::Duration;
-use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper, Reply, Timestamp};
+use finance::instant::Instant;
+use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper, Reply};
 
 use crate::{
     api::{
@@ -31,7 +32,7 @@ where
 {
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> ContractResult<StateResponse> {

--- a/protocol/contracts/lease/src/contract/state/liquidated.rs
+++ b/protocol/contracts/lease/src/contract/state/liquidated.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use finance::duration::Duration;
-use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper, Timestamp};
+use finance::instant::Instant;
+use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper};
 
 use crate::{api::query::StateResponse, error::ContractResult};
 
@@ -13,7 +14,7 @@ pub struct Liquidated {}
 impl Handler for Liquidated {
     fn state(
         self,
-        _now: Timestamp,
+        _now: Instant,
         _due_projection: Duration,
         _querier: QuerierWrapper<'_>,
     ) -> ContractResult<StateResponse> {

--- a/protocol/contracts/lease/src/contract/state/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/mod.rs
@@ -9,7 +9,7 @@ use platform::{
     batch::Batch, ica::ErrorResponse as ICAErrorResponse, message::Response as MessageResponse,
 };
 use sdk::{
-    cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply, Storage, Timestamp},
+    cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply, Storage},
     cw_storage_plus::Item,
 };
 use swap::Impl;
@@ -26,6 +26,7 @@ use crate::{
 
 pub(crate) use self::handler::{Handler, Response};
 use self::{dex::State as DexState, lease::State as LeaseState};
+use finance::instant::Instant;
 
 mod closed;
 mod dex;

--- a/protocol/contracts/lease/src/contract/state/opened/active.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/active.rs
@@ -2,10 +2,12 @@ use serde::{Deserialize, Serialize};
 
 use access_control::composite::Permission as CompositePermission;
 use currency::CurrencyDef;
+use cw_time::IntoInstant;
 use dex::Enterable;
+use finance::instant::Instant;
 use finance::{coin::IntoDTO, duration::Duration};
 use platform::{bank, batch::Emitter, message::Response as MessageResponse};
-use sdk::cosmwasm_std::{Coin as CwCoin, Env, MessageInfo, QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::{Coin as CwCoin, Env, MessageInfo, QuerierWrapper};
 use timealarms::stub::TimeAlarmDelivery;
 
 use crate::{
@@ -71,7 +73,7 @@ impl Active {
                 debug_assert!(payment.of_currency_dto(LpnCurrency::dto()).is_ok());
                 repay::repay(self.lease, payment, env, querier)
             }
-            None => self.start_swap(info.funds, env.block.time, querier),
+            None => self.start_swap(info.funds, env.block.time.into_instant(), querier),
         }
     }
 
@@ -88,7 +90,11 @@ impl Active {
         let time_alarms_ref = self.lease.lease.time_alarms.clone();
         let oracle_ref = self.lease.lease.oracle.clone();
         let close_status = self.lease.lease.clone().execute(
-            CloseStatusCmd::new(&env.block.time, &time_alarms_ref, &oracle_ref),
+            CloseStatusCmd::new(
+                &env.block.time.into_instant(),
+                &time_alarms_ref,
+                &oracle_ref,
+            ),
             querier,
         )?;
 
@@ -119,7 +125,7 @@ impl Active {
     fn start_swap(
         self,
         cw_amount: Vec<CwCoin>,
-        now: Timestamp,
+        now: Instant,
         querier: QuerierWrapper<'_>,
     ) -> ContractResult<Response> {
         self.lease
@@ -145,7 +151,7 @@ impl From<Active> for Lease {
 impl Handler for Active {
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> ContractResult<StateResponse> {
@@ -181,7 +187,7 @@ impl Handler for Active {
             self.lease.update(
                 ChangeClosePolicy::new(
                     change,
-                    &env.block.time,
+                    &env.block.time.into_instant(),
                     profit,
                     time_alarms,
                     &oracle_ref,

--- a/protocol/contracts/lease/src/contract/state/opened/close/anomaly.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/anomaly.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use finance::duration::Duration;
-use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper, Timestamp};
+use finance::instant::Instant;
+use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper};
 
 use crate::{
     api::query::{StateResponse, opened::Status},
@@ -34,7 +35,7 @@ impl SlippageAnomaly {
 impl Handler for SlippageAnomaly {
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> ContractResult<StateResponse> {

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
@@ -8,11 +8,12 @@ use dex::{
     Account, AnomalyTreatment, ContractInSwap, SlippageCalculator, Stage, SwapOutputTask, SwapTask,
     WithCalculator, WithOutputTask,
 };
+use finance::instant::Instant;
 use finance::{
     coin::{Coin, CoinDTO},
     duration::Duration,
 };
-use sdk::cosmwasm_std::{Env, QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::{Env, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
@@ -74,7 +75,7 @@ where
     fn query(
         self,
         in_progress: PositionCloseTrx,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> ContractResult<QueryStateResponse> {
@@ -182,7 +183,7 @@ where
     fn state(
         self,
         in_progress: Stage,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/task.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/task.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 
 use super::{DexState, Task};
+use cw_time::IntoInstant;
 
 pub(super) trait ClosePositionTask<CalculatorT>
 where
@@ -33,7 +34,7 @@ where
 where {
         let start_state = dex::start_remote_local(Task::new(lease, self.into(), slippage_calc));
         start_state
-            .enter(env.block.time, querier)
+            .enter(env.block.time.into_instant(), querier)
             .map(|swap_msg| curr_request_response.merge_with(swap_msg))
             .map(|start| {
                 Response::from(

--- a/protocol/contracts/lease/src/contract/state/opened/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/mod.rs
@@ -1,5 +1,6 @@
 use finance::duration::Duration;
-use sdk::cosmwasm_std::{QuerierWrapper, Timestamp};
+use finance::instant::Instant;
+use sdk::cosmwasm_std::QuerierWrapper;
 
 use crate::{
     api::query::{StateResponse, opened::Status},
@@ -19,7 +20,7 @@ pub mod repay;
 fn lease_state(
     lease: Lease,
     status: Status,
-    now: Timestamp,
+    now: Instant,
     due_projection: Duration,
     querier: QuerierWrapper<'_>,
 ) -> ContractResult<StateResponse> {

--- a/protocol/contracts/lease/src/contract/state/opened/payment/close.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/payment/close.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 
 use super::Repayable;
+use cw_time::IntoInstant;
 
 pub(crate) trait CloseAlgo {
     type OutState: Default + Into<State>;
@@ -97,7 +98,7 @@ where
                     .execute(
                         FullCloseCmd::new(
                             amount,
-                            env.block.time,
+                            env.block.time.into_instant(),
                             profit,
                             reserve,
                             change,

--- a/protocol/contracts/lease/src/contract/state/opened/payment/repay.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/payment/repay.rs
@@ -29,6 +29,7 @@ use crate::{
 };
 
 use super::Repayable;
+use cw_time::IntoInstant;
 
 pub(crate) trait RepayAlgo {
     type RepayFn: RepayFn;
@@ -91,7 +92,7 @@ where
             RepayCmd::new(
                 self.0.repay_fn(),
                 amount,
-                &env.block.time,
+                &env.block.time.into_instant(),
                 self.0.emitter_fn(env),
                 profit,
                 (time_alarms, &price_alarms),

--- a/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
@@ -8,11 +8,12 @@ use dex::{
     AcceptAnyNonZeroSwap, Account, AnomalyTreatment, ContractInSwap, Stage, StartLocalLocalState,
     SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
 };
+use finance::instant::Instant;
 use finance::{
     coin::{Coin, CoinDTO},
     duration::Duration,
 };
-use sdk::cosmwasm_std::{Env, QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::{Env, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
@@ -57,7 +58,7 @@ impl BuyLpn {
     fn query(
         self,
         in_progress: RepayTrx,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> ContractResult<ContractStateResponse> {
@@ -156,7 +157,7 @@ impl ContractInSwap for BuyLpn {
     fn state(
         self,
         in_progress: Stage,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/finish.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/finish.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 
 use super::BuyAsset;
+use cw_time::IntoInstant;
 
 pub struct BuyAssetFinish<SwapTask, OutC> {
     swap_task: SwapTask,
@@ -82,6 +83,7 @@ where
             .try_into()
             .map(|spec| Position::new(amount_out, spec))?;
         let lease_addr = spec.dex_account.owner().clone();
+        let now = env.block.time.into_instant();
         let cmd = {
             let profit = ProfitRef::new(spec.form.loan.profit.clone(), &querier)?;
             let reserve = ReserveRef::try_new(spec.form.reserve.clone(), &querier)?;
@@ -93,7 +95,7 @@ where
                 reserve,
                 (spec.deps.2, spec.deps.1.clone()),
                 spec.start_opening_at,
-                &env.block.time,
+                &now,
             )
         };
         let OpenLeaseResult {

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -8,9 +8,10 @@ use dex::{
     Account, ContractInSwap, Stage, StartLocalRemoteState, SwapOutputTask, SwapTask,
     WithCalculator, WithOutputTask,
 };
+use finance::instant::Instant;
 use finance::{coin::CoinDTO, duration::Duration};
 use platform::ica::HostAccount;
-use sdk::cosmwasm_std::{QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::QuerierWrapper;
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
@@ -53,7 +54,7 @@ pub(super) fn start(
     downpayment: DownpaymentCoin,
     loan: OpenLoanRespResult,
     deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
-    start_opening_at: Timestamp,
+    start_opening_at: Instant,
 ) -> StartState {
     dex::start_local_remote::<_, BuyAsset>(OpenIcaAccount::new(
         new_lease,
@@ -73,7 +74,7 @@ pub struct BuyAsset {
     downpayment: DownpaymentCoin,
     loan: OpenLoanRespResult,
     deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
-    start_opening_at: Timestamp,
+    start_opening_at: Instant,
 }
 
 impl BuyAsset {
@@ -83,7 +84,7 @@ impl BuyAsset {
         downpayment: DownpaymentCoin,
         loan: OpenLoanRespResult,
         deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
-        start_opening_at: Timestamp,
+        start_opening_at: Instant,
     ) -> Self {
         Self {
             form,
@@ -174,7 +175,7 @@ impl ContractInSwap for BuyAsset {
     fn state(
         self,
         in_progress: Stage,
-        _now: Timestamp,
+        _now: Instant,
         _due_projection: Duration,
         _querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {

--- a/protocol/contracts/lease/src/contract/state/opening/open_ica.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_ica.rs
@@ -6,8 +6,9 @@ use dex::{
     Account, Connectable, ConnectionParams, Contract as DexContract, DexResult, IcaConnectee,
     TimeAlarm, TransferOut,
 };
+use finance::instant::Instant;
 use platform::batch::Batch;
-use sdk::cosmwasm_std::{QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::QuerierWrapper;
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
@@ -29,7 +30,7 @@ pub(crate) struct OpenIcaAccount {
     downpayment: DownpaymentCoin,
     loan: OpenLoanRespResult,
     deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
-    start_opening_at: Timestamp,
+    start_opening_at: Instant,
 }
 
 impl OpenIcaAccount {
@@ -38,7 +39,7 @@ impl OpenIcaAccount {
         downpayment: DownpaymentCoin,
         loan: OpenLoanRespResult,
         deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
-        start_opening_at: Timestamp,
+        start_opening_at: Instant,
     ) -> Self {
         Self {
             new_lease,
@@ -77,7 +78,7 @@ impl DexContract for OpenIcaAccount {
 
     fn state(
         self,
-        _now: Timestamp,
+        _now: Instant,
         _due_projection: Duration,
         _querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
@@ -98,7 +99,7 @@ impl Display for OpenIcaAccount {
 }
 
 impl TimeAlarm for OpenIcaAccount {
-    fn setup_alarm(&self, r#for: Timestamp) -> DexResult<Batch> {
+    fn setup_alarm(&self, r#for: Instant) -> DexResult<Batch> {
         self.deps.2.setup_alarm(r#for).map_err(Into::into)
     }
 }

--- a/protocol/contracts/lease/src/contract/state/opening/request_loan.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/request_loan.rs
@@ -1,13 +1,14 @@
 use finance::duration::Duration;
 use serde::{Deserialize, Serialize};
 
+use finance::instant::Instant;
 use platform::{
     batch::{Batch, Emit, Emitter},
     contract,
     message::Response as MessageResponse,
     state_machine::Response as StateMachineResponse,
 };
-use sdk::cosmwasm_std::{Addr, Env, MessageInfo, QuerierWrapper, Reply, Timestamp};
+use sdk::cosmwasm_std::{Addr, Env, MessageInfo, QuerierWrapper, Reply};
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
@@ -23,6 +24,7 @@ use crate::{
 };
 
 use super::buy_asset::DexState;
+use cw_time::IntoInstant;
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct RequestLoan {
@@ -86,7 +88,7 @@ impl RequestLoan {
             self.downpayment,
             loan,
             self.deps,
-            env.block.time,
+            env.block.time.into_instant(),
         );
         Ok(StateMachineResponse::from(
             MessageResponse::messages_with_event(open_ica.enter(), emitter),
@@ -102,7 +104,7 @@ impl RequestLoan {
 impl Handler for RequestLoan {
     fn state(
         self,
-        _now: Timestamp,
+        _now: Instant,
         _due_projection: Duration,
         _querier: QuerierWrapper<'_>,
     ) -> ContractResult<QueryStateResponse> {

--- a/protocol/contracts/lease/src/contract/state/paid/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/paid/mod.rs
@@ -7,6 +7,7 @@ use crate::{contract::Lease, error::ContractResult};
 use super::Response;
 
 use self::transfer_in::DexState;
+use cw_time::IntoInstant;
 
 pub mod transfer_in;
 
@@ -18,7 +19,7 @@ pub fn start_close(
 ) -> ContractResult<Response> {
     let start_transfer_in = transfer_in::start(lease);
     start_transfer_in
-        .enter(env.block.time, querier)
+        .enter(env.block.time.into_instant(), querier)
         .map(|close_msgs| curr_request_response.merge_with(close_msgs))
         .map(|batch| Response::from(batch, DexState::from(start_transfer_in)))
         .map_err(Into::into)

--- a/protocol/contracts/lease/src/contract/state/paid/transfer_in.rs
+++ b/protocol/contracts/lease/src/contract/state/paid/transfer_in.rs
@@ -8,6 +8,7 @@ use dex::{
     Account, AnomalyTreatment, ContractInSwap, Stage, StartTransferInState, SwapOutputTask,
     SwapTask, WithCalculator, WithOutputTask,
 };
+use finance::instant::Instant;
 use finance::{
     coin::{Coin, CoinDTO},
     duration::Duration,
@@ -18,7 +19,7 @@ use platform::{
     message::Response as MessageResponse,
     state_machine::Response as StateMachineResponse,
 };
-use sdk::cosmwasm_std::{Env, QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::{Env, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
@@ -140,7 +141,7 @@ impl ContractInSwap for TransferIn {
     fn state(
         self,
         in_progress: Stage,
-        _now: Timestamp,
+        _now: Instant,
         _due_projection: Duration,
         _querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {

--- a/protocol/contracts/lease/src/lease/close.rs
+++ b/protocol/contracts/lease/src/lease/close.rs
@@ -1,10 +1,10 @@
 use currency::{CurrencyDef, MemberOf};
+use finance::instant::Instant;
 use finance::{coin::Coin, duration::Duration};
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
 use platform::{bank::FixedAddressSender, batch::Batch};
 use reserve::stub::Reserve as ReserveTrait;
-use sdk::cosmwasm_std::Timestamp;
 
 use crate::{
     api::{LeaseAssetCurrencies, LeasePaymentCurrencies},
@@ -50,7 +50,7 @@ where
         &mut self,
         asset: Coin<Asset>,
         payment: LpnCoin,
-        now: &Timestamp,
+        now: &Instant,
         profit: &mut Profit,
     ) -> ContractResult<RepayReceipt>
     where
@@ -63,7 +63,7 @@ where
     pub(crate) fn close_full<Profit, Reserve, Change>(
         mut self,
         payment: LpnCoin,
-        now: Timestamp,
+        now: Instant,
         mut profit: Profit,
         mut reserve: Reserve,
         mut change_recipient: Change,

--- a/protocol/contracts/lease/src/lease/close_policy.rs
+++ b/protocol/contracts/lease/src/lease/close_policy.rs
@@ -1,8 +1,8 @@
 use currency::{Currency, CurrencyDef, MemberOf};
+use finance::instant::Instant;
 use finance::liability::Zone;
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
-use sdk::cosmwasm_std::Timestamp;
 
 use crate::{
     api::{LeaseAssetCurrencies, LeasePaymentCurrencies, position::ClosePolicyChange},
@@ -26,7 +26,7 @@ where
     pub(crate) fn check_close_policy(
         &self,
         asset_in_lpns: Price<Asset>,
-        now: &Timestamp,
+        now: &Instant,
     ) -> ContractResult<CloseStatus<Asset>> {
         self.loan
             .state(now)
@@ -48,7 +48,7 @@ where
         &mut self,
         cmd: ClosePolicyChange,
         asset_in_lpns: Price<Asset>,
-        now: &Timestamp,
+        now: &Instant,
     ) -> ContractResult<()> {
         self.loan.state(now).and_then(|due| {
             self.position

--- a/protocol/contracts/lease/src/lease/mod.rs
+++ b/protocol/contracts/lease/src/lease/mod.rs
@@ -180,6 +180,7 @@ pub(crate) mod tests {
         coin::{Amount, Coin},
         duration::Duration,
         fraction::Fraction,
+        instant::Instant,
         liability::Liability,
         percent::Percent100,
         price::Price,

--- a/protocol/contracts/lease/src/lease/mod.rs
+++ b/protocol/contracts/lease/src/lease/mod.rs
@@ -1,10 +1,11 @@
 use currency::{Currency, CurrencyDef, MemberOf};
 use finance::duration::Duration;
+use finance::instant::Instant;
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
 use platform::batch::Batch;
 use profit::stub::ProfitRef;
-use sdk::cosmwasm_std::{Addr, Timestamp};
+use sdk::cosmwasm_std::Addr;
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
@@ -93,7 +94,7 @@ where
 
     pub(crate) fn state(
         &self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
     ) -> ContractResult<State<Asset>> {
         self.loan.state(&(now + due_projection)).map(|loan| State {
@@ -194,7 +195,7 @@ pub(crate) mod tests {
     };
     use oracle_platform::{Oracle, error::Result as PriceOracleResult};
     use platform::batch::Batch;
-    use sdk::cosmwasm_std::{Addr, Timestamp};
+    use sdk::cosmwasm_std::Addr;
 
     use crate::{
         api::{
@@ -212,7 +213,7 @@ pub(crate) mod tests {
     const LEASE_ADDR: &str = "lease_addr";
     const ORACLE_ADDR: &str = "oracle_addr";
     const MARGIN_INTEREST_RATE: Percent100 = Percent100::from_permille(23);
-    pub(super) const LEASE_START: Timestamp = Timestamp::from_nanos(100);
+    pub(super) const LEASE_START: Instant = Instant::from_nanos(100);
     pub(super) const DUE_PERIOD: Duration = Duration::from_days(100);
     pub(crate) const FIRST_LIQ_WARN: Percent100 = Percent100::from_permille(730);
     pub(super) const SECOND_LIQ_WARN: Percent100 = Percent100::from_permille(750);
@@ -240,11 +241,11 @@ pub(crate) mod tests {
             self.loan.principal_due
         }
 
-        fn interest_due(&self, by: &Timestamp) -> Option<Coin<Lpn>> {
+        fn interest_due(&self, by: &Instant) -> Option<Coin<Lpn>> {
             self.loan.interest_due(by)
         }
 
-        fn repay(&mut self, by: &Timestamp, repayment: Coin<Lpn>) -> Option<RepayShares<Lpn>> {
+        fn repay(&mut self, by: &Instant, repayment: Coin<Lpn>) -> Option<RepayShares<Lpn>> {
             self.loan.repay(by, repayment)
         }
 
@@ -428,7 +429,7 @@ pub(crate) mod tests {
         interest_rate: Percent100,
         lease_amount: Coin<TestCurrency>,
         take_profit: Percent100,
-        state_at: Timestamp,
+        state_at: Instant,
         lease: &TestLease,
         due_projection: Duration,
     ) {
@@ -466,7 +467,7 @@ pub(crate) mod tests {
         );
     }
 
-    fn compare_now_vs_projected(lease: &TestLease, state_at: Timestamp) {
+    fn compare_now_vs_projected(lease: &TestLease, state_at: Instant) {
         let due_projection = Duration::from_days(12);
         let state_now = lease
             .state(state_at + due_projection, Duration::default())

--- a/protocol/contracts/lease/src/lease/repay.rs
+++ b/protocol/contracts/lease/src/lease/repay.rs
@@ -1,9 +1,9 @@
 use currency::{Currency, CurrencyDef, MemberOf};
 use finance::coin::Coin;
+use finance::instant::Instant;
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
 use platform::bank::FixedAddressSender;
-use sdk::cosmwasm_std::Timestamp;
 
 use crate::{
     api::{LeaseAssetCurrencies, LeasePaymentCurrencies},
@@ -37,7 +37,7 @@ where
     pub(crate) fn repay<Profit>(
         &mut self,
         payment: LpnCoin,
-        now: &Timestamp,
+        now: &Instant,
         profit: &mut Profit,
     ) -> ContractResult<RepayReceipt>
     where

--- a/protocol/contracts/lease/src/lease/state.rs
+++ b/protocol/contracts/lease/src/lease/state.rs
@@ -1,5 +1,5 @@
+use finance::instant::Instant;
 use finance::{coin::Coin, duration::Duration, percent::Percent100};
-use sdk::cosmwasm_std::Timestamp;
 
 use crate::{api::query::opened::ClosePolicy, finance::LpnCoin};
 
@@ -17,7 +17,7 @@ pub struct State<Asset> {
     pub due_projection: Duration,
     // Intentionally not using the internal domain type close::Policy
     pub close_policy: ClosePolicy,
-    pub validity: Timestamp,
+    pub validity: Instant,
 }
 
 impl<Asset> State<Asset> {

--- a/protocol/contracts/lease/src/loan/mod.rs
+++ b/protocol/contracts/lease/src/loan/mod.rs
@@ -291,6 +291,7 @@ mod tests {
             coin::Coin,
             duration::Duration,
             fraction::{Fraction, Unit},
+            instant::Instant,
             percent::Percent100,
             zero::Zero,
         };

--- a/protocol/contracts/lease/src/loan/mod.rs
+++ b/protocol/contracts/lease/src/loan/mod.rs
@@ -2,18 +2,17 @@ use std::mem;
 
 use serde::{Deserialize, Serialize};
 
+use crate::{
+    error::{ContractError, ContractResult},
+    finance::{LpnCoin, LpnCurrency},
+};
+use finance::instant::Instant;
 use finance::{
     coin::Coin, duration::Duration, interest, percent::Percent100, period::Period, zero::Zero,
 };
 use lpp::stub::{LppBatch, LppRef as LppGenericRef, loan::LppLoan as LppLoanTrait};
 use platform::{bank::FixedAddressSender, batch::Batch};
 use profit::stub::ProfitRef;
-use sdk::cosmwasm_std::Timestamp;
-
-use crate::{
-    error::{ContractError, ContractResult},
-    finance::{LpnCoin, LpnCurrency},
-};
 
 pub(crate) use self::repay::Receipt as RepayReceipt;
 pub use self::state::{Overdue, State};
@@ -31,7 +30,7 @@ pub(crate) struct LoanDTO {
     profit: ProfitRef,
     due_period: Duration,
     margin_interest: Percent100,
-    margin_paid_by: Timestamp, // only this one should vary!
+    margin_paid_by: Instant, // only this one should vary!
 }
 
 impl LoanDTO {
@@ -53,7 +52,7 @@ pub(crate) struct Loan<LppLoan> {
     lpp_loan: LppLoan,
     due_period: Duration,
     margin_interest: Percent100,
-    margin_paid_by: Timestamp, // only this one should vary!
+    margin_paid_by: Instant, // only this one should vary!
 }
 
 impl<LppLoan> Loan<LppLoan>
@@ -101,7 +100,7 @@ where
 {
     pub(super) fn new(
         lpp_loan: LppLoan,
-        start: Timestamp,
+        start: Instant,
         annual_margin_interest: Percent100,
         due_period: Duration,
     ) -> Self {
@@ -128,7 +127,7 @@ where
     pub(crate) fn repay<Profit>(
         &mut self,
         payment: LpnCoin,
-        by: &Timestamp,
+        by: &Instant,
         profit: &mut Profit,
     ) -> ContractResult<RepayReceipt>
     where
@@ -177,7 +176,7 @@ where
             .inspect(|receipt| debug_assert_eq!(payment, receipt.total()))
     }
 
-    pub(crate) fn state(&self, now: &Timestamp) -> Result<State, ContractError> {
+    pub(crate) fn state(&self, now: &Instant) -> Result<State, ContractError> {
         self.debug_check_start_due_before(now, "in the past. Now is ");
 
         let due_period_margin = Period::from_till(self.margin_paid_by, now);
@@ -218,7 +217,7 @@ where
         &mut self,
         principal_due: LpnCoin,
         margin_paid: LpnCoin,
-        by: &Timestamp,
+        by: &Instant,
     ) -> ContractResult<()> {
         interest::pay(
             self.margin_interest,
@@ -237,7 +236,7 @@ where
         &mut self,
         interest_paid: LpnCoin,
         principal_paid: LpnCoin,
-        by: &Timestamp,
+        by: &Instant,
     ) -> ContractResult<()> {
         self.lpp_loan
             .repay(by, interest_paid + principal_paid)
@@ -250,7 +249,7 @@ where
             .ok_or(ContractError::Overflow("Repay loan overflow"))
     }
 
-    fn debug_check_start_due_before(&self, when: &Timestamp, when_descr: &str) {
+    fn debug_check_start_due_before(&self, when: &Instant, when_descr: &str) {
         debug_assert!(
             &self.margin_paid_by <= when,
             "The current due period starting at {}s, should begin {} {}s",
@@ -265,6 +264,7 @@ where
 mod tests {
     use serde::{Deserialize, Serialize};
 
+    use crate::{finance::LpnCoin, lease::tests};
     pub use currencies::Lpn;
     use finance::{duration::Duration, percent::Percent100};
     use lpp::{
@@ -277,15 +277,12 @@ mod tests {
     };
     use platform::bank::FixedAddressSender;
     use profit::stub::ProfitRef;
-    use sdk::cosmwasm_std::Timestamp;
-
-    use crate::{finance::LpnCoin, lease::tests};
 
     use super::{Loan, LppRef};
 
     const MARGIN_INTEREST_RATE: Percent100 = Percent100::from_permille(50);
     const LOAN_INTEREST_RATE: Percent100 = Percent100::from_permille(500);
-    const LEASE_START: Timestamp = Timestamp::from_nanos(100);
+    const LEASE_START: Instant = Instant::from_nanos(100);
     const PROFIT_ADDR: &str = "profit_addr";
     const ZERO_COIN: LpnCoin = tests::lpn_coin(0);
 
@@ -299,7 +296,7 @@ mod tests {
         };
         use lpp::msg::LoanResponse;
         use platform::{bank, batch::Batch};
-        use sdk::cosmwasm_std::{Addr, Timestamp};
+        use sdk::cosmwasm_std::Addr;
 
         use crate::{
             finance::LpnCoin,
@@ -1025,7 +1022,7 @@ mod tests {
             before_state: State,
             exp_receipt: RepayReceipt,
             exp_due_period_paid: Duration,
-            now: &Timestamp,
+            now: &Instant,
         ) {
             let mut profit = super::profit_stub();
 
@@ -1149,19 +1146,18 @@ mod tests {
 
     #[cfg(test)]
     mod test_state {
-        use finance::{duration::Duration, interest, percent::Percent100, period::Period};
-        use lpp::{msg::LoanResponse, stub::loan::LppLoan};
-        use sdk::cosmwasm_std::Timestamp;
-
         use crate::{
             lease::tests,
             loan::{Overdue, State},
         };
+        use finance::instant::Instant;
+        use finance::{duration::Duration, interest, percent::Percent100, period::Period};
+        use lpp::{msg::LoanResponse, stub::loan::LppLoan};
 
         use super::{LEASE_START, LppLoanLocal, MARGIN_INTEREST_RATE};
 
         #[track_caller]
-        fn test_state(interest_paid_by: Timestamp, margin_paid_by: Timestamp, now: &Timestamp) {
+        fn test_state(interest_paid_by: Instant, margin_paid_by: Instant, now: &Instant) {
             let principal_due = tests::lpn_coin(10000);
             let due_period_len = Duration::YEAR;
             let annual_interest_margin = MARGIN_INTEREST_RATE;
@@ -1268,11 +1264,11 @@ mod tests {
             self.loan.principal_due
         }
 
-        fn interest_due(&self, by: &Timestamp) -> Option<LpnCoin> {
+        fn interest_due(&self, by: &Instant) -> Option<LpnCoin> {
             self.loan.interest_due(by)
         }
 
-        fn repay(&mut self, by: &Timestamp, repayment: LpnCoin) -> Option<RepayShares<Lpn>> {
+        fn repay(&mut self, by: &Instant, repayment: LpnCoin) -> Option<RepayShares<Lpn>> {
             self.loan.repay(by, repayment)
         }
 
@@ -1301,7 +1297,7 @@ mod tests {
     fn create_loan_custom(
         annual_margin_interest: Percent100,
         loan: LoanResponse<Lpn>,
-        due_start: Timestamp,
+        due_start: Instant,
         due_period: Duration,
     ) -> Loan<LppLoanLocal> {
         Loan::new(

--- a/protocol/contracts/lease/src/loan/mod.rs
+++ b/protocol/contracts/lease/src/loan/mod.rs
@@ -266,7 +266,7 @@ mod tests {
 
     use crate::{finance::LpnCoin, lease::tests};
     pub use currencies::Lpn;
-    use finance::{duration::Duration, percent::Percent100};
+    use finance::{duration::Duration, instant::Instant, percent::Percent100};
     use lpp::{
         loan::RepayShares,
         msg::LoanResponse,

--- a/protocol/contracts/lease/src/loan/state.rs
+++ b/protocol/contracts/lease/src/loan/state.rs
@@ -104,11 +104,11 @@ impl Overdue {
 
 #[cfg(all(feature = "internal.test.contract", test))]
 mod test {
+    use finance::instant::Instant;
     use finance::{
         coin::Coin, duration::Duration, interest, percent::Percent100, period::Period, zero::Zero,
     };
     use lpp::{loan::Loan, stub::loan::LppLoan};
-    use sdk::cosmwasm_std::Timestamp;
 
     use crate::{
         lease::tests,
@@ -121,15 +121,14 @@ mod test {
     const LOAN: Loan<Lpn> = Loan {
         principal_due: tests::lpn_coin(1000),
         annual_interest_rate: Percent100::from_permille(165),
-        interest_paid: Timestamp::from_seconds(2425252),
+        interest_paid: Instant::from_seconds(2425252),
     };
 
     #[test]
     fn due_period_less_than_max() {
         let max_due = Duration::YEAR;
         let due_period_length = Duration::from_days(130);
-        let due_period_margin =
-            Period::from_length(Timestamp::from_seconds(100), due_period_length);
+        let due_period_margin = Period::from_length(Instant::from_seconds(100), due_period_length);
 
         let overdue = Overdue::new(
             &due_period_margin,
@@ -148,7 +147,7 @@ mod test {
     #[test]
     fn due_period_equals_to_max() {
         let max_due = Duration::from_minutes(124);
-        let due_period_margin = Period::from_length(Timestamp::from_seconds(100), max_due);
+        let due_period_margin = Period::from_length(Instant::from_seconds(100), max_due);
 
         let overdue = Overdue::new(
             &due_period_margin,

--- a/protocol/contracts/lease/src/position/steady.rs
+++ b/protocol/contracts/lease/src/position/steady.rs
@@ -71,8 +71,8 @@ where
 mod tests {
     use currencies::{LeaseGroup, Lpn, Lpns, testing::PaymentC3};
     use finance::{
-        coin::Coin, duration::Duration, fraction::Fraction, percent::Percent100, price,
-        range::RightOpenRange,
+        coin::Coin, duration::Duration, fraction::Fraction, instant::Instant, percent::Percent100,
+        price, range::RightOpenRange,
     };
     use oracle::api::alarms::{Alarm, ExecuteMsg as PriceAlarmsCmd};
     use oracle_platform::OracleRef;

--- a/protocol/contracts/lease/src/position/steady.rs
+++ b/protocol/contracts/lease/src/position/steady.rs
@@ -1,4 +1,5 @@
 use currency::{CurrencyDef, MemberOf};
+use finance::instant::Instant;
 use finance::{
     duration::Duration,
     range::{Descending, RightOpenRange},
@@ -8,7 +9,6 @@ use oracle::{
     stub::{AsAlarms, PriceAlarms},
 };
 use platform::batch::Batch;
-use sdk::cosmwasm_std::Timestamp;
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{api::LeaseAssetCurrencies, error::ContractResult, finance::OracleRef};
@@ -43,7 +43,7 @@ where
 {
     pub fn try_into_alarms(
         self,
-        when: &Timestamp,
+        when: &Instant,
         time_alarms: &TimeAlarmsRef,
         price_alarms: &OracleRef,
     ) -> ContractResult<Batch> {
@@ -77,7 +77,7 @@ mod tests {
     use oracle::api::alarms::{Alarm, ExecuteMsg as PriceAlarmsCmd};
     use oracle_platform::OracleRef;
     use platform::batch::Batch;
-    use sdk::cosmwasm_std::{self, Addr, Timestamp, WasmMsg};
+    use sdk::cosmwasm_std::{self, Addr, WasmMsg};
     use timealarms::{msg::ExecuteMsg as TimeAlarmsCmd, stub::TimeAlarmsRef};
 
     use crate::{api::LeaseAssetCurrencies, position::Steadiness};
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn try_into_alarms() {
-        let now = Timestamp::from_seconds(1732016180);
+        let now = Instant::from_seconds(1732016180);
         let recheck_in = Duration::from_secs(765758);
         let ltv_to_price = |ltv: Percent100| {
             price::total_of::<TestCurrency>(ltv.of(Coin::new(100))).is(Coin::new(45))
@@ -129,7 +129,7 @@ mod tests {
 
     fn try_into_alarms_int(
         s: Steadiness<TestCurrency>,
-        now: Timestamp,
+        now: Instant,
         recheck_in: Duration,
         exp_alarm: Alarm<LeaseAssetCurrencies, TestLpn, Lpns>,
     ) {

--- a/protocol/contracts/lpp/Cargo.toml
+++ b/protocol/contracts/lpp/Cargo.toml
@@ -32,6 +32,7 @@ stub = []
 testing = ["currency/testing", "finance/testing"]
 
 [dependencies]
+cw-time = { workspace = true }
 access-control = { workspace = true, optional = true }
 currencies = { workspace = true }
 currency = { workspace = true }

--- a/protocol/contracts/lpp/src/contract/borrow.rs
+++ b/protocol/contracts/lpp/src/contract/borrow.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 
 use super::Result;
+use cw_time::IntoInstant;
 
 pub(super) fn try_open_loan<Lpn>(
     deps: DepsMut<'_>,
@@ -32,7 +33,7 @@ where
     let mut lpp = LiquidityPool::load(deps.storage, &config, &bank)?;
     let lease_addr = lpp.validate_lease_addr(&contract::validator(deps.querier), info.sender)?;
 
-    let loan = lpp.try_open_loan(env.block.time, amount)?;
+    let loan = lpp.try_open_loan(env.block.time.into_instant(), amount)?;
     Repo::open(deps.storage, lease_addr.clone(), &loan)?;
 
     lpp.save(deps.storage)?;
@@ -60,7 +61,7 @@ where
     let lease_addr = lpp.validate_lease_addr(&contract::validator(deps.querier), info.sender)?;
 
     let payment = Repo::load(deps.storage, lease_addr.clone()).and_then(|mut loan| {
-        let now = env.block.time;
+        let now = env.block.time.into_instant();
         let payment = loan.repay(&now, repay_amount).ok_or_else(|| {
             ContractError::overflow_loan_repayment("Trying to repay loan", now, repay_amount)
         })?;
@@ -102,7 +103,7 @@ where
     let bank = bank::account_view(&env.contract.address, deps.querier);
     let lpp = LiquidityPool::load(deps.storage, &config, &bank)?;
 
-    match lpp.query_quote(quote, &env.block.time)? {
+    match lpp.query_quote(quote, &env.block.time.into_instant())? {
         Some(quote) => Ok(QueryQuoteResponse::QuoteInterestRate(quote)),
         None => Ok(QueryQuoteResponse::NoLiquidity),
     }

--- a/protocol/contracts/lpp/src/contract/lender.rs
+++ b/protocol/contracts/lpp/src/contract/lender.rs
@@ -5,7 +5,7 @@ use platform::{
     bank::{self, BankAccount, BankAccountView},
     message::Response as MessageResponse,
 };
-use sdk::cosmwasm_std::{Addr, Storage, Timestamp};
+use sdk::cosmwasm_std::{Addr, Storage};
 
 use crate::{
     event::WithdrawEmitter,
@@ -15,6 +15,7 @@ use crate::{
 };
 
 use super::error::{ContractError, Result};
+use finance::instant::Instant;
 
 /// Deposit `Lpn`-s and return the amount of receipts
 pub(super) fn try_deposit<Lpn, Bank>(
@@ -22,7 +23,7 @@ pub(super) fn try_deposit<Lpn, Bank>(
     bank: &Bank,
     lender: Addr,
     pending_deposit: Coin<Lpn>,
-    now: &Timestamp,
+    now: &Instant,
 ) -> Result<Coin<NLpn>>
 where
     Lpn: CurrencyDef,
@@ -57,7 +58,7 @@ where
 pub(super) fn deposit_capacity<Lpn, Bank>(
     storage: &dyn Storage,
     bank: &Bank,
-    now: &Timestamp,
+    now: &Instant,
 ) -> Result<Option<Coin<Lpn>>>
 where
     Lpn: CurrencyDef,
@@ -79,7 +80,7 @@ pub(super) fn try_withdraw<Lpn, Bank>(
     mut pool_account: Bank,
     lender: Addr,
     receipts: Coin<NLpn>,
-    now: &Timestamp,
+    now: &Instant,
     mut emitter: WithdrawEmitter<'_, Lpn>,
 ) -> Result<MessageResponse>
 where
@@ -121,7 +122,7 @@ pub(super) fn try_close_all<Lpn, BankView, Bank>(
     storage: &mut dyn Storage,
     pool_view: BankView, // acceptable trick since the bank transfers get visible after the ransaction finishes
     mut pool_account: Bank, // enable transfer scheduling while in process of reading balances
-    now: &Timestamp,
+    now: &Instant,
     mut emitter: WithdrawEmitter<'_, Lpn>,
 ) -> Result<MessageResponse>
 where
@@ -175,7 +176,7 @@ fn withdraw<Lpn, Bank>(
     deposit: &mut Deposit,
     lpp: &mut LiquidityPool<'_, '_, Lpn, Bank>,
     receipts: Coin<NLpn>,
-    now: &Timestamp,
+    now: &Instant,
     pending_withdraw: Coin<Lpn>,
 ) -> Result<(Coin<Lpn>, Option<Coin<Nls>>)>
 where
@@ -208,7 +209,7 @@ fn transfer_to<Lpn, Bank>(
 pub fn query_ntoken_price<Lpn, Bank>(
     storage: &dyn Storage,
     bank: &Bank,
-    now: &Timestamp,
+    now: &Instant,
 ) -> Result<PriceResponse<Lpn>>
 where
     Lpn: CurrencyDef,
@@ -231,12 +232,13 @@ pub fn query_balance(storage: &dyn Storage, addr: Addr) -> Result<BalanceRespons
 
 #[cfg(test)]
 mod test {
+    use finance::instant::Instant;
     use finance::{coin::Coin, percent::Percent100};
     use platform::{
         bank::{BankAccountView, testing::MockBankView},
         contract::Code,
     };
-    use sdk::cosmwasm_std::{Storage, Timestamp, testing::MockStorage};
+    use sdk::cosmwasm_std::{Storage, testing::MockStorage};
 
     use crate::{
         borrow::InterestRate,
@@ -257,10 +259,10 @@ mod test {
 
     fn test_case<F>(initial_lpp_balance: Coin<TheCurrency>, min_utilization: Percent100, f: F)
     where
-        F: FnOnce(MockStorage, ApiConfig, MockBankView<TheCurrency, TheCurrency>, Timestamp),
+        F: FnOnce(MockStorage, ApiConfig, MockBankView<TheCurrency, TheCurrency>, Instant),
     {
         let mut store = MockStorage::default();
-        let now = Timestamp::from_nanos(1_571_897_419_879_405_538);
+        let now = Instant::from_nanos(1_571_897_419_879_405_538);
 
         let config = ApiConfig::new(
             Code::unchecked(0xDEADC0DE_u64),

--- a/protocol/contracts/lpp/src/contract/mod.rs
+++ b/protocol/contracts/lpp/src/contract/mod.rs
@@ -10,6 +10,7 @@ use access_control::SingleUserAccess;
 use currencies::{
     Lpn as LpnCurrency, Lpns as LpnCurrencies, PaymentGroup, Stable as StableCurrency,
 };
+use cw_time::IntoInstant;
 
 use platform::{
     bank, contract::Code, error as platform_error, message::Response as PlatformResponse, response,
@@ -163,7 +164,7 @@ pub fn execute(
                     &bank::account_view(&env.contract.address.clone(), deps.querier),
                     info.sender.clone(),
                     pending_deposit,
-                    &env.block.time,
+                    &env.block.time.into_instant(),
                 )
                 .map(|receipts| {
                     PlatformResponse::from(event::emit_deposit(
@@ -180,7 +181,7 @@ pub fn execute(
             bank::account(&env.contract.address, deps.querier),
             info.sender.clone(),
             amount,
-            &env.block.time,
+            &env.block.time.into_instant(),
             WithdrawEmitter::new(&env),
         )
         .map(response::response_only_messages),
@@ -199,7 +200,7 @@ pub fn execute(
                 deps.storage,
                 bank::account_view(&env.contract.address.clone(), deps.querier),
                 bank::account(&env.contract.address.clone(), deps.querier),
-                &env.block.time,
+                &env.block.time.into_instant(),
                 WithdrawEmitter::new(&env),
             )
             .map(response::response_only_messages)
@@ -253,7 +254,7 @@ pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg<LpnCurrencies>) -> Result<B
                         deps.storage,
                         config,
                         &bank,
-                        &env.block.time,
+                        &env.block.time.into_instant(),
                     )
                     .and_then(|lpp_balances| {
                         rewards::query_total_receipts::<LpnCurrency, _>(deps.storage, config, &bank)
@@ -268,7 +269,7 @@ pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg<LpnCurrencies>) -> Result<B
                     deps.storage,
                     config,
                     &bank::account_view(&env.contract.address, deps.querier),
-                    &env.block.time,
+                    &env.block.time.into_instant(),
                 )
             })
             .map(LppBalances::into_total)
@@ -282,13 +283,13 @@ pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg<LpnCurrencies>) -> Result<B
         QueryMsg::Price() => lender::query_ntoken_price::<LpnCurrency, _>(
             deps.storage,
             &bank::account_view(&env.contract.address, deps.querier),
-            &env.block.time,
+            &env.block.time.into_instant(),
         )
         .and_then(|ref resp| to_json_binary(resp)),
         QueryMsg::DepositCapacity() => to_json_binary(&lender::deposit_capacity::<LpnCurrency, _>(
             deps.storage,
             &bank::account_view(&env.contract.address, deps.querier),
-            &env.block.time,
+            &env.block.time.into_instant(),
         )?),
     }
     .inspect_err(platform_error::log(deps.api))

--- a/protocol/contracts/lpp/src/contract/rewards.rs
+++ b/protocol/contracts/lpp/src/contract/rewards.rs
@@ -6,7 +6,7 @@ use platform::{
     batch::Batch,
     message::Response as MessageResponse,
 };
-use sdk::cosmwasm_std::{Addr, DepsMut, Env, MessageInfo, Storage, Timestamp};
+use sdk::cosmwasm_std::{Addr, DepsMut, Env, MessageInfo, Storage};
 
 use crate::{
     config::Config as ApiConfig,
@@ -16,6 +16,7 @@ use crate::{
 };
 
 use super::error::{ContractError, Result};
+use finance::instant::Instant;
 
 pub(super) fn try_distribute_rewards<Lpn, Bank>(
     store: &mut dyn Storage,
@@ -88,7 +89,7 @@ pub(super) fn query_lpp_balance<Lpn, Bank>(
     storage: &dyn Storage,
     config: &ApiConfig,
     bank: &Bank,
-    now: &Timestamp,
+    now: &Instant,
 ) -> Result<LppBalances<Lpn>>
 where
     Lpn: CurrencyDef,
@@ -118,13 +119,12 @@ pub(super) fn query_rewards(storage: &dyn Storage, addr: Addr) -> Result<Rewards
 
 #[cfg(test)]
 mod test {
+    use cw_time::IntoInstant;
+    use finance::instant::Instant;
     use finance::{coin::Coin, percent::Percent100, zero::Zero};
     use lpp_platform::NLpn;
     use platform::{bank::testing::MockBankView, contract::Code};
-    use sdk::cosmwasm_std::{
-        Timestamp,
-        testing::{self, MockStorage},
-    };
+    use sdk::cosmwasm_std::testing::{self, MockStorage};
 
     use crate::{
         borrow::InterestRate,
@@ -147,7 +147,7 @@ mod test {
     fn test_claim_zero_rewards() {
         let mut deps = testing::mock_dependencies();
         let env = testing::mock_env();
-        let now = env.block.time;
+        let now = env.block.time.into_instant();
 
         const INITIAL_LPP_BALANCE: Coin<TheCurrency> = Coin::ZERO;
         const DEPOSIT: Coin<TheCurrency> = test::lpn_coin(20_000);
@@ -217,7 +217,7 @@ mod test {
         let bank = MockBankView::<_, TheCurrency>::only_balance(DEPOSIT);
 
         let mut lpp = LiquidityPool::<TheCurrency, _>::new(&config, &bank);
-        lpp.deposit(DEPOSIT, &Timestamp::from_seconds(100)).unwrap();
+        lpp.deposit(DEPOSIT, &Instant::from_seconds(100)).unwrap();
         lpp.save(&mut store).unwrap();
 
         let info = test::lender_msg_no_funds();

--- a/protocol/contracts/lpp/src/loan.rs
+++ b/protocol/contracts/lpp/src/loan.rs
@@ -1,15 +1,14 @@
 use serde::{Deserialize, Serialize};
 
+use finance::instant::Instant;
 use finance::{coin::Coin, duration::Duration, interest, percent::Percent100};
-use sdk::cosmwasm_std::Timestamp;
-
 #[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 #[cfg_attr(any(test, feature = "testing"), derive(Eq, PartialEq))]
 #[serde(rename_all = "snake_case", bound(serialize = "", deserialize = ""))]
 pub struct Loan<Lpn> {
     pub principal_due: Coin<Lpn>,
     pub annual_interest_rate: Percent100,
-    pub interest_paid: Timestamp,
+    pub interest_paid: Instant,
 }
 
 #[derive(Debug, Default, Eq, PartialEq)]
@@ -23,7 +22,7 @@ where
 }
 
 impl<Lpn> Loan<Lpn> {
-    pub fn interest_due(&self, by: &Timestamp) -> Option<Coin<Lpn>> {
+    pub fn interest_due(&self, by: &Instant) -> Option<Coin<Lpn>> {
         interest::interest(
             self.annual_interest_rate,
             self.principal_due,
@@ -31,7 +30,7 @@ impl<Lpn> Loan<Lpn> {
         )
     }
 
-    pub fn repay(&mut self, by: &Timestamp, repayment: Coin<Lpn>) -> Option<RepayShares<Lpn>> {
+    pub fn repay(&mut self, by: &Instant, repayment: Coin<Lpn>) -> Option<RepayShares<Lpn>> {
         interest::pay(
             self.annual_interest_rate,
             self.principal_due,
@@ -54,14 +53,16 @@ impl<Lpn> Loan<Lpn> {
         })
     }
 
-    fn due_period(&self, by: &Timestamp) -> Duration {
+    fn due_period(&self, by: &Instant) -> Duration {
         Duration::between(&self.interest_paid, by.max(&self.interest_paid))
     }
 }
 
 #[cfg(test)]
 mod test {
+    use crate::loan::{Loan, RepayShares};
     use currencies::Lpn;
+    use finance::instant::Instant;
     use finance::{
         coin::{Amount, Coin},
         duration::Duration,
@@ -69,16 +70,13 @@ mod test {
         percent::Percent100,
         zero::Zero,
     };
-    use sdk::cosmwasm_std::Timestamp;
-
-    use crate::loan::{Loan, RepayShares};
 
     #[test]
     fn interest() {
         let l = Loan {
             principal_due: lpn_coin(100),
             annual_interest_rate: Percent100::from_percent(50),
-            interest_paid: Timestamp::from_nanos(200),
+            interest_paid: Instant::from_nanos(200),
         };
 
         assert_eq!(
@@ -97,7 +95,7 @@ mod test {
     fn repay_no_interest() {
         let principal_at_start = lpn_coin(500);
         let interest = Percent100::from_percent(50);
-        let start_at = Timestamp::from_nanos(200);
+        let start_at = Instant::from_nanos(200);
         let interest_paid = start_at;
         let mut l = Loan {
             principal_due: principal_at_start,
@@ -131,7 +129,7 @@ mod test {
         let mut l = Loan {
             principal_due: principal_start,
             annual_interest_rate: interest,
-            interest_paid: Timestamp::from_nanos(200),
+            interest_paid: Instant::from_nanos(200),
         };
 
         let interest_a_year = interest.of(principal_start);
@@ -161,7 +159,7 @@ mod test {
         let mut l = Loan {
             principal_due: principal_start,
             annual_interest_rate: interest,
-            interest_paid: Timestamp::from_nanos(200),
+            interest_paid: Instant::from_nanos(200),
         };
 
         let interest_a_year = interest.of(principal_start);

--- a/protocol/contracts/lpp/src/loans.rs
+++ b/protocol/contracts/lpp/src/loans.rs
@@ -56,8 +56,9 @@ impl<Lpn> Repo<Lpn> {
 
 #[cfg(test)]
 mod test {
+    use finance::instant::Instant;
     use finance::{coin::Coin, duration::Duration, percent::Percent100, zero::Zero};
-    use sdk::cosmwasm_std::{Addr, Timestamp, testing};
+    use sdk::cosmwasm_std::{Addr, testing};
 
     use crate::{
         contract::{
@@ -72,7 +73,7 @@ mod test {
     fn test_open_and_repay_loan() {
         let mut deps = testing::mock_dependencies();
 
-        let mut time = Timestamp::from_nanos(0);
+        let mut time = Instant::from_nanos(0);
 
         let addr = Addr::unchecked("leaser");
         let loan = Loan {
@@ -87,7 +88,7 @@ mod test {
 
         let mut loan = Repo::load(deps.as_ref().storage, addr.clone()).expect("should load loan");
 
-        time = Timestamp::from_nanos(Duration::YEAR.nanos() / 2);
+        time = Instant::from_nanos(Duration::YEAR.nanos() / 2);
         let interest = loan.interest_due(&time).unwrap();
         assert_eq!(interest, test::lpn_coin(100));
         // partial repay

--- a/protocol/contracts/lpp/src/lpp.rs
+++ b/protocol/contracts/lpp/src/lpp.rs
@@ -1,5 +1,6 @@
 use currencies::Lpns;
 use currency::{CurrencyDef, MemberOf};
+use finance::instant::Instant;
 use finance::{
     coin::Coin,
     percent::{Percent100, permilles::Permilles},
@@ -10,7 +11,7 @@ use finance::{
 };
 use lpp_platform::NLpn;
 use platform::{bank::BankAccountView, contract::Validator};
-use sdk::cosmwasm_std::{Addr, Storage, Timestamp};
+use sdk::cosmwasm_std::{Addr, Storage};
 
 use crate::{
     config::Config as ApiConfig,
@@ -90,7 +91,7 @@ where
     /// - `Err(_)` -> an error occured while computing the commited balance
     pub fn deposit_capacity(
         &self,
-        now: &Timestamp,
+        now: &Instant,
         pending_deposit: Coin<Lpn>,
     ) -> Result<Option<Coin<Lpn>>> {
         let min_utilization = self.config.min_utilization();
@@ -118,7 +119,7 @@ where
         }
     }
 
-    pub fn query_lpp_balance(&self, now: &Timestamp) -> Result<LppBalances<Lpn>> {
+    pub fn query_lpp_balance(&self, now: &Instant) -> Result<LppBalances<Lpn>> {
         let balance = self.uncommited_balance()?;
 
         let total_principal_due = self.total.total_principal_due();
@@ -138,7 +139,7 @@ where
 
     pub fn calculate_price(
         &self,
-        now: &Timestamp,
+        now: &Instant,
         uncommited_amount: Coin<Lpn>,
     ) -> Result<NTokenPrice<Lpn>> {
         let balance_nlpn = self.balance_nlpn();
@@ -166,7 +167,7 @@ where
             .map_err(ContractError::from)
     }
 
-    pub fn deposit(&mut self, amount: Coin<Lpn>, now: &Timestamp) -> Result<Coin<NLpn>> {
+    pub fn deposit(&mut self, amount: Coin<Lpn>, now: &Instant) -> Result<Coin<NLpn>> {
         debug_assert_ne!(Coin::ZERO, amount);
 
         if self
@@ -199,7 +200,7 @@ where
         &mut self,
         receipts: Coin<NLpn>,
         pending_withdraw: Coin<Lpn>,
-        now: &Timestamp,
+        now: &Instant,
     ) -> Result<Coin<Lpn>> {
         debug_assert_ne!(Coin::ZERO, receipts);
 
@@ -237,7 +238,7 @@ where
         self.total.receipts()
     }
 
-    pub fn query_quote(&self, quote: Coin<Lpn>, now: &Timestamp) -> Result<Option<Percent100>> {
+    pub fn query_quote(&self, quote: Coin<Lpn>, now: &Instant) -> Result<Option<Percent100>> {
         let balance = self.uncommited_balance()?;
 
         if quote > balance {
@@ -257,7 +258,7 @@ where
         )))
     }
 
-    pub(super) fn try_open_loan(&mut self, now: Timestamp, amount: Coin<Lpn>) -> Result<Loan<Lpn>> {
+    pub(super) fn try_open_loan(&mut self, now: Instant, amount: Coin<Lpn>) -> Result<Loan<Lpn>> {
         if amount.is_zero() {
             return Err(ContractError::ZeroLoanAmount);
         }
@@ -277,7 +278,7 @@ where
 
     pub(super) fn register_repay_loan(
         &mut self,
-        now: Timestamp,
+        now: Instant,
         loan: &Loan<Lpn>,
         payment: &RepayShares<Lpn>,
     ) -> Option<()> {
@@ -303,13 +304,13 @@ where
         })
     }
 
-    fn total_due(&self, now: &Timestamp) -> Option<Coin<Lpn>> {
+    fn total_due(&self, now: &Instant) -> Option<Coin<Lpn>> {
         self.total
             .total_interest_due_by_now(now)
             .map(|interest| interest + self.total.total_principal_due())
     }
 
-    fn total_lpn(&self, now: &Timestamp, uncommited_amount: Coin<Lpn>) -> Result<Coin<Lpn>> {
+    fn total_lpn(&self, now: &Instant, uncommited_amount: Coin<Lpn>) -> Result<Coin<Lpn>> {
         self.total_due(now)
             .ok_or(ContractError::overflow_total_due(
                 "Total due overflow while calculating total pool value ",
@@ -332,6 +333,7 @@ where
 
 #[cfg(test)]
 mod test {
+    use finance::instant::Instant;
     use finance::{
         coin::Coin,
         duration::Duration,
@@ -342,7 +344,7 @@ mod test {
     };
     use lpp_platform::NLpn;
     use platform::{bank::testing::MockBankView, contract::Code};
-    use sdk::cosmwasm_std::{Addr, Timestamp, testing::MockStorage};
+    use sdk::cosmwasm_std::{Addr, testing::MockStorage};
 
     use crate::{
         borrow::InterestRate,
@@ -380,7 +382,7 @@ mod test {
         let lpp = LiquidityPool::<'_, '_, TheCurrency, _>::new(&config, &bank);
 
         let mut store = MockStorage::new();
-        let now = Timestamp::default();
+        let now = Instant::default();
         lpp.save(&mut store).unwrap();
         let lpp = LiquidityPool::<'_, '_, TheCurrency, _>::load(&store, &config, &bank).unwrap();
         assert_eq!(
@@ -428,7 +430,7 @@ mod test {
         const DEPOSIT_AMOUNT: Coin<TheCurrency> = test::lpn_coin(7_000_000);
         let mut store = MockStorage::default();
 
-        let now = Timestamp::from_nanos(0);
+        let now = Instant::from_nanos(0);
 
         let lease_code_id = Code::unchecked(123);
 
@@ -483,7 +485,7 @@ mod test {
         let mut store = MockStorage::new();
         let bank = MockBankView::<TheCurrency, TheCurrency>::only_balance(LPP_BALANCE);
         let lease_addr = Addr::unchecked("loan");
-        let now = Timestamp::from_nanos(0);
+        let now = Instant::from_nanos(0);
         let lease_code_id = Code::unchecked(123);
 
         let config = ApiConfig::new(lease_code_id, interest_rate, DEFAULT_MIN_UTILIZATION);
@@ -559,7 +561,7 @@ mod test {
 
     #[test]
     fn try_open_loan_with_no_liquidity() {
-        let now = Timestamp::from_nanos(0);
+        let now = Instant::from_nanos(0);
         let bank = MockBankView::<TheCurrency, TheCurrency>::only_balance(Coin::ZERO);
         let lease_code_id = Code::unchecked(123);
 
@@ -582,7 +584,7 @@ mod test {
     #[test]
     fn try_open_loan_for_zero_amount() {
         const BALANCE: Coin<TheCurrency> = test::lpn_coin(10_000_000);
-        let now = Timestamp::from_nanos(0);
+        let now = Instant::from_nanos(0);
         let bank = MockBankView::<TheCurrency, TheCurrency>::only_balance(BALANCE);
         let lease_code_id = Code::unchecked(123);
 
@@ -606,7 +608,7 @@ mod test {
     fn open_loan_repay_zero() {
         const BALANCE: Coin<TheCurrency> = test::lpn_coin(10_000_000);
         let mut store = MockStorage::new();
-        let now = Timestamp::from_nanos(0);
+        let now = Instant::from_nanos(0);
         let bank = MockBankView::<TheCurrency, TheCurrency>::only_balance(BALANCE);
         let loan_addr = Addr::unchecked("loan");
         let lease_code_id = Code::unchecked(123);
@@ -653,7 +655,7 @@ mod test {
     fn try_open_and_close_loan_without_paying_interest() {
         const BALANCE: Coin<TheCurrency> = test::lpn_coin(10_000_000);
         let mut store = MockStorage::new();
-        let now = Timestamp::from_nanos(0);
+        let now = Instant::from_nanos(0);
         let bank = MockBankView::<TheCurrency, TheCurrency>::only_balance(BALANCE);
         let loan_addr = Addr::unchecked("loan");
         let lease_code_id = Code::unchecked(123);
@@ -701,7 +703,7 @@ mod test {
         const LOAN_REPAYMENT: Coin<TheCurrency> = test::lpn_coin(6_000_000);
 
         let mut store = MockStorage::new();
-        let now = Timestamp::from_nanos(0);
+        let now = Instant::from_nanos(0);
         let loan_addr = Addr::unchecked("loan");
         let lease_code_id = Code::unchecked(123);
 
@@ -794,17 +796,16 @@ mod test {
     }
 
     mod min_utilization {
+        use crate::{
+            borrow::InterestRate, config::Config as ApiConfig, contract::test, state::Total,
+        };
         use finance::{
             coin::{Amount, Coin},
+            instant::Instant,
             percent::Percent100,
             zero::Zero,
         };
         use platform::{bank::testing::MockBankView, contract::Code};
-        use sdk::cosmwasm_std::Timestamp;
-
-        use crate::{
-            borrow::InterestRate, config::Config as ApiConfig, contract::test, state::Total,
-        };
 
         use super::{super::LiquidityPool, TheCurrency};
 
@@ -816,7 +817,7 @@ mod test {
             min_utilization: Percent100,
             expected_limit: Option<Amount>,
         ) {
-            let now = Timestamp::from_seconds(120);
+            let now = Instant::from_seconds(120);
             let mut total: Total<TheCurrency> = Total::new();
 
             total
@@ -901,13 +902,14 @@ mod test {
         use finance::{
             coin::Coin,
             duration::Duration,
+            instant::Instant,
             percent::Percent100,
             price::{self, Price},
             zero::Zero,
         };
         use lpp_platform::NLpn;
         use platform::{bank::testing::MockBankView, contract::Code};
-        use sdk::cosmwasm_std::{Timestamp, testing::MockStorage};
+        use sdk::cosmwasm_std::testing::MockStorage;
 
         use crate::{
             borrow::InterestRate,
@@ -918,7 +920,7 @@ mod test {
 
         #[test]
         fn test_deposit() {
-            let now = Timestamp::from_seconds(120);
+            let now = Instant::from_seconds(120);
             const DEPOSIT1: Coin<TheCurrency> = test::lpn_coin(1233);
             const RECEIPT1: Coin<NLpn> = Coin::new(1233);
             const DEPOSIT2: Coin<TheCurrency> = test::lpn_coin(3113);
@@ -967,7 +969,7 @@ mod test {
 
         #[test]
         fn test_withdraw() {
-            let now = Timestamp::from_seconds(120);
+            let now = Instant::from_seconds(120);
             const DEPOSIT1: Coin<TheCurrency> = test::lpn_coin(1233);
             const RECEIPT1: Coin<NLpn> = Coin::new(1233);
             const WITHDRAW1: Coin<NLpn> = Coin::new(123);
@@ -1019,7 +1021,7 @@ mod test {
 
         #[test]
         fn test_deposit_less_than_a_receipt() {
-            let now = Timestamp::from_seconds(120);
+            let now = Instant::from_seconds(120);
             const DEPOSIT1: Coin<TheCurrency> = test::lpn_coin(1233);
             const RECEIPT1: Coin<NLpn> = Coin::new(1233);
             const INTEREST: Coin<TheCurrency> = test::lpn_coin(1);

--- a/protocol/contracts/lpp/src/state/total.rs
+++ b/protocol/contracts/lpp/src/state/total.rs
@@ -5,13 +5,10 @@ use finance::{
     ratio::Ratio, zero::Zero,
 };
 use lpp_platform::NLpn;
-use sdk::{
-    cosmwasm_std::{Storage, Timestamp},
-    cw_storage_plus::Item,
-};
+use sdk::{cosmwasm_std::Storage, cw_storage_plus::Item};
 
 use crate::contract::{ContractError, Result as ContractResult};
-
+use finance::instant::Instant;
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "testing"), derive(Debug, PartialEq,))]
 #[serde(bound(serialize = "", deserialize = ""))]
@@ -36,7 +33,7 @@ pub struct Total<Lpn> {
     /// The last time a borrow-related operation is performed
     ///
     /// This concerns only loan open and payments.
-    last_update_time: Timestamp,
+    last_update_time: Instant,
 
     /// The total receipts issued to lenders for their deposits
     receipts: Coin<NLpn>,
@@ -56,7 +53,7 @@ impl<Lpn> Total<Lpn> {
             total_principal_due: Coin::ZERO,
             total_interest_due: Coin::ZERO,
             annual_interest_rate: zero_interest_rate(),
-            last_update_time: Timestamp::default(),
+            last_update_time: Instant::default(),
             receipts: Coin::ZERO,
         }
     }
@@ -73,7 +70,7 @@ impl<Lpn> Total<Lpn> {
         self.total_principal_due
     }
 
-    pub fn total_interest_due_by_now(&self, ctime: &Timestamp) -> Option<Coin<Lpn>> {
+    pub fn total_interest_due_by_now(&self, ctime: &Instant) -> Option<Coin<Lpn>> {
         if self.total_principal_due.is_zero() {
             // TODO remove this case once close protocols with `total_principal_due == 0` and `total_interest_due > 0`
             // the newly added invariant: if `total_principal_due == 0` then `total_interest_due == 0`
@@ -95,7 +92,7 @@ impl<Lpn> Total<Lpn> {
 
     pub fn borrow(
         &mut self,
-        ctime: Timestamp,
+        ctime: Instant,
         amount: Coin<Lpn>,
         loan_interest_rate: Percent100,
     ) -> Result<&Self, ContractError> {
@@ -141,7 +138,7 @@ impl<Lpn> Total<Lpn> {
 
     pub fn repay(
         &mut self,
-        ctime: Timestamp,
+        ctime: Instant,
         loan_interest_payment: Coin<Lpn>,
         loan_principal_payment: Coin<Lpn>,
         loan_interest_rate: Percent100,
@@ -201,7 +198,7 @@ impl<Lpn> Total<Lpn> {
 
     fn repay_interest(
         &self,
-        ctime: Timestamp,
+        ctime: Instant,
         loan_interest_payment: Coin<Lpn>,
         loan_principal_payment: Coin<Lpn>,
         loan_interest_rate: Percent100,
@@ -263,6 +260,7 @@ fn zero_interest_rate<Lpn>() -> Ratio<Coin<Lpn>> {
 #[cfg(test)]
 mod test {
     use currencies::Lpn;
+    use finance::instant::Instant;
     use finance::{coin::Amount, duration::Duration};
     use sdk::cosmwasm_std::testing::MockStorage;
 
@@ -273,7 +271,7 @@ mod test {
     #[test]
     fn borrow_and_repay() {
         let mut store = MockStorage::default();
-        let mut block_time = Timestamp::from_nanos(1_571_797_419_879_305_533);
+        let mut block_time = Instant::from_nanos(1_571_797_419_879_305_533);
 
         let total: Total<Lpn> = Total::default();
         total.store(&mut store).expect("should store");
@@ -311,7 +309,7 @@ mod test {
 
     #[test]
     fn borrow_and_repay_with_overflow() {
-        let mut block_time = Timestamp::from_nanos(0);
+        let mut block_time = Instant::from_nanos(0);
 
         let mut total = Total::default();
         assert_eq!(total.total_principal_due(), Coin::ZERO);

--- a/protocol/contracts/lpp/src/stub/loan.rs
+++ b/protocol/contracts/lpp/src/stub/loan.rs
@@ -2,17 +2,16 @@ use std::{marker::PhantomData, result::Result as StdResult};
 
 use thiserror::Error;
 
-use currency::CurrencyDef;
-use finance::{coin::Coin, percent::Percent100};
-use platform::batch::Batch;
-use sdk::cosmwasm_std::Timestamp;
-
 use crate::{
     loan::{Loan, RepayShares},
     msg::ExecuteMsg,
 };
+use currency::CurrencyDef;
+use finance::{coin::Coin, percent::Percent100};
+use platform::batch::Batch;
 
 use super::{LppBatch, LppRef};
+use finance::instant::Instant;
 
 pub trait LppLoan<Lpn>
 where
@@ -21,14 +20,14 @@ where
     fn principal_due(&self) -> Coin<Lpn>;
 
     /// Returns `None` if an overflow occurs
-    fn interest_due(&self, by: &Timestamp) -> Option<Coin<Lpn>>;
+    fn interest_due(&self, by: &Instant) -> Option<Coin<Lpn>>;
 
     /// Repay the due interest and principal by the specified time
     ///
     /// First, the provided 'repayment' is used to repay the due interest,
     /// and then, if there is any remaining amount, to repay the principal.
     /// Amount 0 is acceptable although does not change the loan.
-    fn repay(&mut self, by: &Timestamp, repayment: Coin<Lpn>) -> Option<RepayShares<Lpn>>;
+    fn repay(&mut self, by: &Instant, repayment: Coin<Lpn>) -> Option<RepayShares<Lpn>>;
     fn annual_interest_rate(&self) -> Percent100;
 }
 
@@ -72,11 +71,11 @@ where
         self.loan.principal_due
     }
 
-    fn interest_due(&self, by: &Timestamp) -> Option<Coin<Lpn>> {
+    fn interest_due(&self, by: &Instant) -> Option<Coin<Lpn>> {
         self.loan.interest_due(by)
     }
 
-    fn repay(&mut self, by: &Timestamp, repayment: Coin<Lpn>) -> Option<RepayShares<Lpn>> {
+    fn repay(&mut self, by: &Instant, repayment: Coin<Lpn>) -> Option<RepayShares<Lpn>> {
         self.loan
             .repay(by, repayment)
             .inspect(|_| self.repayment += repayment)
@@ -122,7 +121,13 @@ where
 
 #[cfg(test)]
 mod test {
+    use crate::{
+        loan::Loan,
+        msg::ExecuteMsg,
+        stub::{LppBatch, LppRef, loan::LppLoan},
+    };
     use currencies::{Lpn, Lpns};
+    use finance::instant::Instant;
     use finance::{
         coin::{Amount, Coin},
         duration::Duration,
@@ -130,20 +135,13 @@ mod test {
         zero::Zero,
     };
     use platform::batch::Batch;
-    use sdk::cosmwasm_std::Timestamp;
-
-    use crate::{
-        loan::Loan,
-        msg::ExecuteMsg,
-        stub::{LppBatch, LppRef, loan::LppLoan},
-    };
 
     use super::LppLoanImpl;
 
     #[test]
     fn try_from_no_payments() {
         let lpp_ref = LppRef::<Lpn>::unchecked("lpp_address");
-        let start = Timestamp::from_seconds(10);
+        let start = Instant::from_seconds(10);
         let mut loan = LppLoanImpl::new(
             lpp_ref.clone(),
             Loan {
@@ -162,7 +160,7 @@ mod test {
     #[test]
     fn try_from_a_few_payments() {
         let lpp_ref = LppRef::<Lpn>::unchecked("lpp_address");
-        let start = Timestamp::from_seconds(0);
+        let start = Instant::from_seconds(0);
         let mut loan = LppLoanImpl::new(
             lpp_ref.clone(),
             Loan {

--- a/protocol/contracts/oracle/Cargo.toml
+++ b/protocol/contracts/oracle/Cargo.toml
@@ -30,8 +30,9 @@ contract = [
     "stub_alarms",
     "stub_price",
     "stub_swap",
-"dep:cosmwasm-std",
-"dep:currencies",
+    "dep:cosmwasm-std",
+    "dep:currencies",
+    "dep:cw-time",
     "dep:marketprice",
     "dep:platform",
     "sdk/contract",
@@ -99,7 +100,7 @@ stub_swap_testing = [
 ]
 
 [dependencies]
-cw-time = { workspace = true }
+cw-time = { workspace = true, optional = true }
 currencies = { workspace = true, optional = true }
 currency = { workspace = true, optional = true }
 finance = { workspace = true, optional = true }

--- a/protocol/contracts/oracle/Cargo.toml
+++ b/protocol/contracts/oracle/Cargo.toml
@@ -99,6 +99,7 @@ stub_swap_testing = [
 ]
 
 [dependencies]
+cw-time = { workspace = true }
 currencies = { workspace = true, optional = true }
 currency = { workspace = true, optional = true }
 finance = { workspace = true, optional = true }

--- a/protocol/contracts/oracle/src/contract/exec.rs
+++ b/protocol/contracts/oracle/src/contract/exec.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 
 use super::oracle::{Oracle, feeder::Feeders};
+use cw_time::IntoInstant;
 
 pub fn do_execute<BaseCurrency, BaseCurrencies, AlarmCurrencies, PriceCurrencies>(
     deps: DepsMut<'_>,
@@ -43,11 +44,13 @@ where
             .and_then(|()| {
                 Oracle::<_, PriceCurrencies, BaseCurrency, BaseCurrencies>::load(deps.storage)
             })
-            .and_then(|mut oracle| oracle.try_feed_prices(env.block.time, sender, prices))
+            .and_then(|mut oracle| {
+                oracle.try_feed_prices(env.block.time.into_instant(), sender, prices)
+            })
             .map(|()| Default::default()),
         ExecuteMsg::DispatchAlarms { max_count } => {
             Oracle::<_, PriceCurrencies, BaseCurrency, BaseCurrencies>::load(deps.storage)?
-                .try_notify_alarms(env.block.time, max_count)
+                .try_notify_alarms(env.block.time.into_instant(), max_count)
                 .and_then(|(total, resp)| {
                     response::response_with_messages(DispatchAlarmsResponse(total), resp)
                 })

--- a/protocol/contracts/oracle/src/contract/mod.rs
+++ b/protocol/contracts/oracle/src/contract/mod.rs
@@ -11,8 +11,7 @@ use platform::{
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
     cosmwasm_std::{
-        self, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Storage, SubMsgResult, Timestamp,
-        entry_point,
+        self, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Storage, SubMsgResult, entry_point,
     },
 };
 use versioning::{
@@ -32,6 +31,8 @@ use crate::{
 };
 
 use self::oracle::feeder::Feeders;
+use cw_time::IntoInstant;
+use finance::instant::Instant;
 
 mod alarms;
 mod config;
@@ -61,7 +62,7 @@ pub fn instantiate(
             )
         })
         .and_then(|supported_pairs| supported_pairs.save(deps.storage))
-        .and_then(|()| validate_swap_tree(deps.storage, env.block.time))
+        .and_then(|()| validate_swap_tree(deps.storage, env.block.time.into_instant()))
         .map(|()| response::empty_response())
 }
 
@@ -78,7 +79,7 @@ pub fn migrate(
     migrate_from
         .update_software(&CURRENT_RELEASE, &to_release)
         .map_err(Error::UpdateSoftware)
-        .and_then(|()| validate_swap_tree(deps.storage, env.block.time))
+        .and_then(|()| validate_swap_tree(deps.storage, env.block.time.into_instant()))
         .map(|()| response::empty_response())
         .inspect_err(platform_error::log(deps.api))
 }
@@ -116,14 +117,18 @@ pub fn query(
                 .collect::<Vec<_>>(),
         ),
         QueryMsg::BasePrice { currency } => to_json_binary(
-            &Oracle::load(deps.storage)?.try_query_base_price(env.block.time, &currency)?,
+            &Oracle::load(deps.storage)?
+                .try_query_base_price(env.block.time.into_instant(), &currency)?,
         ),
         QueryMsg::StablePrice { currency } => to_json_binary(
-            &Oracle::load(deps.storage)?
-                .try_query_stable_price::<StableCurrency>(env.block.time, &currency)?,
+            &Oracle::load(deps.storage)?.try_query_stable_price::<StableCurrency>(
+                env.block.time.into_instant(),
+                &currency,
+            )?,
         ),
         QueryMsg::Prices {} => {
-            let prices = Oracle::load(deps.storage)?.try_query_prices(env.block.time)?;
+            let prices =
+                Oracle::load(deps.storage)?.try_query_prices(env.block.time.into_instant())?;
 
             to_json_binary(&PricesResponse { prices })
         }
@@ -136,9 +141,9 @@ pub fn query(
                 .query_swap_tree()
                 .into_human_readable(),
         }),
-        QueryMsg::AlarmsStatus {} => {
-            to_json_binary(&Oracle::load(deps.storage)?.try_query_alarms(env.block.time)?)
-        }
+        QueryMsg::AlarmsStatus {} => to_json_binary(
+            &Oracle::load(deps.storage)?.try_query_alarms(env.block.time.into_instant())?,
+        ),
     }
 }
 
@@ -165,7 +170,7 @@ pub fn sudo(
         SudoMsg::SwapTree { tree } => {
             SupportedPairs::<PriceCurrencies, BaseCurrency>::new::<StableCurrency>(tree.into_tree())
                 .and_then(|supported_pairs| supported_pairs.save(deps.storage))
-                .and_then(|()| validate_swap_tree(deps.storage, env.block.time))
+                .and_then(|()| validate_swap_tree(deps.storage, env.block.time.into_instant()))
             // TODO move the swap tree validation at the tree instantiation
         }
     }
@@ -197,7 +202,7 @@ pub fn reply(deps: DepsMut<'_>, _env: Env, msg: Reply) -> Result<CwResponse, Pri
     .map(response::response_only_messages)
 }
 
-fn validate_swap_tree(store: &dyn Storage, now: Timestamp) -> Result<(), PriceCurrencies> {
+fn validate_swap_tree(store: &dyn Storage, now: Instant) -> Result<(), PriceCurrencies> {
     // we use calculation of all prices since it does not add a significant overhead over the swap tree validation
     // otherwise we would have to implement a separate and mostly mirroring algorithm
     Oracle::load(store)

--- a/protocol/contracts/oracle/src/contract/oracle/feed/mod.rs
+++ b/protocol/contracts/oracle/src/contract/oracle/feed/mod.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use currency::{CurrencyDTO, CurrencyDef, Group, MemberOf};
+use finance::instant::Instant;
 use finance::{
     flatten::Flatten,
     price::{base::BasePrice, dto::PriceDTO},
@@ -8,7 +9,7 @@ use finance::{
 use marketprice::{
     FeederCount, ObservationsReadRepo, ObservationsRepo, config::Config, market_price::PriceFeeds,
 };
-use sdk::cosmwasm_std::{Addr, Timestamp};
+use sdk::cosmwasm_std::Addr;
 
 use crate::{
     api::{SwapLeg, swap::SwapTarget},
@@ -53,7 +54,7 @@ where
     pub fn all_prices_iter<I>(
         &self,
         swap_pairs_df: I,
-        at: Timestamp,
+        at: Instant,
         total_feeders: FeederCount,
     ) -> impl Iterator<Item = PriceResult<PriceG, BaseC, BaseG, PriceG>>
     where
@@ -87,7 +88,7 @@ where
         &self,
         tree: &SupportedPairs<PriceG, BaseC>,
         currency: &CurrencyDTO<PriceG>,
-        at: Timestamp,
+        at: Instant,
         total_feeders: FeederCount,
     ) -> Result<BasePrice<PriceG, BaseC, BaseG>, PriceG> {
         tree.load_path(currency)
@@ -110,7 +111,7 @@ where
     pub(crate) fn feed_prices(
         &mut self,
         tree: &SupportedPairs<PriceG, BaseC>,
-        block_time: Timestamp,
+        block_time: Instant,
         sender_raw: Addr,
         prices: &[PriceDTO<PriceG>],
     ) -> Result<(), PriceG> {
@@ -199,6 +200,7 @@ mod test {
             Lpns as BaseCurrencies, PaymentGroup as PriceCurrencies,
             testing::{PaymentC1, PaymentC3, PaymentC4, PaymentC5, PaymentC6, PaymentC7},
         };
+        use cw_time::IntoInstant;
         use finance::{duration::Duration, percent::Percent100, price::base::BasePrice};
         use marketprice::{FeederCount, Repo, config::Config};
         use sdk::cosmwasm_std::{
@@ -238,7 +240,7 @@ mod test {
             oracle
                 .feed_prices(
                     &tree,
-                    env.block.time,
+                    env.block.time.into_instant(),
                     Addr::unchecked("feeder"),
                     &[
                         tests::dto_price::<PaymentC4, _, BaseCurrency>(2, 1),
@@ -252,7 +254,11 @@ mod test {
                 .unwrap();
 
             let prices: Vec<_> = oracle
-                .all_prices_iter(tree.swap_pairs_df(), env.block.time, TOTAL_FEEDERS)
+                .all_prices_iter(
+                    tree.swap_pairs_df(),
+                    env.block.time.into_instant(),
+                    TOTAL_FEEDERS,
+                )
                 .flatten()
                 .collect();
 
@@ -292,7 +298,7 @@ mod test {
             oracle
                 .feed_prices(
                     &tree,
-                    env.block.time,
+                    env.block.time.into_instant(),
                     Addr::unchecked("feeder"),
                     &[
                         // tests::dto_price::<PaymentC1, _, BaseCurrency, _>(5, 1), a gap for PaymentC7
@@ -313,7 +319,11 @@ mod test {
             ];
 
             let prices: Vec<_> = oracle
-                .all_prices_iter(tree.swap_pairs_df(), env.block.time, TOTAL_FEEDERS)
+                .all_prices_iter(
+                    tree.swap_pairs_df(),
+                    env.block.time.into_instant(),
+                    TOTAL_FEEDERS,
+                )
                 .collect::<Result<_, _>>()
                 .unwrap();
 

--- a/protocol/contracts/oracle/src/contract/oracle/feed/price_querier.rs
+++ b/protocol/contracts/oracle/src/contract/oracle/feed/price_querier.rs
@@ -1,9 +1,9 @@
 use currency::{Currency, CurrencyDTO, Group, MemberOf};
+use finance::instant::Instant;
 use finance::price::Price;
 use marketprice::{
     FeederCount, ObservationsReadRepo, error::PriceFeedsError, market_price::PriceFeeds,
 };
-use sdk::cosmwasm_std::Timestamp;
 
 use crate::result::Result;
 
@@ -12,7 +12,7 @@ where
     G: Group,
 {
     feeds: &'a PriceFeeds<'config, G, Observations>,
-    at: Timestamp,
+    at: Instant,
     total_feeders: FeederCount,
 }
 
@@ -22,7 +22,7 @@ where
 {
     pub fn new(
         feeds: &'a PriceFeeds<'config, G, Observations>,
-        at: Timestamp,
+        at: Instant,
         total_feeders: FeederCount,
     ) -> Self {
         Self {

--- a/protocol/contracts/oracle/src/contract/oracle/mod.rs
+++ b/protocol/contracts/oracle/src/contract/oracle/mod.rs
@@ -296,11 +296,11 @@ where
 
 #[cfg(all(feature = "internal.test.contract", test))]
 mod test_normalized_price_not_found {
-    use finance::instant::Instant;
     use currencies::{
         Lpn as BaseCurrency, Lpns as BaseCurrencies, Nls, PaymentGroup as PriceCurrencies,
         PaymentGroup as AlarmCurrencies, Stable as StableCurrency,
     };
+    use finance::instant::Instant;
     use finance::{coin::Coin, duration::Duration, percent::Percent100, price};
     use marketprice::{Repo, config::Config as PriceConfig};
     use sdk::{

--- a/protocol/contracts/oracle/src/contract/oracle/mod.rs
+++ b/protocol/contracts/oracle/src/contract/oracle/mod.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use currency::{Currency, CurrencyDTO, CurrencyDef, Group, MemberOf};
+use finance::instant::Instant;
 use finance::price::{
     Price,
     base::{
@@ -17,7 +18,7 @@ use platform::{
     dispatcher::{AlarmsDispatcher, Id},
     message::Response as MessageResponse,
 };
-use sdk::cosmwasm_std::{Addr, Storage, Timestamp};
+use sdk::cosmwasm_std::{Addr, Storage};
 
 use crate::{
     api::{AlarmsStatusResponse, Config, ExecuteAlarmMsg},
@@ -79,7 +80,7 @@ where
 
     pub(super) fn try_query_alarms(
         &self,
-        block_time: Timestamp,
+        block_time: Instant,
     ) -> Result<AlarmsStatusResponse, PriceG> {
         self.tree().and_then(|tree| {
             MarketAlarms::new(self.storage.deref())
@@ -94,7 +95,7 @@ where
 
     pub(super) fn try_query_prices(
         &self,
-        block_time: Timestamp,
+        block_time: Instant,
     ) -> Result<Vec<BasePrice<PriceG, BaseC, BaseG>>, PriceG> {
         self.tree().and_then(|tree| {
             self.calc_all_prices(&tree, &self.feeds_read_only(), block_time)
@@ -104,7 +105,7 @@ where
 
     pub(super) fn try_query_base_price(
         &self,
-        at: Timestamp,
+        at: Instant,
         currency: &CurrencyDTO<PriceG>,
     ) -> Result<BasePrice<PriceG, BaseC, BaseG>, PriceG> {
         self.tree().and_then(|tree| {
@@ -115,7 +116,7 @@ where
 
     pub(super) fn try_query_stable_price<StableCurrency>(
         &self,
-        at: Timestamp,
+        at: Instant,
         currency: &CurrencyDTO<PriceG>,
     ) -> Result<BasePrice<PriceG, StableCurrency, PriceG>, PriceG>
     where
@@ -187,7 +188,7 @@ where
             BaseG,
             Repo<'repo_storage, &(dyn Storage + 'repo_storage), PriceG>,
         >,
-        at: Timestamp,
+        at: Instant,
     ) -> impl Iterator<Item = PriceResult<PriceG, BaseC, BaseG, PriceG>>
     + use<'tree, 'feeds, S, PriceG, BaseC, BaseG> {
         feeds.all_prices_iter(tree.swap_pairs_df(), at, self.feeders)
@@ -227,7 +228,7 @@ where
 
     pub(super) fn try_feed_prices(
         &mut self,
-        block_time: Timestamp,
+        block_time: Instant,
         sender: Addr,
         prices: Vec<PriceDTO<PriceG>>,
     ) -> Result<(), PriceG> {
@@ -239,7 +240,7 @@ where
 
     pub(super) fn try_notify_alarms(
         &mut self,
-        block_time: Timestamp,
+        block_time: Instant,
         max_count: u32,
     ) -> Result<(u32, MessageResponse), PriceG> {
         let subscribers: Vec<Addr> = self.tree().and_then(|tree| {
@@ -295,6 +296,7 @@ where
 
 #[cfg(all(feature = "internal.test.contract", test))]
 mod test_normalized_price_not_found {
+    use finance::instant::Instant;
     use currencies::{
         Lpn as BaseCurrency, Lpns as BaseCurrencies, Nls, PaymentGroup as PriceCurrencies,
         PaymentGroup as AlarmCurrencies, Stable as StableCurrency,
@@ -303,7 +305,7 @@ mod test_normalized_price_not_found {
     use marketprice::{Repo, config::Config as PriceConfig};
     use sdk::{
         cosmwasm_std::{
-            Addr, DepsMut, Empty, QuerierWrapper, Storage, Timestamp,
+            Addr, DepsMut, Empty, QuerierWrapper, Storage,
             testing::{MockApi, MockQuerier, MockStorage},
         },
         testing,
@@ -322,7 +324,7 @@ mod test_normalized_price_not_found {
     type BaseCoin = Coin<BaseCurrency>;
     type TestSupportedPairs = SupportedPairs<PriceCurrencies, BaseCurrency>;
 
-    const NOW: Timestamp = Timestamp::from_seconds(1);
+    const NOW: Instant = Instant::from_seconds(1);
 
     const PRICE_BASE: NlsCoin = Coin::new(1);
     const PRICE_QUOTE: BaseCoin = Coin::new(1);

--- a/protocol/contracts/profit/Cargo.toml
+++ b/protocol/contracts/profit/Cargo.toml
@@ -71,6 +71,7 @@ testing = [
 ]
 
 [dependencies]
+cw-time = { workspace = true }
 access-control = { workspace = true, optional = true }
 currencies = { workspace = true, optional = true }
 currency = { workspace = true, optional = true }

--- a/protocol/contracts/profit/src/contract.rs
+++ b/protocol/contracts/profit/src/contract.rs
@@ -3,6 +3,7 @@ use std::ops::{Deref, DerefMut};
 use access_control::{
     ContractOwnerAccess, SingleUserAccess, permissions::DexResponseSafeDeliveryPermission,
 };
+use cw_time::IntoInstant;
 use dex::{ContinueResult as DexResult, Handler as _, Response as DexResponse};
 use oracle_platform::OracleRef;
 use platform::{
@@ -118,7 +119,8 @@ pub fn execute(
             let StateMachineResponse {
                 response,
                 next_state,
-            } = State::load(deps.storage)?.try_update_config(env.block.time, cadence_hours)?;
+            } = State::load(deps.storage)?
+                .try_update_config(env.block.time.into_instant(), cadence_hours)?;
 
             next_state.store(deps.storage)?;
 
@@ -235,7 +237,7 @@ pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> 
     match msg {
         QueryMsg::Config {} => cosmwasm_std::to_json_binary(&Profit::query_config(
             deps.storage,
-            env.block.time,
+            env.block.time.into_instant(),
             deps.querier,
         )?),
         QueryMsg::ProtocolPackageRelease {} => cosmwasm_std::to_json_binary(&CURRENT_RELEASE),

--- a/protocol/contracts/profit/src/profit.rs
+++ b/protocol/contracts/profit/src/profit.rs
@@ -1,12 +1,13 @@
 use currencies::Nls;
 use dex::Contract;
+use finance::instant::Instant;
 use finance::{coin::Coin, duration::Duration};
 use platform::{
     bank::BankAccount,
     batch::{Emit as _, Emitter},
     message::Response as PlatformResponse,
 };
-use sdk::cosmwasm_std::{Addr, Env, QuerierWrapper, Storage, Timestamp};
+use sdk::cosmwasm_std::{Addr, Env, QuerierWrapper, Storage};
 
 use crate::{msg::ConfigResponse, result::ContractResult, state::State};
 
@@ -42,7 +43,7 @@ impl Profit {
 
     pub fn query_config(
         storage: &dyn Storage,
-        now: Timestamp,
+        now: Instant,
         querier: QuerierWrapper<'_>,
     ) -> ContractResult<ConfigResponse> {
         State::load(storage).map(|state: State| state.state(now, Duration::default(), querier))

--- a/protocol/contracts/profit/src/state/buy_back.rs
+++ b/protocol/contracts/profit/src/state/buy_back.rs
@@ -6,13 +6,14 @@ use dex::{
     AcceptAnyNonZeroSwap, Account, AnomalyTreatment, ContractInSwap, Response as DexResponse,
     Stage, StateLocalOut, SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
 };
+use finance::instant::Instant;
 use finance::{
     coin::{Coin, CoinDTO},
     duration::Duration,
 };
 use oracle::stub::SwapPath;
 use platform::bank::{self, BankAccountView};
-use sdk::cosmwasm_std::{Addr, Env, QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::{Addr, Env, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{msg::ConfigResponse, result::ContractResult};
@@ -148,7 +149,7 @@ impl ContractInSwap for BuyBack {
     fn state(
         self,
         _in_progress: Stage,
-        _now: Timestamp,
+        _now: Instant,
         _due_projection: Duration,
         _querier: QuerierWrapper<'_>,
     ) -> <Self as SwapTask>::StateResponse {

--- a/protocol/contracts/profit/src/state/idle.rs
+++ b/protocol/contracts/profit/src/state/idle.rs
@@ -11,6 +11,7 @@ use dex::{
     Account, Contract, Enterable, Error as DexError, Handler, Response as DexResponse,
     Result as DexResult, StartLocalLocalState,
 };
+use finance::instant::Instant;
 use finance::{
     coin::{Coin, CoinDTO, WithCoin},
     duration::Duration,
@@ -21,10 +22,11 @@ use platform::{
     message::Response as PlatformResponse,
     state_machine::Response as StateMachineResponse,
 };
-use sdk::cosmwasm_std::{Addr, Env, MessageInfo, QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::{Addr, Env, MessageInfo, QuerierWrapper};
 use timealarms::stub::Result as TimeAlarmsResult;
 
 use crate::{msg::ConfigResponse, profit::Profit, result::ContractResult, typedefs::CadenceHours};
+use cw_time::IntoInstant;
 
 use super::{
     Config, ConfigManagement, State, StateEnum, SwapClient, buy_back::BuyBack,
@@ -52,7 +54,7 @@ impl Idle {
     where
         B: BankAccount,
     {
-        self.enter(env.block.time, querier)
+        self.enter(env.block.time.into_instant(), querier)
             .map(PlatformResponse::messages_only)
             .map(|state_response: PlatformResponse| {
                 Profit::transfer_nls(account, self.config.treasury().clone(), nls, env)
@@ -82,7 +84,7 @@ impl Idle {
             self.try_enter_buy_back(
                 querier,
                 env.contract.address.clone(),
-                env.block.time,
+                env.block.time.into_instant(),
                 balances.rest,
             )
         }
@@ -92,7 +94,7 @@ impl Idle {
         self,
         querier: QuerierWrapper<'_>,
         profit_addr: Addr,
-        now: Timestamp,
+        now: Instant,
         balances: Vec<CoinDTO<PaymentGroup>>,
     ) -> ContractResult<DexResponse<Self>> {
         let state: StartLocalLocalState<BuyBack, SwapClient, ForwardToDexEntry> =
@@ -112,7 +114,7 @@ impl Idle {
             .map_err(Into::into)
     }
 
-    fn setup_time_alarm(config: &Config, now: Timestamp) -> TimeAlarmsResult<Batch> {
+    fn setup_time_alarm(config: &Config, now: Instant) -> TimeAlarmsResult<Batch> {
         config
             .time_alarms()
             .setup_alarm(now + Duration::from_hours(config.cadence_hours()))
@@ -120,7 +122,7 @@ impl Idle {
 }
 
 impl Enterable for Idle {
-    fn enter(&self, now: Timestamp, _: QuerierWrapper<'_>) -> Result<Batch, DexError> {
+    fn enter(&self, now: Instant, _: QuerierWrapper<'_>) -> Result<Batch, DexError> {
         Self::setup_time_alarm(&self.config, now).map_err(DexError::TimeAlarmError)
     }
 }
@@ -130,7 +132,7 @@ impl Contract for Idle {
 
     fn state(
         self,
-        _now: Timestamp,
+        _now: Instant,
         _due_projection: Duration,
         _querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
@@ -143,7 +145,7 @@ impl Contract for Idle {
 impl ConfigManagement for Idle {
     fn try_update_config(
         self,
-        now: Timestamp,
+        now: Instant,
         cadence_hours: CadenceHours,
     ) -> ContractResult<StateMachineResponse<Self>> {
         let config: Config = self.config.update(cadence_hours);

--- a/protocol/contracts/profit/src/state/mod.rs
+++ b/protocol/contracts/profit/src/state/mod.rs
@@ -13,9 +13,7 @@ use platform::{
     state_machine::{self, Response as StateMachineResponse},
 };
 use sdk::{
-    cosmwasm_std::{
-        Binary, Env, MessageInfo, QuerierWrapper, Reply as CwReply, Storage, Timestamp,
-    },
+    cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply as CwReply, Storage},
     cw_storage_plus::Item,
 };
 use swap::Impl;
@@ -26,6 +24,7 @@ use crate::{
 
 pub(crate) use self::config::Config;
 use self::{buy_back::BuyBack, idle::Idle, open_ica::OpenIca, resp_delivery::ForwardToDexEntry};
+use finance::instant::Instant;
 
 mod buy_back;
 mod config;
@@ -44,7 +43,7 @@ where
 {
     fn try_update_config(
         self,
-        _: Timestamp,
+        _: Instant,
         _: CadenceHours,
     ) -> ContractResult<StateMachineResponse<Self>> {
         Err(ContractError::unsupported_operation(
@@ -67,7 +66,7 @@ pub(crate) struct State(StateEnum);
 impl ConfigManagement for State {
     fn try_update_config(
         self,
-        now: Timestamp,
+        now: Instant,
         cadence_hours: CadenceHours,
     ) -> ContractResult<StateMachineResponse<Self>> {
         match self.0 {
@@ -125,7 +124,7 @@ impl Contract for State {
 
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {

--- a/protocol/contracts/profit/src/state/open_ica.rs
+++ b/protocol/contracts/profit/src/state/open_ica.rs
@@ -4,7 +4,8 @@ use finance::duration::Duration;
 use serde::{Deserialize, Serialize};
 
 use dex::{Account, Connectable, ConnectionParams, Contract, IcaConnectee};
-use sdk::cosmwasm_std::{QuerierWrapper, Timestamp};
+use finance::instant::Instant;
+use sdk::cosmwasm_std::QuerierWrapper;
 
 use crate::msg::ConfigResponse;
 
@@ -45,7 +46,7 @@ impl Contract for OpenIca {
 
     fn state(
         self,
-        _now: Timestamp,
+        _now: Instant,
         _due_projection: Duration,
         _querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {

--- a/protocol/packages/dex/Cargo.toml
+++ b/protocol/packages/dex/Cargo.toml
@@ -24,6 +24,7 @@ migration = []
 testing = ["finance/testing"]
 
 [dependencies]
+cw-time = { workspace = true }
 access-control = { workspace = true, optional = true }
 currency = { workspace = true }
 finance = { workspace = true }

--- a/protocol/packages/dex/src/enterable.rs
+++ b/protocol/packages/dex/src/enterable.rs
@@ -1,8 +1,9 @@
+use finance::instant::Instant;
 use platform::batch::Batch;
-use sdk::cosmwasm_std::{QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::QuerierWrapper;
 
 use crate::error::Result;
 
 pub trait Enterable {
-    fn enter(&self, now: Timestamp, querier: QuerierWrapper<'_>) -> Result<Batch>;
+    fn enter(&self, now: Instant, querier: QuerierWrapper<'_>) -> Result<Batch>;
 }

--- a/protocol/packages/dex/src/impl_/ica_connector.rs
+++ b/protocol/packages/dex/src/impl_/ica_connector.rs
@@ -6,12 +6,13 @@ use std::{
 use finance::duration::Duration;
 use serde::{Deserialize, Serialize};
 
+use finance::instant::Instant;
 use platform::{
     batch::{Batch, Emit, Emitter},
     ica::HostAccount,
     message,
 };
-use sdk::cosmwasm_std::{Addr, Env, QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::{Addr, Env, QuerierWrapper};
 
 use crate::{
     Account, Connectable, ContinueResult, Contract, Enterable, Handler, IcaConnectee, Response,
@@ -20,6 +21,7 @@ use crate::{
 
 #[cfg(feature = "migration")]
 use super::migration::{InspectSpec, MigrateSpec};
+use cw_time::IntoInstant;
 
 #[derive(Serialize, Deserialize)]
 #[serde(bound(
@@ -100,7 +102,7 @@ impl<Connectee, SwapResult> Enterable for IcaConnector<Connectee, SwapResult>
 where
     Connectee: IcaConnectee + Connectable,
 {
-    fn enter(&self, _now: Timestamp, _querier: QuerierWrapper<'_>) -> Result<Batch> {
+    fn enter(&self, _now: Instant, _querier: QuerierWrapper<'_>) -> Result<Batch> {
         Ok(self.enter())
     }
 }
@@ -122,7 +124,7 @@ where
         let event = Self::emit_ok(env.contract.address, ica.host().clone());
         let next_state = self.connectee.connected(ica);
         next_state
-            .enter(env.block.time, querier)
+            .enter(env.block.time.into_instant(), querier)
             .map(|batch| message::Response::messages_with_event(batch, event))
             .map(|cw_resp| Response::<Self>::from(cw_resp, next_state))
     }
@@ -136,7 +138,7 @@ where
 
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
@@ -157,7 +159,7 @@ impl<Connectee, SwapResult> TimeAlarm for IcaConnector<Connectee, SwapResult>
 where
     Connectee: TimeAlarm,
 {
-    fn setup_alarm(&self, r#for: Timestamp) -> Result<Batch> {
+    fn setup_alarm(&self, r#for: Instant) -> Result<Batch> {
         self.connectee.setup_alarm(r#for)
     }
 }

--- a/protocol/packages/dex/src/impl_/out_local.rs
+++ b/protocol/packages/dex/src/impl_/out_local.rs
@@ -383,7 +383,8 @@ mod impl_handler {
 
 mod impl_contract {
     use finance::duration::Duration;
-    use sdk::cosmwasm_std::{QuerierWrapper, Timestamp};
+    use finance::instant::Instant;
+    use sdk::cosmwasm_std::QuerierWrapper;
 
     use crate::{Contract, ContractInSwap, ForwardToInner, SwapTask as SwapTaskT};
 
@@ -400,7 +401,7 @@ mod impl_contract {
 
         fn state(
             self,
-            now: Timestamp,
+            now: Instant,
             due_projection: Duration,
             querier: QuerierWrapper<'_>,
         ) -> Self::StateResponse {

--- a/protocol/packages/dex/src/impl_/out_remote.rs
+++ b/protocol/packages/dex/src/impl_/out_remote.rs
@@ -342,7 +342,8 @@ mod impl_handler {
 
 mod impl_contract {
     use finance::duration::Duration;
-    use sdk::cosmwasm_std::{QuerierWrapper, Timestamp};
+    use finance::instant::Instant;
+    use sdk::cosmwasm_std::QuerierWrapper;
 
     use crate::{Contract, ContractInSwap, SwapTask as SwapTaskT};
 
@@ -359,7 +360,7 @@ mod impl_contract {
 
         fn state(
             self,
-            now: Timestamp,
+            now: Instant,
             due_projection: Duration,
             querier: QuerierWrapper<'_>,
         ) -> Self::StateResponse {

--- a/protocol/packages/dex/src/impl_/resp_delivery/mod.rs
+++ b/protocol/packages/dex/src/impl_/resp_delivery/mod.rs
@@ -4,11 +4,12 @@ use std::{
 };
 
 use finance::duration::Duration;
+use finance::instant::Instant;
 use platform::{
     batch::{Batch, Emit, Emitter},
     message::Response as MessageResponse,
 };
-use sdk::cosmwasm_std::{Addr, Binary, Env, MessageInfo, QuerierWrapper, Reply, Timestamp};
+use sdk::cosmwasm_std::{Addr, Binary, Env, MessageInfo, QuerierWrapper, Reply};
 
 use serde::{Deserialize, Serialize};
 
@@ -22,6 +23,7 @@ use crate::{
 use super::migration::{InspectSpec, MigrateSpec};
 
 use self::adapter::{DeliveryAdapter, ICAOpenDeliveryAdapter, ResponseDeliveryAdapter};
+use cw_time::IntoInstant;
 
 mod adapter;
 
@@ -139,7 +141,7 @@ where
         Delivery::deliver_again(self.handler, self.response, querier, env).map_into()
     }
 
-    fn setup_next_delivery(self, now: Timestamp) -> ContinueResult<Self> {
+    fn setup_next_delivery(self, now: Instant) -> ContinueResult<Self> {
         self.handler
             .setup_alarm(now + Self::RIGHT_AFTER_NOW)
             .map(|msgs| MessageResponse::messages_with_event(msgs, self.emit_setup_next_delivery()))
@@ -176,7 +178,7 @@ where
         debug_assert_eq!(msg.id, REPLY_ID);
         debug_assert!(msg.result.is_err());
 
-        self.setup_next_delivery(env.block.time)
+        self.setup_next_delivery(env.block.time.into_instant())
     }
 
     fn on_time_alarm(
@@ -199,7 +201,7 @@ where
 
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {

--- a/protocol/packages/dex/src/impl_/swap_exact_in/mod.rs
+++ b/protocol/packages/dex/src/impl_/swap_exact_in/mod.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use currency::{CurrencyDTO, CurrencyDef, Group, MemberOf};
 use decode_resp::{DecodeThenFinish, DecodeThenTransferIn};
 use encode_req::EncodeRequest;
+use finance::instant::Instant;
 use finance::{
     coin::{Coin, CoinDTO},
     duration::Duration,
@@ -15,7 +16,7 @@ use finance::{
 };
 use platform::{batch::Batch, ica::ErrorResponse as ICAErrorResponse, trx};
 use report_anomaly::ReportAnomalyCmd;
-use sdk::cosmwasm_std::{Binary, Env, QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::{Binary, Env, QuerierWrapper};
 
 use crate::{
     AnomalyTreatment, ConnectionParams, Contract, Stage, error::Result, swap::ExactAmountIn,
@@ -32,6 +33,7 @@ use crate::{
 
 #[cfg(feature = "migration")]
 use super::migration::{InspectSpec, MigrateSpec};
+use cw_time::IntoInstant;
 
 mod decode_resp;
 mod encode_req;
@@ -68,11 +70,7 @@ where
     SwapTask: SwapTaskT,
     SwapClient: ExactAmountIn,
 {
-    pub(super) fn enter_state(
-        &self,
-        _now: Timestamp,
-        querier: QuerierWrapper<'_>,
-    ) -> Result<Batch> {
+    pub(super) fn enter_state(&self, _now: Instant, querier: QuerierWrapper<'_>) -> Result<Batch> {
         self.spec
             .with_slippage_calc(EncodeRequest::<'_, '_, _, SwapClient>::from(
                 &self.spec, querier,
@@ -91,7 +89,7 @@ where
             AnomalyTreatment::Retry(spec) => {
                 let swap_exact_in = SwapExactIn::new(spec);
                 swap_exact_in
-                    .enter(env.block.time, querier)
+                    .enter(env.block.time.into_instant(), querier)
                     .and_then(|batch| response::res_continue::<_, _, Self>(batch, swap_exact_in))
                     .into()
             }
@@ -105,7 +103,7 @@ where
     SwapTask: SwapTaskT,
     SwapClient: ExactAmountIn,
 {
-    fn enter(&self, now: Timestamp, querier: QuerierWrapper<'_>) -> Result<Batch> {
+    fn enter(&self, now: Instant, querier: QuerierWrapper<'_>) -> Result<Batch> {
         self.enter_state(now, querier)
     }
 }
@@ -145,7 +143,7 @@ where
             ))
             .and_then(|next_state| {
                 next_state
-                    .enter(env.block.time, querier)
+                    .enter(env.block.time.into_instant(), querier)
                     .and_then(|resp| response::res_continue::<_, _, Self>(resp, next_state))
             })
             .into()
@@ -228,7 +226,7 @@ where
 
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
@@ -249,7 +247,7 @@ impl<SwapTask, SEnum, SwapClient> TimeAlarm for SwapExactIn<SwapTask, SEnum, Swa
 where
     SwapTask: SwapTaskT,
 {
-    fn setup_alarm(&self, forr: Timestamp) -> Result<Batch> {
+    fn setup_alarm(&self, forr: Instant) -> Result<Batch> {
         self.spec.time_alarm().setup_alarm(forr).map_err(Into::into)
     }
 }

--- a/protocol/packages/dex/src/impl_/timeout.rs
+++ b/protocol/packages/dex/src/impl_/timeout.rs
@@ -6,6 +6,7 @@ use platform::{
 use sdk::cosmwasm_std::{Addr, Env, QuerierWrapper};
 
 use crate::{Enterable, error::Result};
+use cw_time::IntoInstant;
 
 pub(crate) fn on_timeout_retry<S, SEnum, L>(
     current_state: S,
@@ -17,14 +18,16 @@ where
     S: Enterable + Into<SEnum>,
     L: Into<String>,
 {
-    current_state.enter(env.block.time, querier).map(|batch| {
-        let emitter = emit_timeout(state_label, env.contract.address);
+    current_state
+        .enter(env.block.time.into_instant(), querier)
+        .map(|batch| {
+            let emitter = emit_timeout(state_label, env.contract.address);
 
-        StateMachineResponse::from(
-            MessageResponse::messages_with_event(batch, emitter),
-            current_state,
-        )
-    })
+            StateMachineResponse::from(
+                MessageResponse::messages_with_event(batch, emitter),
+                current_state,
+            )
+        })
 }
 
 fn emit_timeout<L>(state_label: L, contract: Addr) -> Emitter

--- a/protocol/packages/dex/src/impl_/transfer_in.rs
+++ b/protocol/packages/dex/src/impl_/transfer_in.rs
@@ -1,7 +1,8 @@
 use currency::CurrencyDef;
+use finance::instant::Instant;
 use finance::{coin::Coin, duration::Duration};
 use platform::{bank, batch::Batch};
-use sdk::cosmwasm_std::{Addr, QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::{Addr, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::error::Result;
@@ -21,7 +22,7 @@ where
         .map(|ref balance| balance >= expected_payment)
 }
 
-pub(super) fn setup_alarm(time_alarms: &TimeAlarmsRef, now: Timestamp) -> Result<Batch> {
+pub(super) fn setup_alarm(time_alarms: &TimeAlarmsRef, now: Instant) -> Result<Batch> {
     time_alarms
         .setup_alarm(now + POLLING_INTERVAL)
         .map_err(Into::into)

--- a/protocol/packages/dex/src/impl_/transfer_in_finish.rs
+++ b/protocol/packages/dex/src/impl_/transfer_in_finish.rs
@@ -6,12 +6,13 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use currency::{CurrencyDef, MemberOf};
+use finance::instant::Instant;
 use finance::{coin::CoinDTO, duration::Duration};
 use platform::{
     batch::{Emit, Emitter},
     message::Response as MessageResponse,
 };
-use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper};
 use timealarms::stub::TimeAlarmDelivery;
 
 use crate::{
@@ -26,6 +27,7 @@ use super::{
     transfer_in,
     transfer_in_init::TransferInInit,
 };
+use cw_time::IntoInstant;
 
 #[derive(Serialize, Deserialize)]
 pub struct TransferInFinish<SwapTask, SEnum>
@@ -34,7 +36,7 @@ where
 {
     spec: SwapTask,
     amount_in: CoinDTO<SwapTask::OutG>,
-    timeout: Timestamp,
+    timeout: Instant,
     #[serde(skip)]
     _state_enum: PhantomData<SEnum>,
 }
@@ -46,7 +48,7 @@ where
     pub(super) fn new(
         spec: SwapTask,
         amount_in: CoinDTO<SwapTask::OutG>,
-        timeout: Timestamp,
+        timeout: Instant,
     ) -> Self {
         Self {
             spec,
@@ -109,7 +111,7 @@ where
             SwapTask: SwapTaskT,
         {
             amount_in: CoinDTO<SwapTask::OutG>,
-            timeout: Timestamp,
+            timeout: Instant,
             querier: QuerierWrapper<'querier>,
             env: Env,
             _task: PhantomData<SwapTask>,
@@ -122,7 +124,7 @@ where
         {
             fn from(
                 amount_in: CoinDTO<SwapTask::OutG>,
-                timeout: Timestamp,
+                timeout: Instant,
                 querier: QuerierWrapper<'querier>,
                 env: Env,
             ) -> Self {
@@ -145,7 +147,7 @@ where
             TransferInFinish<SwapTask, Handler::Response>: Into<Handler::Response>,
         {
             fn try_again(self, spec: SwapTask) -> HandlerResult<Handler> {
-                let now = self.env.block.time;
+                let now = self.env.block.time.into_instant();
                 let emitter = self.emit_ok(&spec);
                 if now >= self.timeout {
                     let next_state = TransferInInit::new(spec, self.amount_in);
@@ -255,7 +257,7 @@ where
 
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {

--- a/protocol/packages/dex/src/impl_/transfer_in_init.rs
+++ b/protocol/packages/dex/src/impl_/transfer_in_init.rs
@@ -5,8 +5,9 @@ use finance::duration::Duration;
 use serde::{Deserialize, Serialize};
 
 use finance::coin::CoinDTO;
+use finance::instant::Instant;
 use platform::batch::Batch;
-use sdk::cosmwasm_std::{Binary, Env, QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::{Binary, Env, QuerierWrapper};
 
 use crate::{
     Connectable, ConnectionParams, Contract, ContractInSwap, Enterable, Stage, TimeAlarm,
@@ -22,6 +23,7 @@ use super::{
     transfer_in_finish::TransferInFinish,
     trx::{IBC_TIMEOUT, TransferInTrx},
 };
+use cw_time::IntoInstant;
 
 /// Transfer in a coin from DEX
 ///
@@ -83,7 +85,7 @@ impl<SwapTask, SEnum> TransferInInit<SwapTask, SEnum>
 where
     SwapTask: SwapTaskT,
 {
-    fn enter_state(&self, now: Timestamp) -> Result<Batch> {
+    fn enter_state(&self, now: Instant) -> Result<Batch> {
         let mut sender = TransferInTrx::new(self.spec.dex_account(), now);
         sender.send(&self.amount_in);
         Ok(sender.into())
@@ -97,8 +99,11 @@ where
     TransferInFinish<SwapTask, SEnum>: Into<SEnum>,
 {
     fn on_response(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
-        let finish: TransferInFinish<SwapTask, SEnum> =
-            TransferInFinish::new(self.spec, self.amount_in, env.block.time + IBC_TIMEOUT);
+        let finish: TransferInFinish<SwapTask, SEnum> = TransferInFinish::new(
+            self.spec,
+            self.amount_in,
+            env.block.time.into_instant() + IBC_TIMEOUT,
+        );
         finish.try_complete(querier, env).map_into()
     }
 }
@@ -116,7 +121,7 @@ impl<SwapTask, SEnum> Enterable for TransferInInit<SwapTask, SEnum>
 where
     SwapTask: SwapTaskT,
 {
-    fn enter(&self, now: Timestamp, _querier: QuerierWrapper<'_>) -> Result<Batch> {
+    fn enter(&self, now: Instant, _querier: QuerierWrapper<'_>) -> Result<Batch> {
         self.enter_state(now)
     }
 }
@@ -156,7 +161,7 @@ where
 
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
@@ -181,7 +186,7 @@ impl<SwapTask, SEnum> TimeAlarm for TransferInInit<SwapTask, SEnum>
 where
     SwapTask: SwapTaskT,
 {
-    fn setup_alarm(&self, r#for: Timestamp) -> Result<Batch> {
+    fn setup_alarm(&self, r#for: Instant) -> Result<Batch> {
         self.spec
             .time_alarm()
             .setup_alarm(r#for)

--- a/protocol/packages/dex/src/impl_/transfer_out/mod.rs
+++ b/protocol/packages/dex/src/impl_/transfer_out/mod.rs
@@ -6,12 +6,13 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use finance::duration::Duration;
+use finance::instant::Instant;
 use platform::{
     batch::{Batch, Emitter},
     ica::ErrorResponse as ICAErrorResponse,
     message::Response as MessageResponse,
 };
-use sdk::cosmwasm_std::{Binary, Env, QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::{Binary, Env, QuerierWrapper};
 
 use crate::{
     CoinsNb, Contract, ContractInSwap, Enterable, Stage, SwapTask as SwapTaskT, TimeAlarm,
@@ -26,6 +27,7 @@ use super::{
     timeout,
     trx::TransferOutTrx,
 };
+use cw_time::IntoInstant;
 
 /// Transfer out a list of coins to DEX
 ///
@@ -83,7 +85,7 @@ where
             .expect("Functionality doesn't support this many coins!")
     }
 
-    fn generate_requests(&self, now: Timestamp) -> Batch {
+    fn generate_requests(&self, now: Instant) -> Batch {
         debug_assert_eq!(
             Self::coins_len(&self.spec),
             self.acks_left,
@@ -145,7 +147,7 @@ where
     Self: Into<SEnum>,
     SwapExactIn<SwapTask, SEnum, SwapClient>: Into<SEnum>,
 {
-    fn enter(&self, now: Timestamp, _querier: QuerierWrapper<'_>) -> Result<Batch> {
+    fn enter(&self, now: Instant, _querier: QuerierWrapper<'_>) -> Result<Batch> {
         Ok(self.generate_requests(now))
     }
 }
@@ -169,7 +171,7 @@ where
         let label = self.spec.label();
         if self.last_ack() {
             let next = SwapExactIn::new(self.spec);
-            next.enter(env.block.time, querier)
+            next.enter(env.block.time.into_instant(), querier)
                 .and_then(|msgs| Self::on_response(next, label, msgs))
         } else {
             Self::on_response(self.next(), label, Batch::default())
@@ -202,7 +204,7 @@ where
 
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
@@ -224,7 +226,7 @@ impl<SwapTask, SEnum, SwapClient> TimeAlarm for TransferOut<SwapTask, SEnum, Swa
 where
     SwapTask: SwapTaskT,
 {
-    fn setup_alarm(&self, r#for: Timestamp) -> Result<Batch> {
+    fn setup_alarm(&self, r#for: Instant) -> Result<Batch> {
         self.spec
             .time_alarm()
             .setup_alarm(r#for)

--- a/protocol/packages/dex/src/impl_/trx.rs
+++ b/protocol/packages/dex/src/impl_/trx.rs
@@ -1,6 +1,8 @@
 use std::marker::PhantomData;
 
 use currency::{Group, MemberOf};
+use cw_time::IntoTimestamp;
+use finance::instant::Instant;
 use finance::{coin::CoinDTO, duration::Duration};
 use oracle::stub::SwapPath;
 use platform::{
@@ -9,7 +11,7 @@ use platform::{
     ica::{self, HostAccount},
     trx::Transaction,
 };
-use sdk::cosmwasm_std::{QuerierWrapper, Timestamp};
+use sdk::cosmwasm_std::QuerierWrapper;
 
 use crate::{Account, Connectable, error::Result, swap::ExactAmountIn};
 
@@ -20,13 +22,13 @@ pub(super) struct TransferOutTrx<'ica> {
 }
 
 impl<'ica> TransferOutTrx<'ica> {
-    pub(super) fn new(ica: &'ica Account, now: Timestamp) -> Self {
+    pub(super) fn new(ica: &'ica Account, now: Instant) -> Self {
         Self {
             sender: LocalSender::new(
                 &ica.dex().transfer_channel.local_endpoint,
                 ica.owner(),
                 ica.host(),
-                now + IBC_TIMEOUT,
+                (now + IBC_TIMEOUT).into_timestamp(),
                 format!(
                     "Transfer out: {sender} -> {receiver}",
                     sender = ica.owner(),
@@ -122,12 +124,12 @@ pub(super) struct TransferInTrx<'a> {
 }
 
 impl<'ica> TransferInTrx<'ica> {
-    pub(super) fn new(ica: &'ica Account, now: Timestamp) -> Self {
+    pub(super) fn new(ica: &'ica Account, now: Instant) -> Self {
         let sender = RemoteSender::new(
             &ica.dex().transfer_channel.remote_endpoint,
             ica.host(),
             ica.owner(),
-            now + IBC_TIMEOUT,
+            (now + IBC_TIMEOUT).into_timestamp(),
         );
         TransferInTrx {
             conn: &ica.dex().connection_id,

--- a/protocol/packages/dex/src/state.rs
+++ b/protocol/packages/dex/src/state.rs
@@ -1,5 +1,6 @@
 use finance::duration::Duration;
-use sdk::cosmwasm_std::{QuerierWrapper, Timestamp};
+use finance::instant::Instant;
+use sdk::cosmwasm_std::QuerierWrapper;
 
 /// Contract during a DEX workflow
 pub trait Contract
@@ -10,7 +11,7 @@ where
 
     fn state(
         self,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse;
@@ -26,7 +27,7 @@ where
     fn state(
         self,
         in_progress: Stage,
-        now: Timestamp,
+        now: Instant,
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse;

--- a/protocol/packages/dex/src/time_alarm.rs
+++ b/protocol/packages/dex/src/time_alarm.rs
@@ -1,8 +1,8 @@
+use finance::instant::Instant;
 use platform::batch::Batch;
-use sdk::cosmwasm_std::Timestamp;
 
 use crate::DexResult;
 
 pub trait TimeAlarm {
-    fn setup_alarm(&self, r#for: Timestamp) -> DexResult<Batch>;
+    fn setup_alarm(&self, r#for: Instant) -> DexResult<Batch>;
 }

--- a/protocol/packages/marketprice/src/config.rs
+++ b/protocol/packages/marketprice/src/config.rs
@@ -1,12 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-use finance::{duration::Duration, fraction::Fraction, percent::Percent100};
-use sdk::cosmwasm_std::Timestamp;
-
 use crate::{
     error::{self, PriceFeedsError},
     feeders::Count,
 };
+use finance::instant::Instant;
+use finance::{duration::Duration, fraction::Fraction, percent::Percent100};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "testing"), derive(Debug))]
@@ -70,13 +69,13 @@ impl Config {
         self.samples_number
     }
 
-    pub fn feed_valid_since(&self, now: Timestamp) -> Timestamp {
-        debug_assert!(now > Timestamp::default());
+    pub fn feed_valid_since(&self, now: Instant) -> Instant {
+        debug_assert!(now > Instant::default());
 
-        let ret = if Timestamp::default() + self.feed_validity <= now {
+        let ret = if Instant::default() + self.feed_validity <= now {
             now - self.feed_validity
         } else {
-            Timestamp::default()
+            Instant::default()
         };
         debug_assert!(ret < now, "{ret} >= {now}");
         ret
@@ -165,9 +164,10 @@ mod unchecked {
 
 #[cfg(test)]
 mod test {
+    use finance::instant::Instant;
     use finance::{duration::Duration, percent::Percent100};
     use platform::tests as platform_tests;
-    use sdk::cosmwasm_std::{self, StdError, Timestamp};
+    use sdk::cosmwasm_std::{self, StdError};
 
     use crate::{config::Config, feeders::Count};
 
@@ -180,24 +180,24 @@ mod test {
             Percent100::from_permille(1000),
         );
         assert_eq!(
-            Timestamp::from_seconds(0),
-            c.feed_valid_since(Timestamp::from_seconds(1))
+            Instant::from_seconds(0),
+            c.feed_valid_since(Instant::from_seconds(1))
         );
         assert_eq!(
-            Timestamp::from_seconds(0),
-            c.feed_valid_since(Timestamp::from_seconds(40))
+            Instant::from_seconds(0),
+            c.feed_valid_since(Instant::from_seconds(40))
         );
         assert_eq!(
-            Timestamp::from_seconds(0),
-            c.feed_valid_since(Timestamp::from_seconds(60))
+            Instant::from_seconds(0),
+            c.feed_valid_since(Instant::from_seconds(60))
         );
         assert_eq!(
-            Timestamp::from_seconds(1),
-            c.feed_valid_since(Timestamp::from_seconds(61))
+            Instant::from_seconds(1),
+            c.feed_valid_since(Instant::from_seconds(61))
         );
         assert_eq!(
-            Timestamp::from_seconds(40),
-            c.feed_valid_since(Timestamp::from_seconds(100))
+            Instant::from_seconds(40),
+            c.feed_valid_since(Instant::from_seconds(100))
         );
     }
 

--- a/protocol/packages/marketprice/src/feed/cw/observations.rs
+++ b/protocol/packages/marketprice/src/feed/cw/observations.rs
@@ -1,9 +1,9 @@
-use std::ops::{Deref, DerefMut};
-
+use finance::instant::Instant;
 use sdk::{
-    cosmwasm_std::{Storage, Timestamp},
+    cosmwasm_std::Storage,
     cw_storage_plus::{Deque as CwDeque, Namespace},
 };
+use std::ops::{Deref, DerefMut};
 
 use crate::{
     error::PriceFeedsError,
@@ -72,7 +72,7 @@ where
     QuoteC: 'static,
     S: Deref<Target = dyn Storage + 'storage> + DerefMut,
 {
-    fn retain(&mut self, valid_since: &Timestamp) -> Result<(), PriceFeedsError> {
+    fn retain(&mut self, valid_since: &Instant) -> Result<(), PriceFeedsError> {
         loop {
             match self
                 .storage
@@ -108,6 +108,7 @@ where
 
 #[cfg(test)]
 mod test {
+    use finance::instant::Instant;
     use std::fmt::Debug;
 
     use currency::test::{SuperGroupTestC4, SuperGroupTestC5};
@@ -116,14 +117,14 @@ mod test {
         duration::Duration,
         price::{self, Price},
     };
-    use sdk::cosmwasm_std::{Addr, Storage, Timestamp, testing::MockStorage};
+    use sdk::cosmwasm_std::{Addr, Storage, testing::MockStorage};
 
     use crate::feed::observations::{Observations, ObservationsRead};
 
     use super::{Deque, Observation};
 
     const VALIDITY_PERIOD: Duration = Duration::from_secs(60);
-    const BLOCK_TIME: Timestamp = Timestamp::from_seconds(150);
+    const BLOCK_TIME: Instant = Instant::from_seconds(150);
     const FEEDER: &str = "feeder1";
 
     type C1 = SuperGroupTestC4;

--- a/protocol/packages/marketprice/src/feed/memory.rs
+++ b/protocol/packages/marketprice/src/feed/memory.rs
@@ -1,4 +1,4 @@
-use sdk::cosmwasm_std::Timestamp;
+use finance::instant::Instant;
 
 use crate::error::PriceFeedsError;
 
@@ -47,7 +47,7 @@ where
     C: 'static,
     QuoteC: 'static,
 {
-    fn retain(&mut self, valid_since: &Timestamp) -> Result<(), PriceFeedsError> {
+    fn retain(&mut self, valid_since: &Instant) -> Result<(), PriceFeedsError> {
         self.0.retain(|o| o.valid_since(valid_since));
         Ok(())
     }

--- a/protocol/packages/marketprice/src/feed/mod.rs
+++ b/protocol/packages/marketprice/src/feed/mod.rs
@@ -1,8 +1,9 @@
 use std::{collections::HashSet, marker::PhantomData};
 
+use finance::instant::Instant;
 use finance::{percent::Percent100, price::Price};
 use observations::{Observations, ObservationsRead};
-use sdk::cosmwasm_std::{Addr, Timestamp};
+use sdk::cosmwasm_std::Addr;
 
 use crate::{
     config::Config,
@@ -63,7 +64,7 @@ where
     pub fn calc_price(
         &self,
         config: &Config,
-        at: Timestamp,
+        at: Instant,
         total_feeders: Count,
     ) -> Result<Price<C, QuoteC>> {
         let valid_since = config.feed_valid_since(at);
@@ -99,7 +100,7 @@ where
             })
     }
 
-    fn valid_observations(&self, since: &Timestamp) -> Result<Vec<Observation<C, QuoteC>>> {
+    fn valid_observations(&self, since: &Instant) -> Result<Vec<Observation<C, QuoteC>>> {
         self.observations.as_iter().and_then(|mut items| {
             items.try_fold(
                 Vec::with_capacity(self.observations.len()),
@@ -149,9 +150,9 @@ where
     pub fn add_observation(
         mut self,
         from: Addr,
-        at: Timestamp,
+        at: Instant,
         price: Price<C, QuoteC>,
-        valid_since: &Timestamp,
+        valid_since: &Instant,
     ) -> Result<Self> {
         debug_assert!(valid_since < &at, "{valid_since} >= {at}");
         self.observations
@@ -194,13 +195,14 @@ where
 #[cfg(test)]
 mod test {
     use currency::test::{SuperGroupTestC4, SuperGroupTestC5};
+    use finance::instant::Instant;
     use finance::{
         coin::{Amount, Coin},
         duration::Duration,
         percent::Percent100,
         price::{self, Price},
     };
-    use sdk::cosmwasm_std::{Addr, Timestamp};
+    use sdk::cosmwasm_std::Addr;
 
     use crate::{config::Config, error::PriceFeedsError, feeders::Count};
 
@@ -222,7 +224,7 @@ mod test {
 
     #[test]
     fn old_observations() {
-        let block_time = Timestamp::from_seconds(100);
+        let block_time = Instant::from_seconds(100);
         let config = Config::new(
             Percent100::MAX,
             SAMPLE_PERIOD,
@@ -264,7 +266,7 @@ mod test {
     #[test]
     fn less_feeders() {
         let validity_period = Duration::from_secs(60);
-        let block_time = Timestamp::from_seconds(100);
+        let block_time = Instant::from_seconds(100);
 
         let feeder1 = Addr::unchecked("feeder1");
         let feed1_time = block_time;
@@ -301,7 +303,7 @@ mod test {
     #[test]
     fn less_feeders_with_valid_observations() {
         let validity_period = Duration::from_secs(60);
-        let block_time = Timestamp::from_seconds(150);
+        let block_time = Instant::from_seconds(150);
 
         let feeder1 = Addr::unchecked("feeder1");
         let feed1_time = block_time - validity_period;
@@ -358,7 +360,7 @@ mod test {
 
     #[test]
     fn ema_price() {
-        let block_time = Timestamp::from_seconds(100);
+        let block_time = Instant::from_seconds(100);
         let config = Config::new(
             Percent100::MAX,
             SAMPLE_PERIOD,

--- a/protocol/packages/marketprice/src/feed/observation.rs
+++ b/protocol/packages/marketprice/src/feed/observation.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+use finance::instant::Instant;
 use finance::price::Price;
-use sdk::cosmwasm_std::{Addr, Timestamp};
+use sdk::cosmwasm_std::Addr;
 
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(test, derive(Debug, Eq, PartialEq))]
@@ -12,14 +13,14 @@ where
     QuoteC: 'static,
 {
     feeder_addr: Addr,
-    time: Timestamp,
+    time: Instant,
     price: Price<C, QuoteC>,
 }
 
 impl<C, QuoteC> Observation<C, QuoteC> {
     pub fn new(
         feeder_addr: Addr,
-        time: Timestamp,
+        time: Instant,
         price: Price<C, QuoteC>,
     ) -> Observation<C, QuoteC> {
         Observation {
@@ -37,7 +38,7 @@ impl<C, QuoteC> Observation<C, QuoteC> {
         self.price
     }
 
-    pub fn valid_since(&self, since: &Timestamp) -> bool {
+    pub fn valid_since(&self, since: &Instant) -> bool {
         since < &self.time
     }
 }

--- a/protocol/packages/marketprice/src/feed/observations.rs
+++ b/protocol/packages/marketprice/src/feed/observations.rs
@@ -1,5 +1,5 @@
 use currency::{CurrencyDTO, Group};
-use sdk::cosmwasm_std::Timestamp;
+use finance::instant::Instant;
 
 use crate::error::Result;
 
@@ -23,7 +23,7 @@ where
     Self::C: 'static,
     Self::QuoteC: 'static,
 {
-    fn retain(&mut self, valid_since: &Timestamp) -> Result<()>;
+    fn retain(&mut self, valid_since: &Instant) -> Result<()>;
 
     /// Register a newer observation
     ///

--- a/protocol/packages/marketprice/src/feed/sample.rs
+++ b/protocol/packages/marketprice/src/feed/sample.rs
@@ -3,11 +3,12 @@ use std::collections::HashMap;
 use finance::{
     coin::Amount, duration::Duration, fraction::Unit, price::Price, ratio::SimpleFraction,
 };
-use sdk::cosmwasm_std::{Addr, Timestamp};
+use sdk::cosmwasm_std::Addr;
 
 use crate::feeders::Count;
 
 use super::observation::Observation;
+use finance::instant::Instant;
 
 /// Builds an infinite iterator of samples
 ///
@@ -17,7 +18,7 @@ use super::observation::Observation;
 /// period is yielded again.
 pub fn from_observations<'a, Observations, C, QuoteC>(
     observations: Observations,
-    start_from: Timestamp,
+    start_from: Instant,
     sample_span: Duration,
 ) -> impl Iterator<Item = Sample<C, QuoteC>>
 where
@@ -79,7 +80,7 @@ where
     QuoteC: 'static,
 {
     observations: IterO,
-    sample_start: Timestamp,
+    sample_start: Instant,
     sample_span: Duration,
     consumed: Option<IterO::Item>,
     sample_prices: HashMap<&'a Addr, Price<C, QuoteC>>,
@@ -90,7 +91,7 @@ impl<'a, IterO, C, QuoteC> SampleBuilder<'a, IterO, C, QuoteC>
 where
     IterO: Iterator<Item = &'a Observation<C, QuoteC>>,
 {
-    fn from(observations: IterO, start_from: Timestamp, sample_span: Duration) -> Self {
+    fn from(observations: IterO, start_from: Instant, sample_span: Duration) -> Self {
         Self {
             observations,
             sample_start: start_from,
@@ -101,7 +102,7 @@ where
         }
     }
 
-    fn sample_end(&self) -> Timestamp {
+    fn sample_end(&self) -> Instant {
         self.sample_start + self.sample_span
     }
 
@@ -168,12 +169,13 @@ where
 #[cfg(test)]
 mod test {
     use currency::test::{SuperGroupTestC4, SuperGroupTestC5};
+    use finance::instant::Instant;
     use finance::{
         coin::{Amount, Coin},
         duration::Duration,
         price::{self},
     };
-    use sdk::cosmwasm_std::{Addr, Timestamp};
+    use sdk::cosmwasm_std::Addr;
 
     use crate::feed::{
         observation::Observation,
@@ -185,8 +187,8 @@ mod test {
 
     #[test]
     fn one_observation() {
-        let start_from = Timestamp::from_seconds(150);
-        let t1 = Timestamp::from_seconds(200);
+        let start_from = Instant::from_seconds(150);
+        let t1 = Instant::from_seconds(200);
         let p1 = price(1, 12000);
         let obs = [Observation::new(feeder1(), t1, p1)];
 
@@ -200,10 +202,10 @@ mod test {
 
     #[test]
     fn a_few_observations_per_feeder() {
-        let start_from = Timestamp::from_seconds(150);
-        let t11 = Timestamp::from_seconds(160);
-        let t21 = Timestamp::from_seconds(180);
-        let t22 = Timestamp::from_seconds(200);
+        let start_from = Instant::from_seconds(150);
+        let t11 = Instant::from_seconds(160);
+        let t21 = Instant::from_seconds(180);
+        let t22 = Instant::from_seconds(200);
         let p1 = price(1, 12000);
         let p2 = price(1, 13000);
         let p3 = price(1, 14000);
@@ -224,12 +226,12 @@ mod test {
 
     #[test]
     fn real_observations() {
-        let start_from = Timestamp::from_seconds(150);
-        let t11 = Timestamp::from_seconds(160);
-        let t21 = Timestamp::from_seconds(180);
-        let t22 = Timestamp::from_seconds(200);
-        let t31 = Timestamp::from_seconds(201);
-        let t32 = Timestamp::from_seconds(225);
+        let start_from = Instant::from_seconds(150);
+        let t11 = Instant::from_seconds(160);
+        let t21 = Instant::from_seconds(180);
+        let t22 = Instant::from_seconds(200);
+        let t31 = Instant::from_seconds(201);
+        let t32 = Instant::from_seconds(225);
 
         let p1 = price(1, 12000);
         let p2 = price(1, 13000);
@@ -259,9 +261,9 @@ mod test {
     #[ignore = "issue #594"]
     #[test]
     fn price_sum_overflow_from_c() {
-        let start_from = Timestamp::from_seconds(150);
-        let t1 = Timestamp::from_seconds(160);
-        let t2 = Timestamp::from_seconds(165);
+        let start_from = Instant::from_seconds(150);
+        let t1 = Instant::from_seconds(160);
+        let t2 = Instant::from_seconds(165);
 
         let p1 = price(Amount::MAX / 2, 1);
         let p2 = price(Amount::MAX / 2 + 1, 1);
@@ -280,9 +282,9 @@ mod test {
     #[ignore = "issue #594"]
     #[test]
     fn price_sum_overflow_from_quotec() {
-        let start_from = Timestamp::from_seconds(150);
-        let t1 = Timestamp::from_seconds(160);
-        let t2 = Timestamp::from_seconds(165);
+        let start_from = Instant::from_seconds(150);
+        let t1 = Instant::from_seconds(160);
+        let t2 = Instant::from_seconds(165);
 
         let p1 = price(1, Amount::MAX / 2);
         let p2 = price(1, (Amount::MAX / 2) + 2);
@@ -299,9 +301,9 @@ mod test {
     }
     #[test]
     fn price_max_sum() {
-        let start_from = Timestamp::from_seconds(150);
-        let t1 = Timestamp::from_seconds(160);
-        let t2 = Timestamp::from_seconds(165);
+        let start_from = Instant::from_seconds(150);
+        let t1 = Instant::from_seconds(160);
+        let t2 = Instant::from_seconds(165);
 
         let p1 = price(1, Amount::MAX / 2);
         let p2 = price(1, (Amount::MAX / 2) + 1);

--- a/protocol/packages/marketprice/src/market_price.rs
+++ b/protocol/packages/marketprice/src/market_price.rs
@@ -4,12 +4,13 @@ use currency::{
     self, AnyVisitor, Currency, CurrencyDTO, CurrencyDef, Group, InPoolWith, MemberOf, PairsGroup,
     PairsVisitor,
 };
+use finance::instant::Instant;
 use finance::price::{
     Price,
     base::BasePrice,
     dto::{PriceDTO, WithPrice, with_price},
 };
-use sdk::cosmwasm_std::{Addr, Timestamp};
+use sdk::cosmwasm_std::Addr;
 
 use crate::{
     config::Config,
@@ -41,7 +42,7 @@ where
 {
     pub fn price<'self_, 'currency_dto, BaseC, BaseG, CurrenciesToBaseC>(
         &'self_ self,
-        at: Timestamp,
+        at: Instant,
         total_feeders: Count,
         mut leaf_to_base: CurrenciesToBaseC,
     ) -> Result<BasePrice<PriceG, BaseC, BaseG>, PriceFeedsError>
@@ -67,7 +68,7 @@ where
             G: Group,
         {
             feeds: &'feeds PriceFeeds<'config, G, ObservationsRepoImpl>,
-            at: Timestamp,
+            at: Instant,
             total_feeders: Count,
             leaf_to_base: CurrenciesToBaseC,
             _base_c: PhantomData<BaseC>,
@@ -134,7 +135,7 @@ where
         &self,
         amount_c: &CurrencyDTO<PriceG>,
         quote_c: &CurrencyDTO<PriceG>,
-        at: Timestamp,
+        at: Instant,
         total_feeders: Count,
     ) -> Result<Price<C, QuoteC>, PriceFeedsError>
     where
@@ -159,7 +160,7 @@ where
     /// The time `at` must always flow monotonically forward!
     pub fn feed(
         &mut self,
-        at: Timestamp,
+        at: Instant,
         sender_raw: Addr,
         prices: &[PriceDTO<PriceG>],
     ) -> Result<(), PriceFeedsError> {
@@ -176,9 +177,9 @@ where
     fn add_observation(
         &mut self,
         from: Addr,
-        at: Timestamp,
+        at: Instant,
         price: &PriceDTO<PriceG>,
-        valid_since: &Timestamp,
+        valid_since: &Instant,
     ) -> Result<(), PriceFeedsError> {
         debug_assert!(valid_since < &at);
         struct AddObservation<'feeds, 'since, G, ObservationsRepoImpl>
@@ -189,8 +190,8 @@ where
             amount_c: CurrencyDTO<G>,
             quote_c: CurrencyDTO<G>,
             from: Addr,
-            at: Timestamp,
-            valid_since: &'since Timestamp,
+            at: Instant,
+            valid_since: &'since Instant,
             group: PhantomData<G>,
         }
 
@@ -251,7 +252,7 @@ struct PriceCollect<
 {
     leaf_to_base: CurrenciesToBaseC,
     feeds: &'feeds PriceFeeds<'config, G, ObservationsRepoImpl>,
-    at: Timestamp,
+    at: Instant,
     total_feeders: Count,
     current_c: &'currency CurrencyDTO<G>,
     _base_c: PhantomData<BaseC>,
@@ -400,13 +401,14 @@ mod test {
         SubGroup, SubGroupTestC10, SuperGroupTestC1, SuperGroupTestC2, SuperGroupTestC3,
         SuperGroupTestC4, SuperGroupTestC5,
     };
+    use finance::instant::Instant;
     use finance::{
         coin::Coin,
         duration::Duration,
         percent::Percent100,
         price::{self, Price},
     };
-    use sdk::cosmwasm_std::{Addr, Storage, Timestamp, testing::MockStorage};
+    use sdk::cosmwasm_std::{Addr, Storage, testing::MockStorage};
 
     use crate::{
         Repo,
@@ -425,7 +427,7 @@ mod test {
     const SAMPLES_NUMBER: u16 = 6;
     const DISCOUNTING_FACTOR: Percent100 = Percent100::from_permille(750);
 
-    const NOW: Timestamp = Timestamp::from_seconds(FEED_VALIDITY.secs() * 2);
+    const NOW: Instant = Instant::from_seconds(FEED_VALIDITY.secs() * 2);
 
     #[test]
     fn no_feed() {

--- a/protocol/packages/marketprice/src/tests.rs
+++ b/protocol/packages/marketprice/src/tests.rs
@@ -14,7 +14,7 @@ use finance::{
     price::{self, Price, dto::PriceDTO},
 };
 use sdk::{
-    cosmwasm_std::{Storage, Timestamp, testing::MockStorage},
+    cosmwasm_std::{Storage, testing::MockStorage},
     testing,
 };
 
@@ -24,6 +24,7 @@ use crate::feeders::Count;
 use crate::{
     config::Config, error::PriceFeedsError, feeders::PriceFeeders, market_price::PriceFeeds,
 };
+use finance::instant::Instant;
 
 const ROOT_NS: &str = "root_ns";
 const TOTAL_FEEDERS: Count = Count::new_test(1);
@@ -45,7 +46,7 @@ pub(super) fn assert_price<
 >(
     expected: Price<C, BaseC>,
     feeds: &PriceFeeds<'config, PriceG, ObservationsRepoImpl>,
-    at: Timestamp,
+    at: Instant,
     total_feeders: Count,
     leaf_to_base: CurrenciesToBaseC,
 ) where
@@ -81,7 +82,7 @@ pub(super) fn assert_no_price<
     CurrenciesToBaseC,
 >(
     feeds: &PriceFeeds<'config, PriceG, ObservationsRepoImpl>,
-    at: Timestamp,
+    at: Instant,
     total_feeders: Count,
     leaf_to_base: CurrenciesToBaseC,
 ) where
@@ -338,7 +339,7 @@ fn marketprice_follow_the_path() {
 fn feed_price<C1, C2, G, ObservationsRepoT>(
     market: &mut PriceFeeds<'_, G, ObservationsRepoT>,
     price: Price<C1, C2>,
-) -> Result<Timestamp, PriceFeedsError>
+) -> Result<Instant, PriceFeedsError>
 where
     C1: CurrencyDef,
     C1::Group: MemberOf<G>,
@@ -358,7 +359,7 @@ where
 
 fn price<'config, 'currency_dto, ObservationsRepoImpl, PriceG, BaseC, BaseG, CurrenciesToBaseC>(
     feeds: &PriceFeeds<'config, PriceG, ObservationsRepoImpl>,
-    at: Timestamp,
+    at: Instant,
     total_feeders: Count,
     leaf_to_base: CurrenciesToBaseC,
 ) -> Result<BasePrice<PriceG, BaseC, BaseG>, PriceFeedsError>
@@ -390,9 +391,9 @@ where
     price::total_of(Coin::<C1>::new(coin1)).is(Coin::<C2>::new(coin2))
 }
 
-fn now() -> Timestamp {
+fn now() -> Instant {
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
-    Timestamp::from_seconds(now.as_secs())
+    Instant::from_seconds(now.as_secs())
 }

--- a/protocol/packages/remote_lease/Cargo.toml
+++ b/protocol/packages/remote_lease/Cargo.toml
@@ -30,5 +30,4 @@ thiserror = { workspace = true }
 currencies = { workspace = true, features = ["testing"] }
 currency = { workspace = true, features = ["testing"] }
 finance = { workspace = true, features = ["testing"] }
-sdk = { workspace = true, features = ["testing"] }
 serde_json = { workspace = true }

--- a/protocol/tests/tests/oracle.rs
+++ b/protocol/tests/tests/oracle.rs
@@ -1,7 +1,8 @@
 use currencies::{Lpn, Lpns, PaymentGroup};
+use finance::instant::Instant;
 use sdk::{
     cosmwasm_std::{
-        self, Binary, Deps, Env, Storage, Timestamp,
+        self, Binary, Deps, Env, Storage,
         testing::{self as cw_testing},
     },
     testing::manage_state,

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -519,6 +519,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-time"
+version = "0.1.0"
+dependencies = [
+ "finance",
+ "sdk",
+]
+
+[[package]]
 name = "cw-utils"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +620,7 @@ version = "0.2.3"
 dependencies = [
  "access-control",
  "currency",
+ "cw-time",
  "finance",
  "oracle",
  "oracle-platform",
@@ -775,7 +784,6 @@ dependencies = [
  "currency",
  "gcd",
  "num-integer",
- "sdk",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -938,6 +946,7 @@ dependencies = [
  "admin_contract",
  "currencies",
  "currency",
+ "cw-time",
  "dex",
  "finance",
  "lease",
@@ -1027,6 +1036,7 @@ dependencies = [
  "cosmwasm-std",
  "currencies",
  "currency",
+ "cw-time",
  "dex",
  "enum_dispatch",
  "finance",
@@ -1080,6 +1090,7 @@ dependencies = [
  "cosmwasm-std",
  "currencies",
  "currency",
+ "cw-time",
  "finance",
  "lpp-platform",
  "oracle",
@@ -1168,6 +1179,7 @@ dependencies = [
  "cosmwasm-std",
  "currencies",
  "currency",
+ "cw-time",
  "finance",
  "marketprice",
  "oracle-platform",
@@ -1223,6 +1235,7 @@ name = "platform"
 version = "0.4.0"
 dependencies = [
  "currency",
+ "cw-time",
  "finance",
  "sdk",
  "serde",
@@ -1270,6 +1283,7 @@ dependencies = [
  "cosmwasm-std",
  "currencies",
  "currency",
+ "cw-time",
  "dex",
  "finance",
  "oracle",
@@ -1815,6 +1829,7 @@ dependencies = [
 name = "time-oracle"
 version = "0.2.2"
 dependencies = [
+ "finance",
  "sdk",
  "serde",
  "thiserror 2.0.18",
@@ -1826,6 +1841,8 @@ version = "0.5.2"
 dependencies = [
  "access-control",
  "cosmwasm-std",
+ "cw-time",
+ "finance",
  "platform",
  "sdk",
  "serde",
@@ -1852,6 +1869,7 @@ dependencies = [
  "admin_contract",
  "cosmwasm-std",
  "currency",
+ "cw-time",
  "finance",
  "lpp-platform",
  "oracle-platform",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -49,6 +49,7 @@ timealarms = { path = "../platform/contracts/timealarms", features = ["contract"
 treasury = { path = "../platform/contracts/treasury", default-features = false }
 
 access-control = { path = "../platform/packages/access-control", default-features = false }
+cw-time = { path = "../platform/packages/cw-time", default-features = false }
 currencies = { path = "../protocol/packages/currencies", features = ["testing"], default-features = false }
 currency = { path = "../platform/packages/currency", features = ["testing"], default-features = false }
 dex = { path = "../protocol/packages/dex", features = ["testing"], default-features = false }

--- a/tests/src/common/mod.rs
+++ b/tests/src/common/mod.rs
@@ -8,6 +8,7 @@ use currency::{
     BankSymbols, CurrencyDTO, CurrencyDef, DexSymbols, Group, GroupFilterMap, MemberOf, PairsGroup,
     Symbol,
 };
+use finance::instant::Instant;
 use finance::{
     coin::{Amount, Coin},
     duration::Duration,

--- a/tests/src/lease/repay.rs
+++ b/tests/src/lease/repay.rs
@@ -3,6 +3,7 @@ use std::slice;
 use ::swap::testing::SwapRequest;
 use currencies::PaymentGroup;
 use currency::CurrencyDef;
+use finance::instant::Instant;
 use finance::{
     coin::{Coin, CoinDTO},
     duration::Duration,
@@ -18,11 +19,7 @@ use lease::api::{
     query::{ClosePolicy, StateResponse, opened::Status, paid::ClosingTrx},
 };
 use platform::coin_legacy;
-use sdk::{
-    cosmwasm_std::{Addr, Timestamp},
-    cw_multi_test::AppResponse,
-    testing,
-};
+use sdk::{cosmwasm_std::Addr, cw_multi_test::AppResponse, testing};
 
 use crate::{
     common::{
@@ -196,7 +193,7 @@ fn full_repay_with_max_ltd() {
         due_interest: LpnCoin::ZERO.into(),
         due_projection: Duration::default(),
         close_policy: ClosePolicy::default(),
-        validity: Timestamp::from_nanos(1537237459879305533),
+        validity: Instant::from_nanos(1537237459879305533),
         status: Status::Idle,
     };
     assert_eq!(

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -2,7 +2,8 @@
 #![allow(clippy::unwrap_used)]
 
 use common::test_case::TestCase;
-use sdk::cosmwasm_std::Timestamp;
+use cw_time::IntoInstant;
+use finance::instant::Instant;
 
 mod common;
 mod lease;
@@ -25,6 +26,6 @@ fn block_time<ProtocolsRegistry, Treasury, Profit, Reserve, Leaser, Lpp, Oracle,
         Oracle,
         TimeAlarms,
     >,
-) -> Timestamp {
-    test_case.app.block_info().time
+) -> Instant {
+    test_case.app.block_info().time.into_instant()
 }

--- a/tests/src/oracle_tests.rs
+++ b/tests/src/oracle_tests.rs
@@ -6,6 +6,7 @@ use currencies::{
     testing::{LeaseC1, LeaseC2, PaymentC1, PaymentC4, PaymentC5, PaymentC6, PaymentC7},
 };
 use currency::CurrencyDef;
+use finance::instant::Instant;
 use finance::{
     coin::{Amount, Coin},
     duration::Duration,
@@ -22,8 +23,7 @@ use platform::{batch::Batch, coin_legacy, contract::Code};
 use sdk::{
     cosmwasm_ext::{InterChainMsg, Response as CwResponse},
     cosmwasm_std::{
-        self, Addr, Attribute, Binary, Deps, DepsMut, Env, Event, MessageInfo, Storage, Timestamp,
-        coin,
+        self, Addr, Attribute, Binary, Deps, DepsMut, Env, Event, MessageInfo, Storage, coin,
     },
     cw_multi_test::{AppResponse, Contract as CwContract},
     cw_storage_plus::Item,
@@ -224,7 +224,7 @@ fn wrong_timealarms_addr() {
     let mut test_case = create_test_case();
 
     let alarm_msg = timealarms::msg::ExecuteMsg::AddAlarm {
-        time: Timestamp::from_seconds(100),
+        time: Instant::from_seconds(100),
     };
 
     () = test_case

--- a/tests/src/timealarms_tests.rs
+++ b/tests/src/timealarms_tests.rs
@@ -2,7 +2,8 @@ use std::array;
 
 use currencies::{Lpn, Nls};
 use currency::CurrencyDef;
-use finance::{coin::Coin, duration::Duration};
+use cw_time::IntoInstant;
+use finance::{coin::Coin, duration::Duration, instant::Instant};
 use platform::tests;
 use sdk::{
     cosmwasm_std::{Addr, Attribute, Event, Timestamp, coin},
@@ -24,6 +25,7 @@ use self::mock_lease::*;
 mod mock_lease {
     use serde::{Deserialize, Serialize};
 
+    use cw_time::IntoInstant;
     use finance::duration::Duration;
     use platform::{message::Response as PlatformResponse, response};
     use sdk::{
@@ -84,7 +86,7 @@ mod mock_lease {
 
                 if gate {
                     Ok(Response::new()
-                        .add_attribute("lease_reply", env.block.time.to_string())
+                        .add_attribute("lease_reply", env.block.time.into_instant().to_string())
                         .set_data(cosmwasm_std::to_json_binary(&env.contract.address)?))
                 } else {
                     Err(StdError::msg("closed gate"))
@@ -110,7 +112,7 @@ mod mock_lease {
                     .load(deps.storage)
                     .expect("test setup error");
                 let batch = TimeAlarmsRef::unchecked(timealarms)
-                    .setup_alarm(env.block.time + Duration::from_secs(5))
+                    .setup_alarm(env.block.time.into_instant() + Duration::from_secs(5))
                     .unwrap();
 
                 Ok(response::response_only_messages(
@@ -232,7 +234,7 @@ fn add_alarm<ProtocolsRegistry, Treasury, Profit, Reserve, Leaser, Lpp, Oracle>(
     time_secs: u64,
 ) {
     let alarm_msg = timealarms::msg::ExecuteMsg::AddAlarm {
-        time: Timestamp::from_seconds(time_secs),
+        time: Instant::from_seconds(time_secs),
     };
     () = test_case
         .app


### PR DESCRIPTION
Implements #616.

## Summary

Decouple `finance` from `cosmwasm_std::Timestamp` so that `remote_lease` (and any future Solana-side consumer) no longer transitively links `cosmwasm-std`. The second of two passes that close the transitive cosmwasm path from the cross-chain shared crate; the first was the `currency` dep cleanup that landed on the previous PR (#612).

**Headline result:** `cargo tree -p remote_lease --no-default-features --edges normal | grep cosmwasm` returns **zero** lines. Solana side links zero CosmWasm.

## Changes

- **`finance::Instant`** — a `u64`-nanos-since-epoch newtype with binary-compatible serde (stringified `u64`, matching `Timestamp` exactly). Existing on-chain state written as `Item<Timestamp>` decodes byte-identical into `Item<Instant>`; inter-contract messages with a `Timestamp` field swapped to `Instant` produce identical wire bytes.
- **`finance::duration::Duration` / `finance::period::Period`** — internals migrated. `Duration::between(&Instant, &Instant)`, operator impls on `Instant` / `&Instant`, `Period::start: Instant`. The former `impl Add<Duration> for Timestamp` family is removed.
- **`zero.rs`** — `Uint64`/`Uint128`/`Uint256`/`Uint512` `Zero` impls removed as dead code (no consumer).
- **`finance/Cargo.toml`** — `sdk` removed from `[dependencies]`. Production dep tree no longer contains any cosmwasm crate.
- **`platform/packages/cw-time`** — new tiny bridge crate (~15 LOC). Owns `IntoInstant` and `IntoTimestamp` extension traits — the orphan rule prevents writing these conversions anywhere else once `finance` no longer depends on `cosmwasm-std`. Consumers that meet the cosmwasm API import the bridge at the boundary.
- **~85 consumer files migrated** — storage struct fields, `ExecuteMsg`/`QueryMsg` variants, function signatures, local bindings, test fixtures all swap to `Instant`. Boundary sites (IBC packet timeouts, `env.block.time` writes, ICA-msg timeouts) stay `Timestamp` and convert via `.into_instant()` / `.into_timestamp()`.

## Verification

- Ran `cargo build --all-targets` on platform / protocol / tests workspaces — clean.
- Ran `cargo tree -p finance --invert cosmwasm-std` — empty.
- Ran `cargo tree -p remote_lease --no-default-features --edges normal | grep cosmwasm` — empty.
- Ran `cargo test --all-features --lib` on platform (13 pass), oracle (54), lpp (69), finance (176, including the wire-compatibility pin), cw-time (3).
- Wire-format binary compatibility unit test (`finance::instant::tests::cosmwasm_timestamp_wire_compatibility`) — round-trips a real `cosmwasm_std::Timestamp` through `Instant` and back; byte-identical.
- Walked the standard bug checklist and the refactor-specific checklist (finance cosmwasm-free, wire compat, bridge orphan-rule correctness, boundary discipline, state-storage safety, no lost operator sugar, Solana goal) independently — all pass.

## Follow-ups

- The pre-existing `trait InspectSpec is never used` lint in `protocol/packages/dex/src/impl_/migration.rs` fires on `cargo test --all-features` and exists on `main`. Unrelated to this refactor.