### PR TITLE
feat(remote-lease): controller outbound operations

### DIFF
--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -1421,6 +1421,10 @@ version = "0.1.0"
 dependencies = [
  "access-control",
  "cosmwasm-std",
+ "currencies",
+ "currency",
+ "cw-time",
+ "finance",
  "platform",
  "remote_lease",
  "sdk",

--- a/protocol/contracts/remote_lease/Cargo.toml
+++ b/protocol/contracts/remote_lease/Cargo.toml
@@ -27,7 +27,6 @@ contract = [
     "cosmwasm-std/cosmwasm_2_0",
     "sdk/contract",
     "sdk/cosmos_ibc",
-    "dep:remote_lease",
     "stub",
 ]
 stub = []
@@ -35,8 +34,10 @@ testing = []
 
 [dependencies]
 access-control = { workspace = true, optional = true }
+cw-time = { workspace = true }
+finance = { workspace = true }
 platform = { workspace = true }
-remote_lease = { workspace = true, optional = true }
+remote_lease = { workspace = true }
 sdk = { workspace = true }
 versioning = { workspace = true, features = ["protocol_contract"] }
 
@@ -47,5 +48,8 @@ thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
+currencies = { workspace = true, features = ["testing"] }
+currency = { workspace = true, features = ["testing"] }
+finance = { workspace = true, features = ["testing"] }
 platform = { workspace = true, features = ["testing"] }
 sdk = { workspace = true, features = ["testing"] }

--- a/protocol/contracts/remote_lease/src/api.rs
+++ b/protocol/contracts/remote_lease/src/api.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+use finance::duration::Duration;
 use platform::contract::{Code, CodeId};
+use remote_lease::msg::{CloseLeaseParams, OpenLeaseParams, SwapParams, TransferOutParams};
 use sdk::cosmwasm_std::Uint64;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -29,6 +31,28 @@ pub enum ExecuteMsg {
     NewLeaseCode {
         // This is an internal system API and we use [Code]
         lease_code: Code,
+    },
+    /// Outbound `OpenLease` packet. Caller must be an instance of `Config.lease_code`.
+    /// `timeout` is the relative duration after which the ICS-04 packet expires;
+    /// the controller anchors it to its own block time at send.
+    OpenLease {
+        params: OpenLeaseParams,
+        timeout: Duration,
+    },
+    /// Outbound `CloseLease` packet. See [`ExecuteMsg::OpenLease`] for `timeout` semantics.
+    CloseLease {
+        params: CloseLeaseParams,
+        timeout: Duration,
+    },
+    /// Outbound `Swap` packet. See [`ExecuteMsg::OpenLease`] for `timeout` semantics.
+    Swap {
+        params: SwapParams,
+        timeout: Duration,
+    },
+    /// Outbound `TransferOut` packet. See [`ExecuteMsg::OpenLease`] for `timeout` semantics.
+    TransferOut {
+        params: TransferOutParams,
+        timeout: Duration,
     },
 }
 

--- a/protocol/contracts/remote_lease/src/contract.rs
+++ b/protocol/contracts/remote_lease/src/contract.rs
@@ -2,12 +2,22 @@ use std::ops::{Deref, DerefMut};
 
 use access_control::SingleUserAccess;
 use cosmwasm_std::Storage;
+use cw_time::{IntoInstant as _, IntoTimestamp as _};
+use finance::{duration::Duration, instant::Instant};
 use platform::{
     contract::Code, error as platform_error, message::Response as PlatformResponse, response,
 };
+use remote_lease::{
+    envelope::{LeaseAddrOnWire, PacketEnvelope},
+    msg::Operation,
+    version::ProtocolVersion,
+};
 use sdk::{
     cosmwasm_ext::{CosmosMsg, Response as CwResponse},
-    cosmwasm_std::{self, Binary, Deps, DepsMut, Env, MessageInfo, entry_point},
+    cosmwasm_std::{
+        self, Addr, Binary, Deps, DepsMut, Env, IbcMsg, IbcTimeout, MessageInfo, QuerierWrapper,
+        entry_point,
+    },
 };
 use versioning::{
     ProtocolMigrationMessage, ProtocolPackageRelease, UpdatablePackage as _, VersionSegment,
@@ -94,6 +104,7 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<CwResponse> {
+    let api = deps.api;
     match msg {
         ExecuteMsg::OpenChannel() => authorize_protocol_admin_only(deps.storage.deref(), &info)
             .and_then(|()| open_channel(deps.storage, &env)),
@@ -104,9 +115,33 @@ pub fn execute(
         } => authorize_protocol_admin_only(deps.storage.deref(), &info)
             .and_then(|()| Config::update_lease_code(deps.storage, new_lease_code))
             .map(|()| PlatformResponse::default()),
+        ExecuteMsg::OpenLease { params, timeout } => send_operation(
+            deps,
+            &env,
+            info.sender,
+            Operation::OpenLease(params),
+            timeout,
+        ),
+        ExecuteMsg::CloseLease { params, timeout } => send_operation(
+            deps,
+            &env,
+            info.sender,
+            Operation::CloseLease(params),
+            timeout,
+        ),
+        ExecuteMsg::Swap { params, timeout } => {
+            send_operation(deps, &env, info.sender, Operation::Swap(params), timeout)
+        }
+        ExecuteMsg::TransferOut { params, timeout } => send_operation(
+            deps,
+            &env,
+            info.sender,
+            Operation::TransferOut(params),
+            timeout,
+        ),
     }
     .map(response::response_only_messages)
-    .inspect_err(platform_error::log(deps.api))
+    .inspect_err(platform_error::log(api))
 }
 
 #[entry_point]
@@ -164,6 +199,67 @@ fn close_channel(storage: &mut dyn Storage) -> Result<PlatformResponse> {
                 batch.schedule_execute_no_reply(close_msg);
                 PlatformResponse::messages_only(batch)
             })
+        })
+}
+
+fn send_operation(
+    deps: DepsMut<'_>,
+    env: &Env,
+    caller: Addr,
+    operation: Operation,
+    timeout: Duration,
+) -> Result<PlatformResponse> {
+    let DepsMut {
+        storage, querier, ..
+    } = deps;
+    authorise_and_load_channel(storage, querier, caller).and_then(|(lease, channel)| {
+        build_packet(
+            env.block.time.into_instant(),
+            &channel,
+            lease,
+            operation,
+            timeout,
+        )
+    })
+}
+
+fn authorise_and_load_channel(
+    storage: &dyn Storage,
+    querier: QuerierWrapper<'_>,
+    caller: Addr,
+) -> Result<(Addr, Channel)> {
+    Config::load(storage)
+        .and_then(|config| config.auth_caller(querier, caller))
+        .and_then(|lease| {
+            Channel::may_load(storage)
+                .and_then(|maybe| maybe.ok_or(Error::ChannelNotOpen))
+                .and_then(|channel| channel.usable_or_err().map(|()| (lease, channel)))
+        })
+}
+
+fn build_packet(
+    now: Instant,
+    channel: &Channel,
+    lease: Addr,
+    operation: Operation,
+    timeout: Duration,
+) -> Result<PlatformResponse> {
+    let envelope = PacketEnvelope {
+        lease: LeaseAddrOnWire::new(lease),
+        operation,
+        version: ProtocolVersion,
+    };
+    cosmwasm_std::to_json_binary(&envelope)
+        .map_err(Error::from)
+        .map(|data| {
+            let send = CosmosMsg::Ibc(IbcMsg::SendPacket {
+                channel_id: channel.local_channel_id().to_string(),
+                data,
+                timeout: IbcTimeout::with_timestamp((now + timeout).into_timestamp()),
+            });
+            let mut batch = platform::batch::Batch::default();
+            batch.schedule_execute_no_reply(send);
+            PlatformResponse::messages_only(batch)
         })
 }
 

