### PR TITLE
ci: pin remote_lease_wire MSRV to 1.89 and enforce in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,6 +243,36 @@ jobs:
             --volume ".:/src:ro" \
             "${image_tag:?}" \
             "${workspace:?}"
+  check-remote-lease-wire-msrv:
+    name: "Check remote_lease_wire MSRV (Rust 1.89)"
+    runs-on: ["self-hosted", "nolus-ci"]
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@v5"
+      - name: "Setup Docker"
+        uses: "nolus-protocol/actions/setup-docker@v1"
+      - name: "Setup workspaces"
+        uses: "./.github/actions/setup-workspaces"
+      - id: "build-container"
+        name: "Build container image"
+        uses: "nolus-protocol/actions/build-image@v1"
+        with:
+          context: "./ci"
+          file: "./ci/Containerfile"
+          target: "check-remote-lease-wire-msrv"
+      - env:
+          image_tag: |-
+            ${{ steps.build-container.outputs.tag }}
+        name: "Run container"
+        run: |-
+          "docker" \
+            "container" \
+            "run" \
+            --env "GITHUB_ACTIONS_LOGGING=true" \
+            --rm \
+            --tty \
+            --volume ".:/src:ro" \
+            "${image_tag:?}"
   lint:
     name: "Lint codebase without tests"
     needs:
@@ -587,6 +617,7 @@ jobs:
       - "audit-dependencies"
       - "check-lockfiles"
       - "check-formatting"
+      - "check-remote-lease-wire-msrv"
       - "lint"
       - "test"
       - "check-unused-dependencies"

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -40,6 +40,11 @@ ARG protocol_contracts_count="8"
 ### 1.94.0-alpine3.23
 ARG rust_image_digest="sha256:ef7b340d4201444fa2757dfddfd4c03be9d2bde468de7b7a68b0e9fabb794334"
 
+### 1.89-alpine (pinned MSRV for the `remote_lease_wire` wire crate, consumed by
+### the external `ibc-solray` repo). Bump in lockstep with `rust-version` in
+### `protocol/packages/remote_lease_wire/Cargo.toml`.
+ARG msrv_rust_image_digest="sha256:4b800f2e72e04be908e5f634c504c741bd943b763d1d8ad7b096cc340e1b5b46"
+
 ### 1.96.0
 ARG rust_nightly_version="2026-03-05"
 
@@ -72,6 +77,29 @@ ENV CARGO_INCREMENTAL="0" \
 WORKDIR "/src"
 
 RUN "apk" "update" && "apk" "add" "libc-dev"
+
+FROM docker.io/library/rust@${msrv_rust_image_digest:?} AS msrv-rust
+
+ENV CARGO_INCREMENTAL="0" \
+  CARGO_TARGET_DIR="/tmp/cargo-target/" \
+  CARGO_TERM_COLOR="always" \
+  POSIXLY_CORRECT="1" \
+  SOURCE_DATE_EPOCH="0"
+
+WORKDIR "/src/protocol"
+
+RUN "apk" "update" && "apk" "add" "libc-dev"
+
+FROM msrv-rust AS check-remote-lease-wire-msrv
+
+VOLUME ["/src"]
+
+ENTRYPOINT [ \
+  "cargo", "check", \
+  "--locked", \
+  "--all-targets", \
+  "--package", "remote_lease_wire" \
+]
 
 FROM docker.io/library/rust@${tooling_rust_image_digest:?} AS tooling-rust
 

--- a/protocol/packages/remote_lease_wire/Cargo.toml
+++ b/protocol/packages/remote_lease_wire/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-rust-version.workspace = true
+rust-version = "1.89"
 
 [package.metadata.cargo-each]
 combinations = [


### PR DESCRIPTION
## Summary

The `remote_lease_wire` crate is consumed outside the workspace by the Solana-side `ibc-solray` repo via a git dependency. Pinning its MSRV below the workspace's 1.94 gives downstream consumers more flexibility on their own toolchain choices. Without a CI job that builds the crate on the pinned toolchain, MSRV drift would ship silently.

## Changes

- `protocol/packages/remote_lease_wire/Cargo.toml` — override `rust-version` to `"1.89"` (was `workspace = true`, i.e. 1.94).
- `ci/Containerfile` — add `msrv_rust_image_digest` ARG (pinned `rust:1.89-alpine` manifest digest, comment notes lockstep bump with the crate's `rust-version`), an `msrv-rust` base stage with `WORKDIR /src/protocol`, and a `check-remote-lease-wire-msrv` target whose ENTRYPOINT is `cargo check --locked --all-targets --package remote_lease_wire`.
- `.github/workflows/ci.yaml` — add a `check-remote-lease-wire-msrv` job mirroring the existing self-hosted-runner / `build-image` / `docker run` pattern, and add it to `create-draft-release.needs` so a tagged release fails if MSRV regresses.

`--locked` ensures CI also catches lockfile MSRV bumps (e.g. a future `cargo update` pulling a `serde_json` release that raises its floor past 1.89).

## Verification

- `cargo check -p remote_lease_wire --all-targets` (workspace 1.94 toolchain) — passed.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yaml'))"` — parsed cleanly.
- Confirmed `rust:1.89-alpine` multi-arch manifest digest on Docker Hub.
- The new container stage and job could not be exercised locally (no docker on the dev machine); first CI run on this PR is the real check.

## Follow-ups

- Once green, separate docs PR to refresh `docs/remote-lease-wire-contract.md` with the wire/typed split intro and the `NolusLeaseAddr` envelope wording.