### PR TITLE
feat(remote-lease): controller channel lifecycle

### DIFF
--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -22,7 +22,7 @@ ARG cargo_udeps_version="0.1.59"
 
 ARG cosmwasm_check_version="3.0.4"
 
-ARG cosmwasm_capabilities="cosmwasm_1_1,cosmwasm_1_2,iterator,neutron,staking,stargate"
+ARG cosmwasm_capabilities="cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,cosmwasm_1_4,cosmwasm_2_0,cosmwasm_2_1,cosmwasm_2_2,cosmwasm_3_0,iterator,neutron,staking,stargate"
 
 ARG git_cliff_version="2.12.0"
 

--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -1422,6 +1422,7 @@ dependencies = [
  "access-control",
  "cosmwasm-std",
  "platform",
+ "remote_lease",
  "sdk",
  "serde",
  "thiserror 2.0.18",

--- a/protocol/contracts/remote_lease/Cargo.toml
+++ b/protocol/contracts/remote_lease/Cargo.toml
@@ -27,6 +27,7 @@ contract = [
     "cosmwasm-std/cosmwasm_2_0",
     "sdk/contract",
     "sdk/cosmos_ibc",
+    "dep:remote_lease",
     "stub",
 ]
 stub = []
@@ -35,7 +36,7 @@ testing = []
 [dependencies]
 access-control = { workspace = true, optional = true }
 platform = { workspace = true }
-remote_lease = { workspace = true }
+remote_lease = { workspace = true, optional = true }
 sdk = { workspace = true }
 versioning = { workspace = true, features = ["protocol_contract"] }
 

--- a/protocol/contracts/remote_lease/Cargo.toml
+++ b/protocol/contracts/remote_lease/Cargo.toml
@@ -23,7 +23,10 @@ contract = [
     "dep:access-control",
     "dep:cosmwasm-std",
     "cosmwasm-std/exports",
+    "cosmwasm-std/stargate",
+    "cosmwasm-std/cosmwasm_2_0",
     "sdk/contract",
+    "sdk/cosmos_ibc",
     "stub",
 ]
 stub = []
@@ -32,6 +35,7 @@ testing = []
 [dependencies]
 access-control = { workspace = true, optional = true }
 platform = { workspace = true }
+remote_lease = { workspace = true }
 sdk = { workspace = true }
 versioning = { workspace = true, features = ["protocol_contract"] }
 

--- a/protocol/contracts/remote_lease/src/api.rs
+++ b/protocol/contracts/remote_lease/src/api.rs
@@ -22,6 +22,10 @@ pub struct MigrateMsg {}
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum ExecuteMsg {
+    /// Initiate the channel handshake. Allowed only when no channel is recorded.
+    OpenChannel(),
+    /// Begin closing the recorded channel. Allowed only when it is currently `Open`.
+    CloseChannel(),
     // Internal system API — the validated `Code` wrapper is used.
     NewLeaseCode(Code),
 }

--- a/protocol/contracts/remote_lease/src/contract.rs
+++ b/protocol/contracts/remote_lease/src/contract.rs
@@ -6,7 +6,7 @@ use platform::{
     contract::Code, error as platform_error, message::Response as PlatformResponse, response,
 };
 use sdk::{
-    cosmwasm_ext::Response as CwResponse,
+    cosmwasm_ext::{CosmosMsg, Response as CwResponse},
     cosmwasm_std::{self, Binary, Deps, DepsMut, Env, MessageInfo, entry_point},
 };
 use versioning::{
@@ -17,6 +17,7 @@ use versioning::{
 use crate::{
     api::{ChannelResponse, ConfigResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg},
     error::{Error, Result},
+    ibc as ibc_msg,
     state::{Channel, Config},
 };
 
@@ -89,11 +90,15 @@ pub fn migrate(
 #[entry_point]
 pub fn execute(
     deps: DepsMut<'_>,
-    _env: Env,
+    env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<CwResponse> {
     match msg {
+        ExecuteMsg::OpenChannel() => authorize_protocol_admin_only(deps.storage.deref(), &info)
+            .and_then(|()| open_channel(deps.storage, &env)),
+        ExecuteMsg::CloseChannel() => authorize_protocol_admin_only(deps.storage.deref(), &info)
+            .and_then(|()| close_channel(deps.storage)),
         ExecuteMsg::NewLeaseCode(code) => {
             authorize_protocol_admin_only(deps.storage.deref(), &info)
                 .and_then(|()| Config::update_lease_code(deps.storage, code))
@@ -132,6 +137,34 @@ fn authorize_protocol_admin_only(store: &dyn Storage, call_message: &MessageInfo
     SingleUserAccess::new(store, crate::access_control::PROTOCOL_ADMIN_KEY)
         .check(call_message)
         .map_err(Into::into)
+}
+
+fn open_channel(storage: &mut dyn Storage, env: &Env) -> Result<PlatformResponse> {
+    Channel::may_load(storage)
+        .and_then(|existing| match existing {
+            Some(_) => Err(Error::ChannelAlreadyExists),
+            None => Config::load(storage),
+        })
+        .map(|config| {
+            let open_init: CosmosMsg = ibc_msg::build_channel_open_init(env, &config);
+            let mut batch = platform::batch::Batch::default();
+            batch.schedule_execute_no_reply(open_init);
+            PlatformResponse::messages_only(batch)
+        })
+}
+
+fn close_channel(storage: &mut dyn Storage) -> Result<PlatformResponse> {
+    Channel::may_load(storage)
+        .and_then(|maybe_channel| maybe_channel.ok_or(Error::ChannelNotOpen))
+        .and_then(Channel::into_closing)
+        .and_then(|closing| {
+            closing.store(storage).map(|()| {
+                let close_msg: CosmosMsg = ibc_msg::build_channel_close(&closing);
+                let mut batch = platform::batch::Batch::default();
+                batch.schedule_execute_no_reply(close_msg);
+                PlatformResponse::messages_only(batch)
+            })
+        })
 }
 
 #[cfg(test)]

--- a/protocol/contracts/remote_lease/src/contract/tests.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests.rs
@@ -1,7 +1,8 @@
 use platform::contract::{Code, CodeId};
 use sdk::{
+    cosmwasm_ext::CosmosMsg,
     cosmwasm_std::{
-        Deps, MessageInfo, OwnedDeps, Uint64,
+        AnyMsg, Deps, DepsMut, IbcMsg, MessageInfo, OwnedDeps, SubMsg, Uint64,
         testing::{self, MockApi, MockQuerier, MockStorage},
     },
     testing as sdk_testing,
@@ -11,6 +12,7 @@ use crate::{
     api::{ChannelResponse, ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg},
     contract::{execute, instantiate, query},
     error::Error,
+    state::Channel,
 };
 
 const ADMIN: &str = "admin";
@@ -19,6 +21,10 @@ const CREATOR: &str = "creator";
 const CONNECTION_ID: &str = "connection-3";
 const DEX_LABEL: &str = "osmosis";
 const LEASE_CODE_ID: u64 = 17;
+const LOCAL_CHANNEL_ID: &str = "channel-0";
+const COUNTERPARTY_CHANNEL_ID: &str = "channel-77";
+const COUNTERPARTY_PORT_ID: &str = "nls-remote-lease.osmosis";
+const VERSION: &str = "nls-remote-lease.v1";
 
 #[test]
 fn proper_initialization() {
@@ -109,6 +115,138 @@ fn new_lease_code_admin_succeeds() {
 }
 
 #[test]
+fn open_channel_admin_emits_any_msg() {
+    const CHANNEL_OPEN_INIT: &str = "/ibc.core.channel.v1.MsgChannelOpenInit";
+
+    let mut deps = deps();
+    instantiate_default(deps.as_mut());
+
+    let res = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(ADMIN),
+        ExecuteMsg::OpenChannel(),
+    )
+    .unwrap();
+    assert_eq!(1, res.messages.len());
+    match &res.messages[0] {
+        SubMsg {
+            msg: CosmosMsg::Any(AnyMsg { type_url, value }),
+            ..
+        } => {
+            assert_eq!(CHANNEL_OPEN_INIT, type_url);
+            assert!(!value.is_empty());
+        }
+        other => panic!("expected CosmosMsg::Any, got {other:?}"),
+    }
+
+    assert!(Channel::may_load(&deps.storage).unwrap().is_none());
+}
+
+#[test]
+fn open_channel_non_admin_rejected() {
+    let mut deps = deps();
+    instantiate_default(deps.as_mut());
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(NON_ADMIN),
+        ExecuteMsg::OpenChannel(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::Unauthorized(_)), "got {err:?}");
+}
+
+#[test]
+fn open_channel_when_channel_exists_rejected() {
+    let mut deps = deps();
+    instantiate_default(deps.as_mut());
+    store_open_channel(deps.as_mut());
+
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(ADMIN),
+        ExecuteMsg::OpenChannel(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::ChannelAlreadyExists), "got {err:?}");
+}
+
+#[test]
+fn close_channel_admin_transitions_state_and_emits_close() {
+    let mut deps = deps();
+    instantiate_default(deps.as_mut());
+    store_open_channel(deps.as_mut());
+
+    let res = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(ADMIN),
+        ExecuteMsg::CloseChannel(),
+    )
+    .unwrap();
+    assert_eq!(1, res.messages.len());
+    assert!(matches!(
+        &res.messages[0].msg,
+        CosmosMsg::Ibc(IbcMsg::CloseChannel { channel_id }) if channel_id == LOCAL_CHANNEL_ID
+    ));
+
+    let channel = query_channel(deps.as_ref()).channel.unwrap();
+    assert!(matches!(
+        channel.state,
+        crate::api::ChannelStateResponse::Closing
+    ));
+}
+
+#[test]
+fn close_channel_non_admin_rejected() {
+    let mut deps = deps();
+    instantiate_default(deps.as_mut());
+    store_open_channel(deps.as_mut());
+
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(NON_ADMIN),
+        ExecuteMsg::CloseChannel(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::Unauthorized(_)), "got {err:?}");
+}
+
+#[test]
+fn close_channel_when_absent_rejected() {
+    let mut deps = deps();
+    instantiate_default(deps.as_mut());
+
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(ADMIN),
+        ExecuteMsg::CloseChannel(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::ChannelNotOpen), "got {err:?}");
+}
+
+#[test]
+fn close_channel_when_already_closing_rejected() {
+    let mut deps = deps();
+    instantiate_default(deps.as_mut());
+    store_closing_channel(deps.as_mut());
+
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(ADMIN),
+        ExecuteMsg::CloseChannel(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::ChannelNotOperational), "got {err:?}");
+}
+
+#[test]
 fn new_lease_code_non_admin_rejected() {
     let mut deps = deps();
     instantiate(
@@ -134,6 +272,40 @@ fn new_lease_code_non_admin_rejected() {
 
 fn deps() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
     sdk_testing::mock_deps_with_contracts([])
+}
+
+fn instantiate_default(deps: DepsMut<'_>) {
+    instantiate(
+        deps,
+        testing::mock_env(),
+        sender(CREATOR),
+        instantiate_msg(),
+    )
+    .unwrap();
+}
+
+fn store_open_channel(deps: DepsMut<'_>) {
+    Channel::new_open(
+        LOCAL_CHANNEL_ID.into(),
+        COUNTERPARTY_CHANNEL_ID.into(),
+        COUNTERPARTY_PORT_ID.into(),
+        VERSION.into(),
+    )
+    .store(deps.storage)
+    .unwrap();
+}
+
+fn store_closing_channel(deps: DepsMut<'_>) {
+    Channel::new_open(
+        LOCAL_CHANNEL_ID.into(),
+        COUNTERPARTY_CHANNEL_ID.into(),
+        COUNTERPARTY_PORT_ID.into(),
+        VERSION.into(),
+    )
+    .into_closing()
+    .unwrap()
+    .store(deps.storage)
+    .unwrap();
 }
 
 fn instantiate_msg() -> InstantiateMsg {

--- a/protocol/contracts/remote_lease/src/error.rs
+++ b/protocol/contracts/remote_lease/src/error.rs
@@ -18,6 +18,36 @@ pub enum Error {
 
     #[error("[RemoteLease] {0} must be non-empty")]
     EmptyInstantiateField(&'static str),
+
+    #[error("[RemoteLease] A channel is already recorded for this controller")]
+    ChannelAlreadyExists,
+
+    #[error("[RemoteLease] No channel is recorded for this controller")]
+    ChannelNotOpen,
+
+    #[error("[RemoteLease] The recorded channel is not operational")]
+    ChannelNotOperational,
+
+    #[error("[RemoteLease] Counterparty port id mismatch: expected '{expected}', got '{actual}'")]
+    InvalidCounterpartyPort { expected: String, actual: String },
+
+    #[error("[RemoteLease] Channel version mismatch: expected '{expected}', got '{actual}'")]
+    InvalidChannelVersion { expected: String, actual: String },
+
+    #[error("[RemoteLease] Channel ordering must be UNORDERED")]
+    InvalidChannelOrdering,
+
+    #[error("[RemoteLease] Channel connection id mismatch: expected '{expected}', got '{actual}'")]
+    InvalidConnectionId { expected: String, actual: String },
+
+    #[error("[RemoteLease] Counterparty-initiated channel-open handshakes are not supported")]
+    UnsupportedCounterpartyOpen,
+
+    #[error("[RemoteLease] Unsolicited channel close attempt rejected")]
+    UnsolicitedChannelClose,
+
+    #[error("[RemoteLease] Inbound packets are not supported by this controller")]
+    UnsupportedInboundPacket,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/protocol/contracts/remote_lease/src/ibc.rs
+++ b/protocol/contracts/remote_lease/src/ibc.rs
@@ -1,0 +1,211 @@
+use sdk::{
+    cosmos_sdk_proto::prost::Message as _,
+    cosmwasm_ext::CosmosMsg,
+    cosmwasm_std::{
+        Addr, AnyMsg, Binary, DepsMut, Env, IbcBasicResponse, IbcChannel, IbcChannelCloseMsg,
+        IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse, IbcMsg, IbcOrder,
+        IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, Never,
+        StdAck, entry_point,
+    },
+    ibc_proto::ibc::core::channel::v1::{
+        Channel as ProtoChannel, Counterparty as ProtoCounterparty, MsgChannelOpenInit,
+        Order as ProtoOrder, State as ProtoState,
+    },
+};
+
+use crate::{
+    error::{Error, Result},
+    state::{Channel, ChannelState, Config},
+};
+
+const MSG_CHANNEL_OPEN_INIT_TYPE_URL: &str = "/ibc.core.channel.v1.MsgChannelOpenInit";
+
+/// Build the `CosmosMsg::Any { MsgChannelOpenInit }` that initiates the handshake.
+pub fn build_channel_open_init(env: &Env, config: &Config) -> CosmosMsg {
+    let counterparty_port_id = remote_lease::port_id_for(config.dex_label());
+    let channel = ProtoChannel {
+        state: ProtoState::Init.into(),
+        ordering: ProtoOrder::Unordered.into(),
+        counterparty: Some(ProtoCounterparty {
+            port_id: counterparty_port_id,
+            channel_id: String::new(),
+        }),
+        connection_hops: vec![config.connection_id().to_string()],
+        version: remote_lease::VERSION.to_string(),
+        upgrade_sequence: 0,
+    };
+    let msg = MsgChannelOpenInit {
+        port_id: contract_port_id(&env.contract.address),
+        channel: Some(channel),
+        signer: env.contract.address.to_string(),
+    };
+
+    CosmosMsg::Any(AnyMsg {
+        type_url: MSG_CHANNEL_OPEN_INIT_TYPE_URL.to_string(),
+        value: Binary::new(msg.encode_to_vec()),
+    })
+}
+
+/// Build the `CosmosMsg::Ibc(IbcMsg::CloseChannel)` for the recorded local channel.
+pub fn build_channel_close(channel: &Channel) -> CosmosMsg {
+    CosmosMsg::Ibc(IbcMsg::CloseChannel {
+        channel_id: channel.local_channel_id().to_string(),
+    })
+}
+
+#[entry_point]
+pub fn ibc_channel_open(
+    deps: DepsMut<'_>,
+    _env: Env,
+    msg: IbcChannelOpenMsg,
+) -> Result<IbcChannelOpenResponse> {
+    match msg {
+        IbcChannelOpenMsg::OpenInit { channel } => Config::load(deps.storage)
+            .and_then(|config| validate_handshake_channel(&channel, &config))
+            .map(|()| None),
+        IbcChannelOpenMsg::OpenTry { .. } => Err(Error::UnsupportedCounterpartyOpen),
+    }
+}
+
+#[entry_point]
+pub fn ibc_channel_connect(
+    deps: DepsMut<'_>,
+    _env: Env,
+    msg: IbcChannelConnectMsg,
+) -> Result<IbcBasicResponse> {
+    let channel = match msg {
+        IbcChannelConnectMsg::OpenAck { channel, .. }
+        | IbcChannelConnectMsg::OpenConfirm { channel } => channel,
+    };
+
+    Channel::may_load(deps.storage)
+        .and_then(|existing| match existing {
+            Some(_) => Err(Error::ChannelAlreadyExists),
+            None => Config::load(deps.storage)
+                .and_then(|config| validate_handshake_channel(&channel, &config).map(|()| channel)),
+        })
+        .and_then(|channel| persist_open_channel(deps, channel))
+        .map(|()| IbcBasicResponse::new())
+}
+
+#[entry_point]
+pub fn ibc_channel_close(
+    deps: DepsMut<'_>,
+    _env: Env,
+    msg: IbcChannelCloseMsg,
+) -> Result<IbcBasicResponse> {
+    match msg {
+        IbcChannelCloseMsg::CloseInit { .. } => Channel::may_load(deps.storage)
+            .and_then(|maybe_channel| match maybe_channel {
+                Some(channel) if channel.state() == ChannelState::Closing => Ok(()),
+                _ => Err(Error::UnsolicitedChannelClose),
+            })
+            .map(|()| IbcBasicResponse::new()),
+        IbcChannelCloseMsg::CloseConfirm { .. } => {
+            Channel::clear(deps.storage);
+            Ok(IbcBasicResponse::new())
+        }
+    }
+}
+
+#[entry_point]
+pub fn ibc_packet_receive(
+    _deps: DepsMut<'_>,
+    _env: Env,
+    _msg: IbcPacketReceiveMsg,
+) -> std::result::Result<IbcReceiveResponse, Never> {
+    Ok(IbcReceiveResponse::new(
+        StdAck::error(Error::UnsupportedInboundPacket.to_string()).to_binary(),
+    ))
+}
+
+#[entry_point]
+pub fn ibc_packet_ack(
+    _deps: DepsMut<'_>,
+    _env: Env,
+    _msg: IbcPacketAckMsg,
+) -> Result<IbcBasicResponse> {
+    Ok(IbcBasicResponse::new())
+}
+
+#[entry_point]
+pub fn ibc_packet_timeout(
+    _deps: DepsMut<'_>,
+    _env: Env,
+    _msg: IbcPacketTimeoutMsg,
+) -> Result<IbcBasicResponse> {
+    Ok(IbcBasicResponse::new())
+}
+
+fn validate_handshake_channel(channel: &IbcChannel, config: &Config) -> Result<()> {
+    require_unordered(channel.order.clone())
+        .and_then(|()| require_version(&channel.version))
+        .and_then(|()| require_connection_id(&channel.connection_id, config.connection_id()))
+        .and_then(|()| {
+            require_counterparty_port(&channel.counterparty_endpoint.port_id, config.dex_label())
+        })
+}
+
+fn require_unordered(order: IbcOrder) -> Result<()> {
+    match order {
+        IbcOrder::Unordered => Ok(()),
+        IbcOrder::Ordered => Err(Error::InvalidChannelOrdering),
+    }
+}
+
+fn require_version(actual: &str) -> Result<()> {
+    if actual == remote_lease::VERSION {
+        Ok(())
+    } else {
+        Err(Error::InvalidChannelVersion {
+            expected: remote_lease::VERSION.to_string(),
+            actual: actual.to_string(),
+        })
+    }
+}
+
+fn require_connection_id(actual: &str, expected: &str) -> Result<()> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(Error::InvalidConnectionId {
+            expected: expected.to_string(),
+            actual: actual.to_string(),
+        })
+    }
+}
+
+fn require_counterparty_port(actual: &str, dex_label: &str) -> Result<()> {
+    let expected = remote_lease::port_id_for(dex_label);
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(Error::InvalidCounterpartyPort {
+            expected,
+            actual: actual.to_string(),
+        })
+    }
+}
+
+fn persist_open_channel(deps: DepsMut<'_>, channel: IbcChannel) -> Result<()> {
+    let IbcChannel {
+        endpoint,
+        counterparty_endpoint,
+        version,
+        ..
+    } = channel;
+    Channel::new_open(
+        endpoint.channel_id,
+        counterparty_endpoint.channel_id,
+        counterparty_endpoint.port_id,
+        version,
+    )
+    .store(deps.storage)
+}
+
+fn contract_port_id(contract: &Addr) -> String {
+    format!("wasm.{contract}")
+}
+
+#[cfg(test)]
+mod tests;

--- a/protocol/contracts/remote_lease/src/ibc/tests.rs
+++ b/protocol/contracts/remote_lease/src/ibc/tests.rs
@@ -1,0 +1,408 @@
+use sdk::{
+    cosmwasm_std::{
+        Binary, DepsMut, IbcChannel, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg,
+        IbcEndpoint, IbcOrder, IbcPacket, IbcPacketReceiveMsg, IbcTimeout, MessageInfo, OwnedDeps,
+        StdAck, Timestamp,
+        testing::{self, MockApi, MockQuerier, MockStorage},
+    },
+    testing as sdk_testing,
+};
+
+use crate::{
+    api::InstantiateMsg,
+    contract::instantiate,
+    error::Error,
+    state::{Channel, ChannelState},
+};
+
+use super::{ibc_channel_close, ibc_channel_connect, ibc_channel_open, ibc_packet_receive};
+
+const ADMIN: &str = "admin";
+const CREATOR: &str = "creator";
+const CONNECTION_ID: &str = "connection-3";
+const WRONG_CONNECTION_ID: &str = "connection-9";
+const DEX_LABEL: &str = "osmosis";
+const LOCAL_PORT_ID: &str = "wasm.controller";
+const LOCAL_CHANNEL_ID: &str = "channel-0";
+const COUNTERPARTY_CHANNEL_ID: &str = "channel-77";
+const COUNTERPARTY_PORT_ID: &str = "nls-remote-lease.osmosis";
+const WRONG_COUNTERPARTY_PORT_ID: &str = "nls-remote-lease.evil";
+const VERSION: &str = "nls-remote-lease.v1";
+const WRONG_VERSION: &str = "nls-remote-lease.v2";
+const LEASE_CODE_ID: u64 = 17;
+
+#[test]
+fn open_init_valid_succeeds() {
+    let mut deps = deps_with_config();
+    let response = ibc_channel_open(
+        deps.as_mut(),
+        testing::mock_env(),
+        open_init_msg(channel(
+            IbcOrder::Unordered,
+            VERSION,
+            CONNECTION_ID,
+            COUNTERPARTY_PORT_ID,
+        )),
+    )
+    .unwrap();
+    assert!(response.is_none());
+
+    assert!(Channel::may_load(&deps.storage).unwrap().is_none());
+}
+
+#[test]
+fn open_init_wrong_counterparty_port_rejected() {
+    let mut deps = deps_with_config();
+    let err = ibc_channel_open(
+        deps.as_mut(),
+        testing::mock_env(),
+        open_init_msg(channel(
+            IbcOrder::Unordered,
+            VERSION,
+            CONNECTION_ID,
+            WRONG_COUNTERPARTY_PORT_ID,
+        )),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidCounterpartyPort { .. }),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn open_init_wrong_version_rejected() {
+    let mut deps = deps_with_config();
+    let err = ibc_channel_open(
+        deps.as_mut(),
+        testing::mock_env(),
+        open_init_msg(channel(
+            IbcOrder::Unordered,
+            WRONG_VERSION,
+            CONNECTION_ID,
+            COUNTERPARTY_PORT_ID,
+        )),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidChannelVersion { .. }),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn open_init_ordered_rejected() {
+    let mut deps = deps_with_config();
+    let err = ibc_channel_open(
+        deps.as_mut(),
+        testing::mock_env(),
+        open_init_msg(channel(
+            IbcOrder::Ordered,
+            VERSION,
+            CONNECTION_ID,
+            COUNTERPARTY_PORT_ID,
+        )),
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidChannelOrdering), "got {err:?}");
+}
+
+#[test]
+fn open_init_wrong_connection_rejected() {
+    let mut deps = deps_with_config();
+    let err = ibc_channel_open(
+        deps.as_mut(),
+        testing::mock_env(),
+        open_init_msg(channel(
+            IbcOrder::Unordered,
+            VERSION,
+            WRONG_CONNECTION_ID,
+            COUNTERPARTY_PORT_ID,
+        )),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidConnectionId { .. }),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn open_try_rejected() {
+    let mut deps = deps_with_config();
+    let err = ibc_channel_open(
+        deps.as_mut(),
+        testing::mock_env(),
+        IbcChannelOpenMsg::OpenTry {
+            channel: channel(
+                IbcOrder::Unordered,
+                VERSION,
+                CONNECTION_ID,
+                COUNTERPARTY_PORT_ID,
+            ),
+            counterparty_version: VERSION.into(),
+        },
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, Error::UnsupportedCounterpartyOpen),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn connect_open_ack_persists_channel() {
+    let mut deps = deps_with_config();
+    let connect = IbcChannelConnectMsg::OpenAck {
+        channel: channel(
+            IbcOrder::Unordered,
+            VERSION,
+            CONNECTION_ID,
+            COUNTERPARTY_PORT_ID,
+        ),
+        counterparty_version: VERSION.into(),
+    };
+    ibc_channel_connect(deps.as_mut(), testing::mock_env(), connect).unwrap();
+
+    let stored = Channel::may_load(&deps.storage).unwrap().unwrap();
+    assert_eq!(ChannelState::Open, stored.state());
+    assert_eq!(LOCAL_CHANNEL_ID, stored.local_channel_id());
+}
+
+#[test]
+fn connect_open_confirm_persists_channel() {
+    let mut deps = deps_with_config();
+    let connect = IbcChannelConnectMsg::OpenConfirm {
+        channel: channel(
+            IbcOrder::Unordered,
+            VERSION,
+            CONNECTION_ID,
+            COUNTERPARTY_PORT_ID,
+        ),
+    };
+    ibc_channel_connect(deps.as_mut(), testing::mock_env(), connect).unwrap();
+
+    let stored = Channel::may_load(&deps.storage).unwrap().unwrap();
+    assert_eq!(ChannelState::Open, stored.state());
+}
+
+#[test]
+fn connect_rejects_when_channel_exists() {
+    let mut deps = deps_with_config();
+    persist_existing_open_channel(deps.as_mut());
+
+    let err = ibc_channel_connect(
+        deps.as_mut(),
+        testing::mock_env(),
+        IbcChannelConnectMsg::OpenConfirm {
+            channel: channel(
+                IbcOrder::Unordered,
+                VERSION,
+                CONNECTION_ID,
+                COUNTERPARTY_PORT_ID,
+            ),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::ChannelAlreadyExists), "got {err:?}");
+}
+
+#[test]
+fn connect_rejects_invalid_handshake_params() {
+    let mut deps = deps_with_config();
+    let err = ibc_channel_connect(
+        deps.as_mut(),
+        testing::mock_env(),
+        IbcChannelConnectMsg::OpenConfirm {
+            channel: channel(
+                IbcOrder::Unordered,
+                WRONG_VERSION,
+                CONNECTION_ID,
+                COUNTERPARTY_PORT_ID,
+            ),
+        },
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidChannelVersion { .. }),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn close_init_when_closing_accepted() {
+    let mut deps = deps_with_config();
+    persist_existing_closing_channel(deps.as_mut());
+
+    ibc_channel_close(
+        deps.as_mut(),
+        testing::mock_env(),
+        IbcChannelCloseMsg::CloseInit {
+            channel: channel(
+                IbcOrder::Unordered,
+                VERSION,
+                CONNECTION_ID,
+                COUNTERPARTY_PORT_ID,
+            ),
+        },
+    )
+    .unwrap();
+
+    assert!(Channel::may_load(&deps.storage).unwrap().is_some());
+}
+
+#[test]
+fn close_init_when_open_rejected() {
+    let mut deps = deps_with_config();
+    persist_existing_open_channel(deps.as_mut());
+
+    let err = ibc_channel_close(
+        deps.as_mut(),
+        testing::mock_env(),
+        IbcChannelCloseMsg::CloseInit {
+            channel: channel(
+                IbcOrder::Unordered,
+                VERSION,
+                CONNECTION_ID,
+                COUNTERPARTY_PORT_ID,
+            ),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::UnsolicitedChannelClose), "got {err:?}");
+}
+
+#[test]
+fn close_init_when_no_channel_rejected() {
+    let mut deps = deps_with_config();
+    let err = ibc_channel_close(
+        deps.as_mut(),
+        testing::mock_env(),
+        IbcChannelCloseMsg::CloseInit {
+            channel: channel(
+                IbcOrder::Unordered,
+                VERSION,
+                CONNECTION_ID,
+                COUNTERPARTY_PORT_ID,
+            ),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::UnsolicitedChannelClose), "got {err:?}");
+}
+
+#[test]
+fn close_confirm_clears_channel() {
+    let mut deps = deps_with_config();
+    persist_existing_closing_channel(deps.as_mut());
+
+    ibc_channel_close(
+        deps.as_mut(),
+        testing::mock_env(),
+        IbcChannelCloseMsg::CloseConfirm {
+            channel: channel(
+                IbcOrder::Unordered,
+                VERSION,
+                CONNECTION_ID,
+                COUNTERPARTY_PORT_ID,
+            ),
+        },
+    )
+    .unwrap();
+
+    assert!(Channel::may_load(&deps.storage).unwrap().is_none());
+}
+
+#[test]
+fn packet_receive_returns_error_ack() {
+    let mut deps = deps_with_config();
+    let packet = IbcPacket::new(
+        Binary::new(b"anything".to_vec()),
+        IbcEndpoint {
+            port_id: COUNTERPARTY_PORT_ID.into(),
+            channel_id: COUNTERPARTY_CHANNEL_ID.into(),
+        },
+        IbcEndpoint {
+            port_id: LOCAL_PORT_ID.into(),
+            channel_id: LOCAL_CHANNEL_ID.into(),
+        },
+        1,
+        IbcTimeout::with_timestamp(Timestamp::from_seconds(1)),
+    );
+    let relayer = sdk_testing::user("relayer");
+    let msg = IbcPacketReceiveMsg::new(packet, relayer);
+
+    let res = ibc_packet_receive(deps.as_mut(), testing::mock_env(), msg).unwrap();
+    let ack: StdAck =
+        sdk::cosmwasm_std::from_json(res.acknowledgement.expect("ack present")).unwrap();
+    assert!(matches!(ack, StdAck::Error(_)));
+    assert!(res.messages.is_empty());
+}
+
+fn channel(
+    order: IbcOrder,
+    version: &str,
+    connection_id: &str,
+    counterparty_port_id: &str,
+) -> IbcChannel {
+    IbcChannel::new(
+        IbcEndpoint {
+            port_id: LOCAL_PORT_ID.into(),
+            channel_id: LOCAL_CHANNEL_ID.into(),
+        },
+        IbcEndpoint {
+            port_id: counterparty_port_id.into(),
+            channel_id: COUNTERPARTY_CHANNEL_ID.into(),
+        },
+        order,
+        version,
+        connection_id,
+    )
+}
+
+fn open_init_msg(channel: IbcChannel) -> IbcChannelOpenMsg {
+    IbcChannelOpenMsg::OpenInit { channel }
+}
+
+fn deps_with_config() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
+    let mut deps = sdk_testing::mock_deps_with_contracts([]);
+    instantiate(
+        deps.as_mut(),
+        testing::mock_env(),
+        MessageInfo {
+            sender: sdk_testing::user(CREATOR),
+            funds: vec![],
+        },
+        InstantiateMsg {
+            protocol_admin: sdk_testing::user(ADMIN).into_string(),
+            connection_id: CONNECTION_ID.into(),
+            dex_label: DEX_LABEL.into(),
+            lease_code: LEASE_CODE_ID.into(),
+        },
+    )
+    .unwrap();
+    deps
+}
+
+fn persist_existing_open_channel(deps: DepsMut<'_>) {
+    Channel::new_open(
+        LOCAL_CHANNEL_ID.into(),
+        COUNTERPARTY_CHANNEL_ID.into(),
+        COUNTERPARTY_PORT_ID.into(),
+        VERSION.into(),
+    )
+    .store(deps.storage)
+    .unwrap();
+}
+
+fn persist_existing_closing_channel(deps: DepsMut<'_>) {
+    let closing = Channel::new_open(
+        LOCAL_CHANNEL_ID.into(),
+        COUNTERPARTY_CHANNEL_ID.into(),
+        COUNTERPARTY_PORT_ID.into(),
+        VERSION.into(),
+    )
+    .into_closing()
+    .unwrap();
+    closing.store(deps.storage).unwrap();
+}

--- a/protocol/contracts/remote_lease/src/lib.rs
+++ b/protocol/contracts/remote_lease/src/lib.rs
@@ -6,4 +6,6 @@ pub mod contract;
 #[cfg(feature = "contract")]
 pub mod error;
 #[cfg(feature = "contract")]
+pub mod ibc;
+#[cfg(feature = "contract")]
 mod state;

--- a/protocol/contracts/remote_lease/src/state/channel.rs
+++ b/protocol/contracts/remote_lease/src/state/channel.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use sdk::{cosmwasm_std::Storage, cw_storage_plus::Item};
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -23,8 +23,51 @@ pub struct Channel {
 impl Channel {
     const STORAGE: Item<Self> = Item::new("channel");
 
+    pub fn new_open(
+        local_channel_id: String,
+        counterparty_channel_id: String,
+        counterparty_port_id: String,
+        version: String,
+    ) -> Self {
+        Self {
+            local_channel_id,
+            counterparty_channel_id,
+            counterparty_port_id,
+            version,
+            state: ChannelState::Open,
+        }
+    }
+
     pub fn may_load(storage: &dyn Storage) -> Result<Option<Self>> {
         Self::STORAGE.may_load(storage).map_err(Into::into)
+    }
+
+    pub fn store(&self, storage: &mut dyn Storage) -> Result<()> {
+        Self::STORAGE.save(storage, self).map_err(Into::into)
+    }
+
+    pub fn clear(storage: &mut dyn Storage) {
+        Self::STORAGE.remove(storage)
+    }
+
+    pub const fn state(&self) -> ChannelState {
+        self.state
+    }
+
+    pub fn local_channel_id(&self) -> &str {
+        &self.local_channel_id
+    }
+
+    /// Transitions an `Open` channel to `Closing`.
+    /// Returns `ChannelNotOperational` if the channel is already `Closing`.
+    pub fn into_closing(self) -> Result<Self> {
+        match self.state {
+            ChannelState::Open => Ok(Self {
+                state: ChannelState::Closing,
+                ..self
+            }),
+            ChannelState::Closing => Err(Error::ChannelNotOperational),
+        }
     }
 
     pub(super) fn into_parts(self) -> (String, String, String, String, ChannelState) {
@@ -42,6 +85,8 @@ impl Channel {
 mod test {
     use sdk::cosmwasm_std::testing::MockStorage;
 
+    use crate::error::Error;
+
     use super::{Channel, ChannelState};
 
     const LOCAL_CHANNEL_ID: &str = "channel-7";
@@ -56,25 +101,44 @@ mod test {
     }
 
     #[test]
-    fn round_trip_open() {
-        round_trip(ChannelState::Open);
+    fn store_load_open() {
+        let mut store = MockStorage::new();
+        let channel = open_channel();
+        channel.store(&mut store).unwrap();
+        assert_eq!(Some(channel), Channel::may_load(&store).unwrap());
     }
 
     #[test]
-    fn round_trip_closing() {
-        round_trip(ChannelState::Closing);
+    fn into_closing_from_open() {
+        let channel = open_channel();
+        let closing = channel.clone().into_closing().unwrap();
+        assert_eq!(ChannelState::Open, channel.state());
+        assert_eq!(ChannelState::Closing, closing.state());
+        assert_eq!(channel.local_channel_id(), closing.local_channel_id());
     }
 
-    fn round_trip(state: ChannelState) {
+    #[test]
+    fn into_closing_from_closing_errors() {
+        let closing = open_channel().into_closing().unwrap();
+        let err = closing.into_closing().unwrap_err();
+        assert!(matches!(err, Error::ChannelNotOperational), "got {err:?}");
+    }
+
+    #[test]
+    fn clear_removes() {
         let mut store = MockStorage::new();
-        let channel = Channel {
-            local_channel_id: LOCAL_CHANNEL_ID.into(),
-            counterparty_channel_id: COUNTERPARTY_CHANNEL_ID.into(),
-            counterparty_port_id: COUNTERPARTY_PORT_ID.into(),
-            version: VERSION.into(),
-            state,
-        };
-        Channel::STORAGE.save(&mut store, &channel).unwrap();
-        assert_eq!(Some(channel), Channel::may_load(&store).unwrap());
+        open_channel().store(&mut store).unwrap();
+        assert!(Channel::may_load(&store).unwrap().is_some());
+        Channel::clear(&mut store);
+        assert!(Channel::may_load(&store).unwrap().is_none());
+    }
+
+    fn open_channel() -> Channel {
+        Channel::new_open(
+            LOCAL_CHANNEL_ID.into(),
+            COUNTERPARTY_CHANNEL_ID.into(),
+            COUNTERPARTY_PORT_ID.into(),
+            VERSION.into(),
+        )
     }
 }


### PR DESCRIPTION
## Summary

Implements §3.2/3.4/4 of the Remote Lease Protocol ADR — the controller contract now owns its IBC channel end-to-end. Lifecycle ops are gated by `protocol_admin` (mirroring `Lpp::NewLeaseCode`); IBC handshake parameters are pinned to the protocol's invariants (UNORDERED ordering, fixed version `nls-remote-lease.v1`, configured connection, dex-derived counterparty port). Closes [ibc-solray#136](https://github.com/nolus-protocol/ibc-solray/issues/136).

## Changes

- `ExecuteMsg::OpenChannel` (admin-gated): rejects if a channel is already recorded; emits `CosmosMsg::Any(MsgChannelOpenInit)` with the contract's `wasm.<addr>` port, configured connection hop, fixed version, and counterparty port `nls-remote-lease.<dex_label>`.
- `ExecuteMsg::CloseChannel` (admin-gated): transitions `Open → Closing`; emits `IbcMsg::CloseChannel`; rejects when absent or already `Closing`.
- Six IBC entry points (`ibc_channel_open`, `ibc_channel_connect`, `ibc_channel_close`, `ibc_packet_receive`, `ibc_packet_ack`, `ibc_packet_timeout`) declared with `#[entry_point]` so wasmd recognises the contract as IBC-enabled.
  - `OpenInit` validates counterparty port, version, ordering, connection id.
  - `OpenTry` rejected — the controller never accepts counterparty-initiated handshakes.
  - `OpenAck`/`OpenConfirm` reject if a channel is already recorded; otherwise persist it `Open`.
  - `CloseInit` accepted iff `state == Closing`; rejected otherwise (unsolicited close).
  - `CloseConfirm` clears the channel.
  - `ibc_packet_receive` returns `Result<_, Never>` per ADR §4.4 — `Never` is uninhabited, statically preventing channel poisoning. Always emits `StdAck::error` in v1 (one-way Cosmos → Solana).
  - `ibc_packet_ack` / `ibc_packet_timeout` are no-op stubs until #139 wires the `RemoteLeaseCallback` dispatch — v1 sends no outbound packets that could reach them.
- Channel state model (`state::Channel`) extended with `new_open`, `store`, `clear`, `state`, `local_channel_id`, `into_closing` (Open→Closing; Closing→err `ChannelNotOperational`).
- New error variants: `ChannelAlreadyExists`, `ChannelNotOpen`, `ChannelNotOperational`, `InvalidCounterpartyPort`, `InvalidChannelVersion`, `InvalidChannelOrdering`, `InvalidConnectionId`, `UnsupportedCounterpartyOpen`, `UnsolicitedChannelClose`, `UnsupportedInboundPacket`.
- `Cargo.toml`: enabled `cosmwasm-std/{stargate,cosmwasm_2_0}` and `sdk/cosmos_ibc` under the `contract` feature; added `remote_lease` workspace dep for the shared port-prefix / version constants. No new external crates.

## Verification

- `cargo each --tag ci --tag @agnostic -p remote_lease_controller run -- test --all-targets --locked` — 36 tests passed across both feature combinations (`contract,testing` and `stub,testing`).
- `cargo each --tag ci --tag @agnostic -p remote_lease_controller run -- clippy --all-targets --locked` — clean on both feature combinations.
- `cargo fmt --all -- --check` — clean.
- `cargo build -p remote_lease_controller --features contract --target wasm32-unknown-unknown` — WASM build succeeded; verified all 10 entry points (`instantiate`, `execute`, `query`, `migrate`, plus six `ibc_*`) are exported.

## Follow-ups

- [#137](https://github.com/nolus-protocol/ibc-solray/issues/137) — `NewLeaseCode` admin op (mostly scaffolded; `ExecuteMsg::NewLeaseCode` already present).
- [#138](https://github.com/nolus-protocol/ibc-solray/issues/138) — outbound `OpenLease`/`CloseLease`/`Swap`/`TransferOut` operations.
- [#139](https://github.com/nolus-protocol/ibc-solray/issues/139) — wire `ibc_packet_ack` / `ibc_packet_timeout` to the `RemoteLeaseCallback` dispatch (currently no-op stubs).