--- a/protocol/contracts/remote_lease/src/contract/tests.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests.rs
@@ -1,8 +1,19 @@
+use currencies::{
+    PaymentGroup,
+    testing::{PaymentC1, PaymentC2, PaymentC3},
+};
+use finance::{coin::Coin, duration::Duration, instant::Instant};
 use platform::contract::{Code, CodeId};
+use remote_lease::{
+    envelope::{LeaseAddrOnWire, PacketEnvelope},
+    msg::{CloseLeaseParams, OpenLeaseParams, Operation, SwapParams, TransferOutParams},
+    version::ProtocolVersion,
+};
 use sdk::{
-    cosmwasm_ext::CosmosMsg,
+    cosmwasm_ext::{CosmosMsg, SubMsg},
     cosmwasm_std::{
-        AnyMsg, Deps, DepsMut, IbcMsg, MessageInfo, OwnedDeps, SubMsg, Uint64,
+        Addr, AnyMsg, Binary, ContractInfoResponse, ContractResult, Deps, DepsMut, IbcMsg,
+        IbcTimeout, MessageInfo, OwnedDeps, SystemError, SystemResult, Uint64, WasmQuery,
         testing::{self, MockApi, MockQuerier, MockStorage},
     },
     testing as sdk_testing,
@@ -21,6 +32,11 @@ const CREATOR: &str = "creator";
 const CONNECTION_ID: &str = "connection-3";
 const DEX_LABEL: &str = "osmosis";
 const LEASE_CODE_ID: u64 = 17;
+const WRONG_CODE_ID: u64 = LEASE_CODE_ID + 1;
+const LEASE: &str = "lease";
+const WRONG_CODE_CONTRACT: &str = "wrong-code-contract";
+const NON_CONTRACT_CALLER: &str = "wallet-only";
+const PACKET_TIMEOUT: Duration = Duration::from_secs(600);
 const LOCAL_CHANNEL_ID: &str = "channel-0";
 const COUNTERPARTY_CHANNEL_ID: &str = "channel-77";
 const COUNTERPARTY_PORT_ID: &str = "nls-remote-lease.osmosis";
@@ -274,8 +290,199 @@ fn new_lease_code_non_admin_rejected() {
     assert_eq!(Uint64::from(LEASE_CODE_ID), config.lease_code_id);
 }
 
+#[test]
+fn open_lease_emits_send_packet() {
+    let mut deps = deps_with_lease();
+    instantiate_default(deps.as_mut());
+    store_open_channel(deps.as_mut());
+
+    let params = sample_open_lease_params();
+    let res = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(LEASE),
+        ExecuteMsg::OpenLease {
+            params: params.clone(),
+            timeout: PACKET_TIMEOUT,
+        },
+    )
+    .unwrap();
+    assert_send_packet(&Operation::OpenLease(params), &res.messages);
+}
+
+#[test]
+fn close_lease_emits_send_packet() {
+    let mut deps = deps_with_lease();
+    instantiate_default(deps.as_mut());
+    store_open_channel(deps.as_mut());
+
+    let params = CloseLeaseParams {};
+    let res = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(LEASE),
+        ExecuteMsg::CloseLease {
+            params: params.clone(),
+            timeout: PACKET_TIMEOUT,
+        },
+    )
+    .unwrap();
+    assert_send_packet(&Operation::CloseLease(params), &res.messages);
+}
+
+#[test]
+fn swap_emits_send_packet() {
+    let mut deps = deps_with_lease();
+    instantiate_default(deps.as_mut());
+    store_open_channel(deps.as_mut());
+
+    let params = sample_swap_params();
+    let res = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(LEASE),
+        ExecuteMsg::Swap {
+            params: params.clone(),
+            timeout: PACKET_TIMEOUT,
+        },
+    )
+    .unwrap();
+    assert_send_packet(&Operation::Swap(params), &res.messages);
+}
+
+#[test]
+fn transfer_out_emits_send_packet() {
+    let mut deps = deps_with_lease();
+    instantiate_default(deps.as_mut());
+    store_open_channel(deps.as_mut());
+
+    let params = sample_transfer_out_params();
+    let res = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(LEASE),
+        ExecuteMsg::TransferOut {
+            params: params.clone(),
+            timeout: PACKET_TIMEOUT,
+        },
+    )
+    .unwrap();
+    assert_send_packet(&Operation::TransferOut(params), &res.messages);
+}
+
+#[test]
+fn outbound_when_no_channel_rejected() {
+    let mut deps = deps_with_lease();
+    instantiate_default(deps.as_mut());
+
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(LEASE),
+        open_lease_execute(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::ChannelNotOpen), "got {err:?}");
+}
+
+#[test]
+fn outbound_when_channel_closing_rejected() {
+    let mut deps = deps_with_lease();
+    instantiate_default(deps.as_mut());
+    store_closing_channel(deps.as_mut());
+
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(LEASE),
+        open_lease_execute(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::ChannelNotOperational), "got {err:?}");
+}
+
+#[test]
+fn outbound_wrong_caller_code_rejected() {
+    let mut deps = deps_with_lease();
+    instantiate_default(deps.as_mut());
+    store_open_channel(deps.as_mut());
+
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(WRONG_CODE_CONTRACT),
+        open_lease_execute(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::UnauthorisedCaller), "got {err:?}");
+}
+
+#[test]
+fn outbound_non_contract_caller_rejected() {
+    let mut deps = deps_with_lease();
+    instantiate_default(deps.as_mut());
+    store_open_channel(deps.as_mut());
+
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(NON_CONTRACT_CALLER),
+        open_lease_execute(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::UnauthorisedCaller), "got {err:?}");
+}
+
 fn deps() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
     sdk_testing::mock_deps_with_contracts([])
+}
+
+/// Wasm querier that resolves the two registered contract addresses to their
+/// distinct code ids; all other addresses return `NoSuchContract`. CodeInfo is
+/// passed through so `instantiate` can validate `lease_code` (see
+/// `sdk_testing::mock_deps_with_contracts` for the equivalent default handling).
+fn deps_with_lease() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
+    let lease = sdk_testing::user(LEASE);
+    let wrong = sdk_testing::user(WRONG_CODE_CONTRACT);
+    let mut deps = sdk_testing::mock_deps_with_contracts([]);
+    deps.querier.update_wasm(move |query| match query {
+        WasmQuery::ContractInfo { contract_addr } => {
+            let addr = Addr::unchecked(contract_addr);
+            if addr == lease {
+                contract_info_response(LEASE_CODE_ID)
+            } else if addr == wrong {
+                contract_info_response(WRONG_CODE_ID)
+            } else {
+                SystemResult::Err(SystemError::NoSuchContract {
+                    addr: contract_addr.clone(),
+                })
+            }
+        }
+        WasmQuery::CodeInfo { code_id } => SystemResult::Ok(ContractResult::Ok(
+            sdk::cosmwasm_std::to_json_binary(&sdk::cosmwasm_std::CodeInfoResponse::new(
+                *code_id,
+                sdk_testing::user(""),
+                sdk::cosmwasm_std::Checksum::generate(&[0x1f, 0x4e, 0x20, 0x9a]),
+            ))
+            .expect("serialization succeeds"),
+        )),
+        _ => unimplemented!(),
+    });
+    deps
+}
+
+fn contract_info_response(code_id: u64) -> SystemResult<ContractResult<Binary>> {
+    SystemResult::Ok(ContractResult::Ok(
+        sdk::cosmwasm_std::to_json_binary(&ContractInfoResponse::new(
+            code_id,
+            sdk_testing::user("creator"),
+            None,
+            false,
+            None,
+            None,
+        ))
+        .expect("serialization succeeds"),
+    ))
 }
 
 fn instantiate_default(deps: DepsMut<'_>) {
@@ -336,4 +543,62 @@ fn query_config(deps: Deps<'_>) -> ConfigResponse {
 fn query_channel(deps: Deps<'_>) -> ChannelResponse {
     let raw = query(deps, testing::mock_env(), QueryMsg::Channel()).unwrap();
     sdk::cosmwasm_std::from_json(raw).unwrap()
+}
+
+fn open_lease_execute() -> ExecuteMsg {
+    ExecuteMsg::OpenLease {
+        params: sample_open_lease_params(),
+        timeout: PACKET_TIMEOUT,
+    }
+}
+
+fn sample_open_lease_params() -> OpenLeaseParams {
+    OpenLeaseParams::new(
+        7,
+        currency::dto::<PaymentC1, PaymentGroup>(),
+        currency::dto::<PaymentC2, PaymentGroup>(),
+        currency::dto::<PaymentC3, PaymentGroup>(),
+    )
+    .expect("sample uses three distinct currencies")
+}
+
+fn sample_swap_params() -> SwapParams {
+    SwapParams::new(
+        Coin::<PaymentC1>::new(1_000).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    )
+    .expect("sample uses two distinct non-zero amounts")
+}
+
+fn sample_transfer_out_params() -> TransferOutParams {
+    TransferOutParams::new(Coin::<PaymentC3>::new(1_000).into())
+        .expect("sample uses a non-zero amount")
+}
+
+fn assert_send_packet(expected_operation: &Operation, messages: &[SubMsg]) {
+    assert_eq!(1, messages.len(), "expected exactly one outbound message");
+    match &messages[0].msg {
+        CosmosMsg::Ibc(IbcMsg::SendPacket {
+            channel_id,
+            data,
+            timeout,
+        }) => {
+            assert_eq!(LOCAL_CHANNEL_ID, channel_id);
+            assert_eq!(&expected_timeout(), timeout);
+            let envelope: PacketEnvelope = sdk::cosmwasm_std::from_json(data).unwrap();
+            assert_eq!(
+                LeaseAddrOnWire::new(sdk_testing::user(LEASE)),
+                envelope.lease,
+            );
+            assert_eq!(expected_operation, &envelope.operation);
+            assert_eq!(ProtocolVersion, envelope.version);
+        }
+        other => panic!("expected CosmosMsg::Ibc(IbcMsg::SendPacket {{..}}), got {other:?}"),
+    }
+}
+
+fn expected_timeout() -> IbcTimeout {
+    use cw_time::{IntoInstant as _, IntoTimestamp as _};
+    let now: Instant = testing::mock_env().block.time.into_instant();
+    IbcTimeout::with_timestamp((now + PACKET_TIMEOUT).into_timestamp())
 }

--- a/protocol/contracts/remote_lease/src/error.rs
+++ b/protocol/contracts/remote_lease/src/error.rs
@@ -16,6 +16,9 @@ pub enum Error {
     #[error("[RemoteLease] {0}")]
     Unauthorized(#[from] access_control::error::Error),
 
+    #[error("[RemoteLease] Caller is not an authorised Lease instance")]
+    UnauthorisedCaller,
+
     #[error("[RemoteLease] {0} must be non-empty")]
     EmptyInstantiateField(&'static str),
 

--- a/protocol/contracts/remote_lease/src/state/channel.rs
+++ b/protocol/contracts/remote_lease/src/state/channel.rs
@@ -70,6 +70,14 @@ impl Channel {
         }
     }
 
+    /// Guard for outbound packet emission: accept only `Open`.
+    pub fn usable_or_err(&self) -> Result<()> {
+        match self.state {
+            ChannelState::Open => Ok(()),
+            ChannelState::Closing => Err(Error::ChannelNotOperational),
+        }
+    }
+
     pub(super) fn into_parts(self) -> (String, String, String, String, ChannelState) {
         (
             self.local_channel_id,
@@ -121,6 +129,21 @@ mod test {
     fn into_closing_from_closing_errors() {
         let closing = open_channel().into_closing().unwrap();
         let err = closing.into_closing().unwrap_err();
+        assert!(matches!(err, Error::ChannelNotOperational), "got {err:?}");
+    }
+
+    #[test]
+    fn usable_or_err_open() {
+        open_channel().usable_or_err().unwrap();
+    }
+
+    #[test]
+    fn usable_or_err_closing() {
+        let err = open_channel()
+            .into_closing()
+            .unwrap()
+            .usable_or_err()
+            .unwrap_err();
         assert!(matches!(err, Error::ChannelNotOperational), "got {err:?}");
     }
 

--- a/protocol/contracts/remote_lease/src/state/config.rs
+++ b/protocol/contracts/remote_lease/src/state/config.rs
@@ -2,10 +2,13 @@ use std::mem;
 
 use serde::{Deserialize, Serialize};
 
-use platform::contract::Code;
-use sdk::{cosmwasm_std::Storage, cw_storage_plus::Item};
+use platform::contract::{self, Code, Validator as _};
+use sdk::{
+    cosmwasm_std::{Addr, QuerierWrapper, Storage},
+    cw_storage_plus::Item,
+};
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct Config {
@@ -59,17 +62,39 @@ impl Config {
             })
             .map(mem::drop)
     }
+
+    /// Verify the caller is a contract instance of `Config.lease_code`.
+    ///
+    /// Both failure paths (the caller is not a contract; the caller has a different
+    /// code id) collapse to a single `UnauthorisedCaller` — the controller does not
+    /// distinguish them at the protocol layer, and surfacing the underlying platform
+    /// error would leak internal cosmwasm shape into the public error surface.
+    pub fn auth_caller(&self, querier: QuerierWrapper<'_>, caller: Addr) -> Result<Addr> {
+        contract::validator(querier)
+            .check_contract_code(caller, &self.lease_code)
+            .map_err(|_| Error::UnauthorisedCaller)
+    }
 }
 
 #[cfg(test)]
 mod test {
     use platform::contract::{Code, CodeId};
-    use sdk::cosmwasm_std::{Storage, testing::MockStorage};
+    use sdk::{
+        cosmwasm_std::{
+            Addr, ContractInfoResponse, ContractResult, QuerierWrapper, Storage, SystemError,
+            SystemResult, WasmQuery,
+            testing::{MockQuerier, MockStorage},
+        },
+        testing as sdk_testing,
+    };
+
+    use crate::error::Error;
 
     use super::Config;
 
     const CONNECTION_ID: &str = "connection-0";
     const DEX_LABEL: &str = "osmosis";
+    const LEASE_USER: &str = "lease";
 
     #[test]
     fn store_load() {
@@ -95,11 +120,75 @@ mod test {
         assert_eq!(DEX_LABEL, loaded.dex_label());
     }
 
+    #[test]
+    fn auth_caller_matching_code() {
+        let lease_code = Code::unchecked(11);
+        let lease = sdk_testing::user(LEASE_USER);
+        let querier = querier_with(lease.clone(), lease_code);
+        let returned = config(lease_code)
+            .auth_caller(QuerierWrapper::new(&querier), lease.clone())
+            .unwrap();
+        assert_eq!(lease, returned);
+    }
+
+    #[test]
+    fn auth_caller_mismatched_code() {
+        let configured = Code::unchecked(11);
+        let actual = Code::unchecked(99);
+        let lease = sdk_testing::user(LEASE_USER);
+        let querier = querier_with(lease.clone(), actual);
+        let err = config(configured)
+            .auth_caller(QuerierWrapper::new(&querier), lease)
+            .unwrap_err();
+        assert!(matches!(err, Error::UnauthorisedCaller), "got {err:?}");
+    }
+
+    #[test]
+    fn auth_caller_non_contract_caller() {
+        let lease_code = Code::unchecked(11);
+        let querier = MockQuerier::default();
+        let err = config(lease_code)
+            .auth_caller(QuerierWrapper::new(&querier), sdk_testing::user(LEASE_USER))
+            .unwrap_err();
+        assert!(matches!(err, Error::UnauthorisedCaller), "got {err:?}");
+    }
+
     fn config(lease_code: Code) -> Config {
         Config::new(CONNECTION_ID.into(), DEX_LABEL.into(), lease_code)
     }
 
     fn assert_lease_code(expected: Code, store: &dyn Storage) {
         assert_eq!(expected, Config::load(store).unwrap().lease_code());
+    }
+
+    fn querier_with(contract: Addr, code: Code) -> MockQuerier {
+        let mut querier = MockQuerier::default();
+        let code_id = CodeId::from(code);
+        querier.update_wasm(move |query| match query {
+            WasmQuery::ContractInfo { contract_addr }
+                if Addr::unchecked(contract_addr) == contract =>
+            {
+                SystemResult::Ok(ContractResult::Ok(
+                    sdk::cosmwasm_std::to_json_binary(&ContractInfoResponse::new(
+                        code_id,
+                        sdk_testing::user("creator"),
+                        None,
+                        false,
+                        None,
+                        None,
+                    ))
+                    .expect("serialization succeeds"),
+                ))
+            }
+            WasmQuery::ContractInfo { contract_addr }
+            | WasmQuery::Smart { contract_addr, .. }
+            | WasmQuery::Raw { contract_addr, .. } => {
+                SystemResult::Err(SystemError::NoSuchContract {
+                    addr: contract_addr.clone(),
+                })
+            }
+            _ => unimplemented!(),
+        });
+        querier
     }
 }


### PR DESCRIPTION
## Summary

Implements §§3.2/3.3/3.5 of the Remote Lease Protocol ADR — the four outbound `ExecuteMsg` paths (`OpenLease`, `CloseLease`, `Swap`, `TransferOut`) share a single `send_operation` pipeline that authorises the caller, loads the channel, builds a `PacketEnvelope { lease, operation, version }` and emits `IbcMsg::SendPacket` with a caller-supplied timeout. Closes [ibc-solray#138](https://github.com/nolus-protocol/ibc-solray/issues/138).

## Changes

- `ExecuteMsg::{OpenLease, CloseLease, Swap, TransferOut} { params, timeout }` — four new variants in the controller's API. Each carries the operation-specific `*Params` from the shared `remote_lease` crate plus a per-call `Duration` timeout.
- `send_operation` dispatcher in `contract.rs`: routes all four paths through the same `authorise_and_load_channel` → `build_packet` chain. The four arms differ only by the `Operation::X(params)` constructor — no duplication.
- Shared `Channel::usable_or_err(&self) -> Result<()>` in `state/channel.rs`: returns `ChannelNotOpen` when no channel is recorded, `ChannelNotOperational` when `state == Closing`. Matches the per-§3.3 channel-state guard.
- Shared `Config::auth_caller(storage, querier, caller) -> Result<Addr>` in `state/config.rs`: verifies the sender's code id against `Config.lease_code` via `platform::contract::validator(...).check_contract_code(...)`. Single failure variant `UnauthorisedCaller` collapses both "non-contract caller" and "wrong code id" — sender-controlled input, no point leaking the inner error shape.
- `PacketEnvelope` construction: `lease = LeaseAddrOnWire::from(info.sender)`, `operation = Operation::*(params)`, `version = ProtocolVersion` (zero-sized marker, pinned at the shared crate's `VERSION`).
- `IbcMsg::SendPacket`: `channel_id` is the local channel id from the stored `Channel`; `timeout` is derived from `env.block.time + caller_supplied_duration` via `cw_time::IntoInstant`/`IntoTimestamp`.
- `error.rs`: new `UnauthorisedCaller` variant.
- `Cargo.toml`: `remote_lease` workspace dep moved from optional to a hard dep (the controller's API types now reference `OpenLeaseParams` etc. unconditionally). Adds `cw-time` and `finance` for the timeout-arithmetic path.
- Tests: four happy-path tests (one per operation) verifying `CosmosMsg::Ibc(IbcMsg::SendPacket)` with the expected channel id and JSON-decoded `PacketEnvelope` payload; four rejection tests via `OpenLease` covering all rejection branches (no channel; channel `Closing`; wrong caller code; non-contract caller).

## Verification

- `cargo build`, `cargo fmt --check`, `cargo test -p remote_lease_controller --features contract,testing` — 49 tests pass.
- `cargo each --tag ci --tag @agnostic -p remote_lease_controller run -- clippy --all-targets --locked` — clean across all six feature combinations (`testing`, `contract`, `contract,testing`, `stub`, `stub,testing`, bare).

## Follow-ups

- [ibc-solray#139](https://github.com/nolus-protocol/ibc-solray/issues/139) — wire `ibc_packet_ack` / `ibc_packet_timeout` to the `RemoteLeaseCallback` dispatch (currently no-op stubs).
- [ibc-solray#140](https://github.com/nolus-protocol/ibc-solray/issues/140) — end-to-end integration tests.