### PR TITLE
feat: switch Lease lifecycle to remote-lease stubs (#142)

### DIFF
--- a/docs/remote-lease-wire-contract.md
+++ b/docs/remote-lease-wire-contract.md
@@ -56,7 +56,7 @@ mapping the IBC outcomes:
 - `StdAck::Error(message)` → `RemoteLeaseCallback::OperationErr(RemoteErrorMessage)` (rejected if > 512 bytes).
 - timeout → `RemoteLeaseCallback::OperationTimeout` (unit; the original `Operation` is recoverable from the lease's own pending-state).
 
-The lease address travels with the packet (`envelope.lease`) — the controller keeps no per-packet correlation map. The lease contract authorises the call by querying its leaser (`QueryMsg::CheckRemoteLeaseCallbackPermission { by: info.sender }`); the leaser compares the caller against its protocol-wide `Config.remote_lease`, set at leaser instantiation. That address is immutable — no `ExecuteMsg` or `SudoMsg` variant updates `remote_lease` — so the live-query semantic is equivalent to a pin set at lease open. The controller does not retry on the lease's behalf. See ADR 0001 §3.7 in `nolus-protocol/ibc-solray` for the atomicity model.
+The lease address travels with the packet (`envelope.lease`) — the controller keeps no per-packet correlation map. The lease contract authorises the call by querying its leaser (`QueryMsg::CheckRemoteLeaseCallbackPermission { by: info.sender }`); the leaser compares the caller against its protocol-wide `Config.remote_lease_controller`, set at leaser instantiation. That address is immutable — no `ExecuteMsg` or `SudoMsg` variant updates `remote_lease_controller` — so the live-query semantic is equivalent to a pin set at lease open. The controller does not retry on the lease's behalf. See ADR 0001 §3.7 in `nolus-protocol/ibc-solray` for the atomicity model.
 
 ## Design principle
 

--- a/docs/remote-lease-wire-contract.md
+++ b/docs/remote-lease-wire-contract.md
@@ -15,7 +15,7 @@ The `remote_lease` crate defines the IBC packet types exchanged between the Nolu
 
 ## Operations
 
-- `OpenLease { expected_instance_ordinal: u16, downpayment_currency, lpn_currency, asset_currency }` — currencies must be pairwise distinct.
+- `OpenLease { expected_instance_ordinal: u16, downpayment_currency, lpn_currency, asset_currency }` — the only enforced inequality is `lpn_currency != asset_currency`. `downpayment_currency == lpn_currency` and `downpayment_currency == asset_currency` are both permitted; the Solana side does not constrain those pairs. The wire-level invariant is intentionally permissive — any tighter constraint belongs in the Nolus-side caller, not the wire.
 - `CloseLease {}`
 - `Swap { coin_in, min_out }` — both amounts non-zero, currencies distinct.
 - `TransferOut { amount }` — amount non-zero.

--- a/protocol/contracts/lease/Cargo.toml
+++ b/protocol/contracts/lease/Cargo.toml
@@ -38,6 +38,7 @@ contract = [
     "dep:thiserror",
     "dep:timealarms",
     "dep:versioning",
+    "remote_lease/stub",
 ]
 contract_testing = [
     "contract",

--- a/protocol/contracts/lease/src/api/open/mod.rs
+++ b/protocol/contracts/lease/src/api/open/mod.rs
@@ -21,8 +21,9 @@ use super::LeaseAssetCurrencies;
 mod unchecked;
 
 /// Fields are ordered by lifecycle role: lease identity (`form`), DEX
-/// transport (`dex`), and finally the downstream notification sink invoked
-/// at terminal states (`finalizer`).
+/// transport (`dex`), downstream notification sink invoked at terminal
+/// states (`finalizer`), and the remote-instance pin used by the
+/// remote-lease controller (`expected_instance_ordinal`).
 #[derive(Serialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "skel", derive(Deserialize))]
 #[cfg_attr(feature = "skel_testing", derive(Debug))]
@@ -36,6 +37,13 @@ pub struct NewLeaseContract {
     ///
     /// The finalizer API should provide all `FinalizerExecuteMsg` variants.
     pub finalizer: Addr,
+    /// The Solana-side instance ordinal expected by the remote-lease
+    /// controller for this protocol deployment.
+    ///
+    /// Threaded into `OpenLeaseParams` at the start of the remote-lease
+    /// open lifecycle. The Cosmos side does not interpret this value; it
+    /// is forwarded to the controller and asserted on the Solana side.
+    pub expected_instance_ordinal: u16,
 }
 
 #[derive(Serialize, Clone, PartialEq, Eq)]

--- a/protocol/contracts/lease/src/api/open/mod.rs
+++ b/protocol/contracts/lease/src/api/open/mod.rs
@@ -22,8 +22,9 @@ mod unchecked;
 
 /// Fields are ordered by lifecycle role: lease identity (`form`), DEX
 /// transport (`dex`), downstream notification sink invoked at terminal
-/// states (`finalizer`), and the remote-instance pin used by the
-/// remote-lease controller (`expected_instance_ordinal`).
+/// states (`finalizer`), the local remote-lease controller invoked for
+/// outbound operations (`remote_lease_controller`), and the remote-instance
+/// pin used by that controller (`expected_instance_ordinal`).
 #[derive(Serialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "skel", derive(Deserialize))]
 #[cfg_attr(feature = "skel_testing", derive(Debug))]
@@ -37,6 +38,13 @@ pub struct NewLeaseContract {
     ///
     /// The finalizer API should provide all `FinalizerExecuteMsg` variants.
     pub finalizer: Addr,
+    /// The local remote-lease controller that fronts the IBC channel to
+    /// the Solana side.
+    ///
+    /// Outbound remote-lease operations are dispatched through this
+    /// address via the `remote_lease::stub::Factory` and
+    /// `remote_lease::stub::Lease` builders.
+    pub remote_lease_controller: Addr,
     /// The Solana-side instance ordinal expected by the remote-lease
     /// controller for this protocol deployment.
     ///

--- a/protocol/contracts/lease/src/api/query.rs
+++ b/protocol/contracts/lease/src/api/query.rs
@@ -72,6 +72,7 @@ pub enum StateResponse {
 }
 
 pub mod opening {
+    use remote_lease::response::RemoteLeaseId;
     #[cfg(feature = "skel_testing")]
     use serde::Deserialize;
     use serde::Serialize;
@@ -84,6 +85,7 @@ pub mod opening {
     #[serde(deny_unknown_fields, rename_all = "snake_case")]
     pub enum OngoingTrx {
         OpenIcaAccount,
+        OpenLease { remote_lease: RemoteLeaseId },
         TransferOut { ica_account: String },
         BuyAsset { ica_account: String },
     }

--- a/protocol/contracts/lease/src/api/query.rs
+++ b/protocol/contracts/lease/src/api/query.rs
@@ -69,6 +69,12 @@ pub enum StateResponse {
     },
     Closed(),
     Liquidated(),
+    /// The remote-lease open lifecycle failed before reaching the live
+    /// lease. The downpayment was refunded to the customer and the LPP
+    /// loan was repaid in the same atomic batch.
+    OpenFailed {
+        reason: remote_lease::callback::RemoteErrorMessage,
+    },
 }
 
 pub mod opening {

--- a/protocol/contracts/lease/src/api/query.rs
+++ b/protocol/contracts/lease/src/api/query.rs
@@ -96,9 +96,15 @@ pub mod opening {
         RequestingOpenLease,
         /// The controller has acked; the lease holds the Solana-side
         /// PDA and is progressing toward the live `Active` state.
-        OpenLease { remote_lease: RemoteLeaseId },
-        TransferOut { ica_account: String },
-        BuyAsset { ica_account: String },
+        OpenLease {
+            remote_lease: RemoteLeaseId,
+        },
+        TransferOut {
+            ica_account: String,
+        },
+        BuyAsset {
+            ica_account: String,
+        },
     }
 }
 

--- a/protocol/contracts/lease/src/api/query.rs
+++ b/protocol/contracts/lease/src/api/query.rs
@@ -90,7 +90,12 @@ pub mod opening {
     )]
     #[serde(deny_unknown_fields, rename_all = "snake_case")]
     pub enum OngoingTrx {
-        OpenIcaAccount,
+        /// The lease has emitted `Factory::open` and is waiting for the
+        /// controller's `OpenLease` ack. The Solana-side PDA is not yet
+        /// known at this point.
+        RequestingOpenLease,
+        /// The controller has acked; the lease holds the Solana-side
+        /// PDA and is progressing toward the live `Active` state.
         OpenLease { remote_lease: RemoteLeaseId },
         TransferOut { ica_account: String },
         BuyAsset { ica_account: String },

--- a/protocol/contracts/lease/src/contract/cmd/open.rs
+++ b/protocol/contracts/lease/src/contract/cmd/open.rs
@@ -3,6 +3,7 @@ use finance::instant::Instant;
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
 use profit::stub::ProfitRef;
+use remote_lease::response::RemoteLeaseId;
 use sdk::cosmwasm_std::Addr;
 use timealarms::stub::TimeAlarmsRef;
 
@@ -27,11 +28,13 @@ pub struct LeaseFactory<'a> {
     price_alarms: OracleRef,
     start_at: Instant,
     now: &'a Instant,
+    remote_lease_id: Option<RemoteLeaseId>,
 }
 
 pub type OpenLeaseResult = LeaseDTOResult<CloseStatusDTO>;
 
 impl<'a> LeaseFactory<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         form: NewLeaseForm,
         lease_addr: Addr,
@@ -40,6 +43,7 @@ impl<'a> LeaseFactory<'a> {
         alarms: (TimeAlarmsRef, OracleRef),
         start_at: Instant,
         now: &'a Instant,
+        remote_lease_id: Option<RemoteLeaseId>,
     ) -> Self {
         Self {
             form,
@@ -50,6 +54,7 @@ impl<'a> LeaseFactory<'a> {
             price_alarms: alarms.1,
             start_at,
             now,
+            remote_lease_id,
         }
     }
 }
@@ -78,7 +83,14 @@ impl WithLeaseDeps for LeaseFactory<'_> {
                 self.form.loan.annual_margin_interest,
                 self.form.loan.due_period,
             );
-            Lease::new(self.lease_addr, self.form.customer, position, loan, oracle)
+            Lease::new(
+                self.lease_addr,
+                self.form.customer,
+                position,
+                loan,
+                oracle,
+                self.remote_lease_id,
+            )
         };
 
         check::check(&lease, self.now, &self.time_alarms, &self.price_alarms).map(|status| {

--- a/protocol/contracts/lease/src/contract/cmd/open.rs
+++ b/protocol/contracts/lease/src/contract/cmd/open.rs
@@ -28,7 +28,7 @@ pub struct LeaseFactory<'a> {
     price_alarms: OracleRef,
     start_at: Instant,
     now: &'a Instant,
-    remote_lease_id: Option<RemoteLeaseId>,
+    remote_lease_id: RemoteLeaseId,
 }
 
 pub type OpenLeaseResult = LeaseDTOResult<CloseStatusDTO>;
@@ -43,7 +43,7 @@ impl<'a> LeaseFactory<'a> {
         alarms: (TimeAlarmsRef, OracleRef),
         start_at: Instant,
         now: &'a Instant,
-        remote_lease_id: Option<RemoteLeaseId>,
+        remote_lease_id: RemoteLeaseId,
     ) -> Self {
         Self {
             form,

--- a/protocol/contracts/lease/src/contract/endpoins.rs
+++ b/protocol/contracts/lease/src/contract/endpoins.rs
@@ -15,8 +15,7 @@ use sdk::{
     },
 };
 use versioning::{
-    ProtocolMigrationMessage, ProtocolPackageRelease, VersionSegment, package_name,
-    package_version,
+    ProtocolMigrationMessage, ProtocolPackageRelease, VersionSegment, package_name, package_version,
 };
 
 use crate::{

--- a/protocol/contracts/lease/src/contract/endpoins.rs
+++ b/protocol/contracts/lease/src/contract/endpoins.rs
@@ -64,10 +64,19 @@ pub fn migrate(
 ) -> ContractResult<CwResponse> {
     // v10 reshapes the persisted `LeaseDTO` to carry the Solana-side
     // remote-lease PDA as a non-optional field, so a pre-v10 lease cannot
-    // be deserialised under the new layout. Mainnet v9-lease population
-    // is zero (plan §10.A.1), so no in-flight state is at risk — reject
-    // any migrate attempt loudly rather than silently failing the first
-    // post-upgrade load.
+    // be deserialised under the new layout. A v9 lease has no meaningful
+    // `remote_lease_id` to synthesise — its `dex_account` is an ICA host on
+    // the DEX chain, not a Solana PDA — so a real v9→v10 migration would
+    // have to invent a sentinel and leave the lease permanently Cosmos-side
+    // only. Mainnet v9-lease population is zero (plan §10.A.1), so no
+    // in-flight state is at risk there; reject any migrate attempt loudly
+    // rather than silently failing the first post-upgrade load.
+    //
+    // Operational posture for non-mainnet (devnet/testnet/local): drain all
+    // v9 leases to a terminal state before upgrading the lease code to v10.
+    // There is no `ExecuteMsg` escape hatch for a stranded v9 lease — the
+    // storage layout is binary-incompatible — so the drain is a prerequisite,
+    // not a recovery step. See `protocol/docs/remote-lease-callback-flow.md`.
     Err(ContractError::UnsupportedMigration).inspect_err(platform_error::log(deps.api))
 }
 

--- a/protocol/contracts/lease/src/contract/endpoins.rs
+++ b/protocol/contracts/lease/src/contract/endpoins.rs
@@ -15,8 +15,8 @@ use sdk::{
     },
 };
 use versioning::{
-    ProtocolMigrationMessage, ProtocolPackageRelease, UpdatablePackage, VersionSegment,
-    package_name, package_version,
+    ProtocolMigrationMessage, ProtocolPackageRelease, VersionSegment, package_name,
+    package_version,
 };
 
 use crate::{
@@ -27,7 +27,7 @@ use crate::{
 
 use super::state::{self, Response, State};
 
-const CONTRACT_STORAGE_VERSION: VersionSegment = 9;
+const CONTRACT_STORAGE_VERSION: VersionSegment = 10;
 const CURRENT_RELEASE: ProtocolPackageRelease = ProtocolPackageRelease::current(
     package_name!(),
     package_version!(),
@@ -61,17 +61,15 @@ pub fn instantiate(
 pub fn migrate(
     deps: DepsMut<'_>,
     _env: Env,
-    ProtocolMigrationMessage {
-        migrate_from,
-        to_release,
-        message: MigrateMsg {},
-    }: ProtocolMigrationMessage<MigrateMsg>,
+    _msg: ProtocolMigrationMessage<MigrateMsg>,
 ) -> ContractResult<CwResponse> {
-    migrate_from
-        .update_software(&CURRENT_RELEASE, &to_release)
-        .map(|()| response::empty_response())
-        .map_err(ContractError::UpdateSoftware)
-        .inspect_err(platform_error::log(deps.api))
+    // v10 reshapes the persisted `LeaseDTO` to carry the Solana-side
+    // remote-lease PDA as a non-optional field, so a pre-v10 lease cannot
+    // be deserialised under the new layout. Mainnet v9-lease population
+    // is zero (plan §10.A.1), so no in-flight state is at risk — reject
+    // any migrate attempt loudly rather than silently failing the first
+    // post-upgrade load.
+    Err(ContractError::UnsupportedMigration).inspect_err(platform_error::log(deps.api))
 }
 
 #[entry_point]

--- a/protocol/contracts/lease/src/contract/finalize.rs
+++ b/protocol/contracts/lease/src/contract/finalize.rs
@@ -14,7 +14,7 @@ use crate::{
     error::{ContractError, ContractResult},
 };
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct LeasesRef {
     addr: Addr,

--- a/protocol/contracts/lease/src/contract/finalize.rs
+++ b/protocol/contracts/lease/src/contract/finalize.rs
@@ -31,7 +31,7 @@ impl LeasesRef {
             .map_err(Into::into)
     }
 
-    pub(super) fn finalize_lease(&self, customer: Addr) -> ContractResult<Batch> {
+    pub(crate) fn finalize_lease(&self, customer: Addr) -> ContractResult<Batch> {
         let mut msgs = Batch::default();
         msgs.schedule_execute_wasm_no_reply_no_funds(
             self.addr.clone(),

--- a/protocol/contracts/lease/src/contract/state/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/mod.rs
@@ -36,6 +36,7 @@ mod event;
 mod handler;
 mod lease;
 mod liquidated;
+mod open_failed;
 mod opened;
 mod opening;
 mod out_task;
@@ -45,6 +46,8 @@ mod resp_delivery;
 type RequestLoan = LeaseState<opening::request_loan::RequestLoan>;
 
 type OpenLease = opening::open_lease::OpenLease;
+
+type OpenFailed = open_failed::OpenFailed;
 
 type BuyAsset = DexState<opening::buy_asset::DexState>;
 
@@ -77,6 +80,7 @@ type SwapClient = Impl;
 pub enum State {
     RequestLoan,
     OpenLease,
+    OpenFailed,
     BuyAsset,
     OpenedActive,
     BuyLpn,

--- a/protocol/contracts/lease/src/contract/state/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/mod.rs
@@ -44,6 +44,8 @@ mod resp_delivery;
 
 type RequestLoan = LeaseState<opening::request_loan::RequestLoan>;
 
+type OpenLease = opening::open_lease::OpenLease;
+
 type BuyAsset = DexState<opening::buy_asset::DexState>;
 
 type OpenedActive = LeaseState<opened::active::Active>;
@@ -74,6 +76,7 @@ type SwapClient = Impl;
 #[derive(Serialize, Deserialize)]
 pub enum State {
     RequestLoan,
+    OpenLease,
     BuyAsset,
     OpenedActive,
     BuyLpn,

--- a/protocol/contracts/lease/src/contract/state/open_failed.rs
+++ b/protocol/contracts/lease/src/contract/state/open_failed.rs
@@ -1,0 +1,65 @@
+use finance::{duration::Duration, instant::Instant};
+use platform::{
+    batch::{Batch, Emit, Emitter},
+    message::Response as MessageResponse,
+    state_machine::Response as StateMachineResponse,
+};
+use remote_lease::callback::{RemoteErrorMessage, RemoteLeaseCallback};
+use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    api::query::StateResponse as QueryStateResponse,
+    contract::api::Contract,
+    error::ContractResult,
+};
+
+use super::Response;
+
+const LATE_ACK_EVENT: &str = "ls-remote-lease-late-ack";
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct OpenFailed {
+    reason: RemoteErrorMessage,
+}
+
+impl OpenFailed {
+    pub(crate) fn new(reason: RemoteErrorMessage) -> Self {
+        Self { reason }
+    }
+}
+
+impl Contract for OpenFailed {
+    fn state(
+        self,
+        _now: Instant,
+        _due_projection: Duration,
+        _querier: QuerierWrapper<'_>,
+    ) -> ContractResult<QueryStateResponse> {
+        Ok(QueryStateResponse::OpenFailed {
+            reason: self.reason,
+        })
+    }
+
+    /// Absorbs late-after-terminal callbacks. The remote-lease IBC
+    /// channel is UNORDERED, so the original packet's success ack may
+    /// still land here after a timeout already moved us to this
+    /// terminal. Return `Ok` with an observability event so the
+    /// controller's `ibc_packet_ack` commits and the relayer's retry
+    /// loop unblocks. Idempotent — no state mutation.
+    fn on_remote_lease_callback(
+        self,
+        _callback: RemoteLeaseCallback,
+        _info: MessageInfo,
+        _querier: QuerierWrapper<'_>,
+        env: Env,
+    ) -> ContractResult<Response> {
+        let emitter = Emitter::of_type(LATE_ACK_EVENT)
+            .emit("id", env.contract.address)
+            .emit("terminal", "open_failed");
+        Ok(StateMachineResponse::from(
+            MessageResponse::messages_with_event(Batch::default(), emitter),
+            super::State::from(self),
+        ))
+    }
+}

--- a/protocol/contracts/lease/src/contract/state/open_failed.rs
+++ b/protocol/contracts/lease/src/contract/state/open_failed.rs
@@ -59,8 +59,11 @@ impl Contract for OpenFailed {
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> ContractResult<Response> {
-        access_control::check(&self.leases.remote_lease_callback_permission(querier), &info)
-            .map_err(ContractError::from)?;
+        access_control::check(
+            &self.leases.remote_lease_callback_permission(querier),
+            &info,
+        )
+        .map_err(ContractError::from)?;
         let emitter = Emitter::of_type(LATE_ACK_EVENT)
             .emit("id", env.contract.address)
             .emit("terminal", "open_failed");

--- a/protocol/contracts/lease/src/contract/state/open_failed.rs
+++ b/protocol/contracts/lease/src/contract/state/open_failed.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     api::query::StateResponse as QueryStateResponse,
-    contract::api::Contract,
-    error::ContractResult,
+    contract::{api::Contract, finalize::LeasesRef},
+    error::{ContractError, ContractResult},
 };
 
 use super::Response;
@@ -21,11 +21,12 @@ const LATE_ACK_EVENT: &str = "ls-remote-lease-late-ack";
 #[derive(Serialize, Deserialize)]
 pub(crate) struct OpenFailed {
     reason: RemoteErrorMessage,
+    leases: LeasesRef,
 }
 
 impl OpenFailed {
-    pub(crate) fn new(reason: RemoteErrorMessage) -> Self {
-        Self { reason }
+    pub(crate) fn new(reason: RemoteErrorMessage, leases: LeasesRef) -> Self {
+        Self { reason, leases }
     }
 }
 
@@ -47,13 +48,19 @@ impl Contract for OpenFailed {
     /// terminal. Return `Ok` with an observability event so the
     /// controller's `ibc_packet_ack` commits and the relayer's retry
     /// loop unblocks. Idempotent — no state mutation.
+    ///
+    /// Gated by the same `remote_lease_callback_permission` check the
+    /// in-flight states use, so a third party cannot spam late-ack
+    /// events against a terminal lease.
     fn on_remote_lease_callback(
         self,
         _callback: RemoteLeaseCallback,
-        _info: MessageInfo,
-        _querier: QuerierWrapper<'_>,
+        info: MessageInfo,
+        querier: QuerierWrapper<'_>,
         env: Env,
     ) -> ContractResult<Response> {
+        access_control::check(&self.leases.remote_lease_callback_permission(querier), &info)
+            .map_err(ContractError::from)?;
         let emitter = Emitter::of_type(LATE_ACK_EVENT)
             .emit("id", env.contract.address)
             .emit("terminal", "open_failed");

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/finish.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/finish.rs
@@ -96,6 +96,7 @@ where
                 (spec.deps.2, spec.deps.1.clone()),
                 spec.start_opening_at,
                 &now,
+                spec.remote_lease_id,
             )
         };
         let OpenLeaseResult {

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -57,7 +57,7 @@ pub(super) fn start(
     loan: OpenLoanRespResult,
     deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
     start_opening_at: Instant,
-    remote_lease_id: Option<RemoteLeaseId>,
+    remote_lease_id: RemoteLeaseId,
 ) -> StartState {
     dex::start_local_remote::<_, BuyAsset>(OpenIcaAccount::new(
         new_lease,
@@ -79,8 +79,7 @@ pub struct BuyAsset {
     loan: OpenLoanRespResult,
     deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
     start_opening_at: Instant,
-    #[serde(default)]
-    remote_lease_id: Option<RemoteLeaseId>,
+    remote_lease_id: RemoteLeaseId,
 }
 
 impl BuyAsset {
@@ -91,7 +90,7 @@ impl BuyAsset {
         loan: OpenLoanRespResult,
         deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
         start_opening_at: Instant,
-        remote_lease_id: Option<RemoteLeaseId>,
+        remote_lease_id: RemoteLeaseId,
     ) -> Self {
         Self {
             form,

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -40,6 +40,7 @@ mod calculator;
 mod finish;
 
 type AssetGroup = LeaseAssetCurrencies;
+#[allow(dead_code)]
 pub(super) type StartState = StartLocalRemoteState<OpenIcaAccount, BuyAsset>;
 pub(in super::super) type DexState = dex::StateRemoteOut<
     OpenIcaAccount,
@@ -49,6 +50,7 @@ pub(in super::super) type DexState = dex::StateRemoteOut<
     ForwardToDexEntryContinue,
 >;
 
+#[allow(dead_code)]
 pub(super) fn start(
     new_lease: NewLeaseContract,
     downpayment: DownpaymentCoin,

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -11,6 +11,7 @@ use dex::{
 use finance::instant::Instant;
 use finance::{coin::CoinDTO, duration::Duration};
 use platform::ica::HostAccount;
+use remote_lease::response::RemoteLeaseId;
 use sdk::cosmwasm_std::{MessageInfo, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
@@ -50,13 +51,13 @@ pub(in super::super) type DexState = dex::StateRemoteOut<
     ForwardToDexEntryContinue,
 >;
 
-#[allow(dead_code)]
 pub(super) fn start(
     new_lease: NewLeaseContract,
     downpayment: DownpaymentCoin,
     loan: OpenLoanRespResult,
     deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
     start_opening_at: Instant,
+    remote_lease_id: Option<RemoteLeaseId>,
 ) -> StartState {
     dex::start_local_remote::<_, BuyAsset>(OpenIcaAccount::new(
         new_lease,
@@ -64,6 +65,7 @@ pub(super) fn start(
         loan,
         deps,
         start_opening_at,
+        remote_lease_id,
     ))
 }
 
@@ -77,6 +79,8 @@ pub struct BuyAsset {
     loan: OpenLoanRespResult,
     deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
     start_opening_at: Instant,
+    #[serde(default)]
+    remote_lease_id: Option<RemoteLeaseId>,
 }
 
 impl BuyAsset {
@@ -87,6 +91,7 @@ impl BuyAsset {
         loan: OpenLoanRespResult,
         deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
         start_opening_at: Instant,
+        remote_lease_id: Option<RemoteLeaseId>,
     ) -> Self {
         Self {
             form,
@@ -95,6 +100,7 @@ impl BuyAsset {
             loan,
             deps,
             start_opening_at,
+            remote_lease_id,
         }
     }
 

--- a/protocol/contracts/lease/src/contract/state/opening/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/mod.rs
@@ -1,3 +1,4 @@
 pub mod buy_asset;
 pub mod open_ica;
+pub mod open_lease;
 pub mod request_loan;

--- a/protocol/contracts/lease/src/contract/state/opening/open_ica.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_ica.rs
@@ -34,6 +34,7 @@ pub(crate) struct OpenIcaAccount {
 }
 
 impl OpenIcaAccount {
+    #[allow(dead_code)]
     pub(super) fn new(
         new_lease: NewLeaseContract,
         downpayment: DownpaymentCoin,

--- a/protocol/contracts/lease/src/contract/state/opening/open_ica.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_ica.rs
@@ -32,8 +32,7 @@ pub(crate) struct OpenIcaAccount {
     loan: OpenLoanRespResult,
     deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
     start_opening_at: Instant,
-    #[serde(default)]
-    remote_lease_id: Option<RemoteLeaseId>,
+    remote_lease_id: RemoteLeaseId,
 }
 
 impl OpenIcaAccount {
@@ -43,7 +42,7 @@ impl OpenIcaAccount {
         loan: OpenLoanRespResult,
         deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
         start_opening_at: Instant,
-        remote_lease_id: Option<RemoteLeaseId>,
+        remote_lease_id: RemoteLeaseId,
     ) -> Self {
         Self {
             new_lease,
@@ -97,16 +96,14 @@ impl DexContract for OpenIcaAccount {
         _due_projection: Duration,
         _querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
-        let in_progress = match self.remote_lease_id {
-            Some(remote_lease) => OngoingTrx::OpenLease { remote_lease },
-            None => OngoingTrx::OpenIcaAccount {},
-        };
         Ok(QueryStateResponse::Opening {
             currency: self.new_lease.form.currency,
             downpayment: self.downpayment,
             loan: self.loan.principal,
             loan_interest_rate: self.loan.annual_interest_rate,
-            in_progress,
+            in_progress: OngoingTrx::OpenLease {
+                remote_lease: self.remote_lease_id,
+            },
         })
     }
 }

--- a/protocol/contracts/lease/src/contract/state/opening/open_ica.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_ica.rs
@@ -97,12 +97,16 @@ impl DexContract for OpenIcaAccount {
         _due_projection: Duration,
         _querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
+        let in_progress = match self.remote_lease_id {
+            Some(remote_lease) => OngoingTrx::OpenLease { remote_lease },
+            None => OngoingTrx::OpenIcaAccount {},
+        };
         Ok(QueryStateResponse::Opening {
             currency: self.new_lease.form.currency,
             downpayment: self.downpayment,
             loan: self.loan.principal,
             loan_interest_rate: self.loan.annual_interest_rate,
-            in_progress: OngoingTrx::OpenIcaAccount {},
+            in_progress,
         })
     }
 }

--- a/protocol/contracts/lease/src/contract/state/opening/open_ica.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_ica.rs
@@ -8,6 +8,7 @@ use dex::{
 };
 use finance::instant::Instant;
 use platform::batch::Batch;
+use remote_lease::response::RemoteLeaseId;
 use sdk::cosmwasm_std::{MessageInfo, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
@@ -31,16 +32,18 @@ pub(crate) struct OpenIcaAccount {
     loan: OpenLoanRespResult,
     deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
     start_opening_at: Instant,
+    #[serde(default)]
+    remote_lease_id: Option<RemoteLeaseId>,
 }
 
 impl OpenIcaAccount {
-    #[allow(dead_code)]
     pub(super) fn new(
         new_lease: NewLeaseContract,
         downpayment: DownpaymentCoin,
         loan: OpenLoanRespResult,
         deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
         start_opening_at: Instant,
+        remote_lease_id: Option<RemoteLeaseId>,
     ) -> Self {
         Self {
             new_lease,
@@ -48,6 +51,7 @@ impl OpenIcaAccount {
             loan,
             deps,
             start_opening_at,
+            remote_lease_id,
         }
     }
 }
@@ -64,6 +68,7 @@ impl IcaConnectee for OpenIcaAccount {
             self.loan,
             self.deps,
             self.start_opening_at,
+            self.remote_lease_id,
         ))
     }
 

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -33,7 +33,7 @@ use crate::{
         api::Contract,
         cmd::OpenLoanRespResult,
         finalize::LeasesRef,
-        state::{Response, State, closed::Closed},
+        state::{Response, State},
     },
     error::{ContractError, ContractResult},
     finance::{LpnCoin, LpnCurrency, LppRef, OracleRef},
@@ -120,7 +120,7 @@ impl OpenLease {
         self,
         querier: QuerierWrapper<'_>,
         env: &Env,
-        reason_label: String,
+        reason: RemoteErrorMessage,
     ) -> ContractResult<Response> {
         let Self {
             new_lease,
@@ -149,10 +149,10 @@ impl OpenLease {
             .map(|batch| {
                 let emitter = Emitter::of_type(OPEN_FAILED_EVENT)
                     .emit("id", lease_addr)
-                    .emit("reason", reason_label);
+                    .emit("reason", reason.as_str().to_owned());
                 StateMachineResponse::from(
                     MessageResponse::messages_with_event(batch, emitter),
-                    State::from(Closed::default()),
+                    State::from(crate::contract::state::open_failed::OpenFailed::new(reason)),
                 )
             })
     }
@@ -192,17 +192,16 @@ impl Contract for OpenLease {
                     )))
                 }
                 RemoteLeaseCallback::OperationErr(reason) => {
-                    self.on_open_failed(querier, &env, reason_to_label(&reason))
+                    self.on_open_failed(querier, &env, reason)
                 }
-                RemoteLeaseCallback::OperationTimeout => {
-                    self.on_open_failed(querier, &env, "timeout".to_owned())
-                }
+                RemoteLeaseCallback::OperationTimeout => self.on_open_failed(
+                    querier,
+                    &env,
+                    RemoteErrorMessage::new("timeout")
+                        .expect("'timeout' is within RemoteErrorMessage cap"),
+                ),
             })
     }
-}
-
-fn reason_to_label(reason: &RemoteErrorMessage) -> String {
-    reason.as_str().to_owned()
 }
 
 #[derive(Serialize)]

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -33,7 +33,7 @@ use crate::{
         api::Contract,
         cmd::OpenLoanRespResult,
         finalize::LeasesRef,
-        state::{Response, State},
+        state::{Response, State, open_failed::OpenFailed},
     },
     error::{ContractError, ContractResult},
     finance::{LpnCoin, LpnCurrency, LppRef, OracleRef},
@@ -119,6 +119,19 @@ impl OpenLease {
         env: &Env,
         reason: RemoteErrorMessage,
     ) -> ContractResult<Response> {
+        let lease_addr = env.contract.address.clone();
+        let now = env.block.time.into_instant();
+        let leases_ref = self.deps.3.clone();
+        self.refund_batch(querier, &lease_addr, now)
+            .map(|batch| Self::open_failed_response(batch, lease_addr, reason, leases_ref))
+    }
+
+    fn refund_batch(
+        self,
+        querier: QuerierWrapper<'_>,
+        lease_addr: &Addr,
+        now: Instant,
+    ) -> ContractResult<Batch> {
         let Self {
             new_lease,
             downpayment,
@@ -127,9 +140,6 @@ impl OpenLease {
             start_opening_at: _,
         } = self;
         let customer = new_lease.form.customer;
-        let lease_addr = env.contract.address.clone();
-        let now = env.block.time.into_instant();
-
         Coin::<LpnCurrency>::try_from(loan.principal)
             .map_err(ContractError::from)
             .and_then(|principal| {
@@ -147,17 +157,21 @@ impl OpenLease {
                     .finalize_lease(customer)
                     .map(|finalize_batch| lpp_batch.merge(customer_batch).merge(finalize_batch))
             })
-            .map(|batch| {
-                let emitter = Emitter::of_type(OPEN_FAILED_EVENT)
-                    .emit("id", lease_addr)
-                    .emit("reason", reason.as_str().to_owned());
-                StateMachineResponse::from(
-                    MessageResponse::messages_with_event(batch, emitter),
-                    State::from(crate::contract::state::open_failed::OpenFailed::new(
-                        reason, leases_ref,
-                    )),
-                )
-            })
+    }
+
+    fn open_failed_response(
+        batch: Batch,
+        lease_addr: Addr,
+        reason: RemoteErrorMessage,
+        leases_ref: LeasesRef,
+    ) -> Response {
+        let emitter = Emitter::of_type(OPEN_FAILED_EVENT)
+            .emit("id", lease_addr)
+            .emit("reason", reason.as_str().to_owned());
+        StateMachineResponse::from(
+            MessageResponse::messages_with_event(batch, emitter),
+            State::from(OpenFailed::new(reason, leases_ref)),
+        )
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -1,0 +1,235 @@
+use currencies::PaymentGroup;
+use currency::{CurrencyDef, Group, MemberOf};
+use cw_time::IntoInstant;
+use finance::{
+    coin::{Coin, WithCoin},
+    duration::Duration,
+    instant::Instant,
+};
+use lpp::stub::loan::{LppLoan, WithLppLoan};
+use platform::{
+    bank::{FixedAddressSender, LazySenderStub},
+    batch::{Batch, Emit, Emitter},
+    message::Response as MessageResponse,
+    state_machine::Response as StateMachineResponse,
+};
+use remote_lease::{
+    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    msg::OpenLeaseParams,
+    response::OperationResponse,
+    stub::{ControllerInnerMessage, Factory},
+};
+use sdk::cosmwasm_std::{Addr, Env, MessageInfo, QuerierWrapper};
+use serde::{Deserialize, Serialize};
+use timealarms::stub::TimeAlarmsRef;
+
+use crate::{
+    api::{
+        DownpaymentCoin,
+        open::NewLeaseContract,
+        query::{StateResponse as QueryStateResponse, opening::OngoingTrx},
+    },
+    contract::{
+        api::Contract,
+        cmd::OpenLoanRespResult,
+        finalize::LeasesRef,
+        state::{Response, State, closed::Closed},
+    },
+    error::{ContractError, ContractResult},
+    finance::{LpnCoin, LpnCurrency, LppRef, OracleRef},
+};
+
+const OPEN_FAILED_EVENT: &str = "ls-remote-lease-open-failed";
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct OpenLease {
+    new_lease: NewLeaseContract,
+    downpayment: DownpaymentCoin,
+    loan: OpenLoanRespResult,
+    deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
+    start_opening_at: Instant,
+}
+
+impl OpenLease {
+    pub(super) fn new(
+        new_lease: NewLeaseContract,
+        downpayment: DownpaymentCoin,
+        loan: OpenLoanRespResult,
+        deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
+        start_opening_at: Instant,
+    ) -> Self {
+        Self {
+            new_lease,
+            downpayment,
+            loan,
+            deps,
+            start_opening_at,
+        }
+    }
+
+    pub(super) fn enter(&self) -> ContractResult<Batch> {
+        OpenLeaseParams::new(
+            self.new_lease.expected_instance_ordinal,
+            self.downpayment.currency(),
+            self.loan.principal.currency().into_super_group(),
+            self.new_lease.form.currency.into_super_group(),
+        )
+        .map_err(ContractError::OpenLeaseParams)
+        .and_then(|params| {
+            Factory::new(&self.new_lease.remote_lease_controller)
+                .open(params, OpenLeaseParams::TIMEOUT, |params, timeout| {
+                    ControllerExecuteMsg::OpenLease { params, timeout }
+                })
+                .map_err(ContractError::from)
+        })
+    }
+
+    fn authz_callback(
+        &self,
+        querier: QuerierWrapper<'_>,
+        info: &MessageInfo,
+    ) -> ContractResult<()> {
+        access_control::check(
+            &self.deps.3.remote_lease_callback_permission(querier),
+            info,
+        )
+        .map_err(Into::into)
+    }
+
+    fn on_open_failed(
+        self,
+        querier: QuerierWrapper<'_>,
+        env: &Env,
+        reason_label: String,
+    ) -> ContractResult<Response> {
+        let Self {
+            new_lease,
+            downpayment,
+            loan,
+            deps: (lpp_ref, _oracle, _time_alarms, leases_ref),
+            start_opening_at: _,
+        } = self;
+        let customer = new_lease.form.customer;
+        let lease_addr = env.contract.address.clone();
+        let now = env.block.time.into_instant();
+
+        Coin::<LpnCurrency>::try_from(loan.principal)
+            .map_err(ContractError::from)
+            .and_then(|principal| {
+                lpp_ref.execute_loan(RepayOpenLoan { principal, now }, lease_addr.clone(), querier)
+            })
+            .and_then(|lpp_batch| {
+                let customer_batch = downpayment.with_coin(SendToCustomer {
+                    customer: customer.clone(),
+                });
+                leases_ref
+                    .finalize_lease(customer)
+                    .map(|finalize_batch| lpp_batch.merge(customer_batch).merge(finalize_batch))
+            })
+            .map(|batch| {
+                let emitter = Emitter::of_type(OPEN_FAILED_EVENT)
+                    .emit("id", lease_addr)
+                    .emit("reason", reason_label);
+                StateMachineResponse::from(
+                    MessageResponse::messages_with_event(batch, emitter),
+                    State::from(Closed::default()),
+                )
+            })
+    }
+}
+
+impl Contract for OpenLease {
+    fn state(
+        self,
+        _now: Instant,
+        _due_projection: Duration,
+        _querier: QuerierWrapper<'_>,
+    ) -> ContractResult<QueryStateResponse> {
+        Ok(QueryStateResponse::Opening {
+            currency: self.new_lease.form.currency,
+            downpayment: self.downpayment,
+            loan: self.loan.principal,
+            loan_interest_rate: self.loan.annual_interest_rate,
+            in_progress: OngoingTrx::OpenIcaAccount {},
+        })
+    }
+
+    fn on_remote_lease_callback(
+        self,
+        callback: RemoteLeaseCallback,
+        info: MessageInfo,
+        querier: QuerierWrapper<'_>,
+        env: Env,
+    ) -> ContractResult<Response> {
+        self.authz_callback(querier, &info)
+            .and_then(|()| match callback {
+                RemoteLeaseCallback::OperationOk(OperationResponse::OpenLease(_response)) => Err(
+                    ContractError::unsupported_operation("open lease ok (deferred)"),
+                ),
+                RemoteLeaseCallback::OperationOk(other) => {
+                    Err(ContractError::unsupported_operation(format!(
+                        "open lease unexpected operation response: {other:?}"
+                    )))
+                }
+                RemoteLeaseCallback::OperationErr(reason) => {
+                    self.on_open_failed(querier, &env, reason_to_label(&reason))
+                }
+                RemoteLeaseCallback::OperationTimeout => {
+                    self.on_open_failed(querier, &env, "timeout".to_owned())
+                }
+            })
+    }
+}
+
+fn reason_to_label(reason: &RemoteErrorMessage) -> String {
+    reason.as_str().to_owned()
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ControllerExecuteMsg {
+    OpenLease {
+        params: OpenLeaseParams,
+        timeout: Duration,
+    },
+}
+
+impl ControllerInnerMessage for ControllerExecuteMsg {}
+
+struct RepayOpenLoan {
+    principal: LpnCoin,
+    now: Instant,
+}
+
+impl WithLppLoan<LpnCurrency> for RepayOpenLoan {
+    type Output = Batch;
+    type Error = ContractError;
+
+    fn exec<Loan>(self, mut loan: Loan) -> Result<Self::Output, Self::Error>
+    where
+        Loan: LppLoan<LpnCurrency>,
+    {
+        let _receipt = loan.repay(&self.now, self.principal);
+        loan.try_into()
+            .map(|batch: lpp::stub::LppBatch<lpp::stub::LppRef<LpnCurrency>>| batch.batch)
+            .map_err(Into::into)
+    }
+}
+
+struct SendToCustomer {
+    customer: Addr,
+}
+
+impl WithCoin<PaymentGroup> for SendToCustomer {
+    type Outcome = Batch;
+
+    fn on<C>(self, amount: Coin<C>) -> Self::Outcome
+    where
+        C: CurrencyDef,
+        C::Group: MemberOf<PaymentGroup> + MemberOf<<PaymentGroup as Group>::TopG>,
+    {
+        let mut sender = LazySenderStub::new(self.customer);
+        sender.send(amount);
+        sender.into()
+    }
+}

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -41,6 +41,18 @@ use crate::{
 
 const OPEN_FAILED_EVENT: &str = "ls-remote-lease-open-failed";
 
+/// Open-failure reason recorded when the IBC layer reports the OpenLease
+/// packet was never acknowledged.
+const TIMEOUT_REASON: &str = "timeout";
+
+/// Open-failure reason recorded when the counterparty acks the OpenLease
+/// packet with a success response for a different operation. The offending
+/// variant is intentionally not echoed into the reason — it is
+/// counterparty-controlled and the controller already logs the raw
+/// response; keeping a fixed string avoids interpolating unbounded
+/// attacker-influenced data into stored state and events.
+const UNEXPECTED_OPERATION_REASON: &str = "unexpected operation response";
+
 #[derive(Serialize, Deserialize)]
 pub(crate) struct OpenLease {
     new_lease: NewLeaseContract,
@@ -203,7 +215,7 @@ impl Contract for OpenLease {
                 RemoteLeaseCallback::OperationOk(OperationResponse::OpenLease(
                     OpenLeaseResponse { remote_lease_id },
                 )) => self.on_open_lease_ack(remote_lease_id, &env),
-                RemoteLeaseCallback::OperationOk(other) => {
+                RemoteLeaseCallback::OperationOk(_unexpected) => {
                     // A success ack for a non-`OpenLease` operation can only
                     // come from a buggy or hostile counterparty. Returning
                     // `Err` here would revert the controller's
@@ -212,20 +224,20 @@ impl Contract for OpenLease {
                     // instead: refund the customer and move to the terminal
                     // `OpenFailed` so the ack commits and operators see a
                     // `wasm-ls-remote-lease-open-failed` event to audit.
-                    let reason = RemoteErrorMessage::new(format!(
-                        "unexpected operation response: {other:?}"
-                    ))
-                    .unwrap_or_else(|_| {
-                        RemoteErrorMessage::from_static("unexpected operation response")
-                    });
-                    self.on_open_failed(querier, &env, reason)
+                    self.on_open_failed(
+                        querier,
+                        &env,
+                        RemoteErrorMessage::from_static(UNEXPECTED_OPERATION_REASON),
+                    )
                 }
                 RemoteLeaseCallback::OperationErr(reason) => {
                     self.on_open_failed(querier, &env, reason)
                 }
-                RemoteLeaseCallback::OperationTimeout => {
-                    self.on_open_failed(querier, &env, RemoteErrorMessage::from_static("timeout"))
-                }
+                RemoteLeaseCallback::OperationTimeout => self.on_open_failed(
+                    querier,
+                    &env,
+                    RemoteErrorMessage::from_static(TIMEOUT_REASON),
+                ),
             })
     }
 }

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -89,11 +89,8 @@ impl OpenLease {
         querier: QuerierWrapper<'_>,
         info: &MessageInfo,
     ) -> ContractResult<()> {
-        access_control::check(
-            &self.deps.3.remote_lease_callback_permission(querier),
-            info,
-        )
-        .map_err(Into::into)
+        access_control::check(&self.deps.3.remote_lease_callback_permission(querier), info)
+            .map_err(Into::into)
     }
 
     fn on_open_lease_ack(
@@ -136,7 +133,11 @@ impl OpenLease {
         Coin::<LpnCurrency>::try_from(loan.principal)
             .map_err(ContractError::from)
             .and_then(|principal| {
-                lpp_ref.execute_loan(RepayOpenLoan { principal, now }, lease_addr.clone(), querier)
+                lpp_ref.execute_loan(
+                    RepayOpenLoan { principal, now },
+                    lease_addr.clone(),
+                    querier,
+                )
             })
             .and_then(|lpp_batch| {
                 let customer_batch = downpayment.with_coin(SendToCustomer {
@@ -153,8 +154,7 @@ impl OpenLease {
                 StateMachineResponse::from(
                     MessageResponse::messages_with_event(batch, emitter),
                     State::from(crate::contract::state::open_failed::OpenFailed::new(
-                        reason,
-                        leases_ref,
+                        reason, leases_ref,
                     )),
                 )
             })

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -107,7 +107,7 @@ impl OpenLease {
             self.loan,
             self.deps,
             self.start_opening_at,
-            Some(remote_lease_id),
+            remote_lease_id,
         );
         let batch = next.enter();
         Ok(StateMachineResponse::from(

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -152,7 +152,10 @@ impl OpenLease {
                     .emit("reason", reason.as_str().to_owned());
                 StateMachineResponse::from(
                     MessageResponse::messages_with_event(batch, emitter),
-                    State::from(crate::contract::state::open_failed::OpenFailed::new(reason)),
+                    State::from(crate::contract::state::open_failed::OpenFailed::new(
+                        reason,
+                        leases_ref,
+                    )),
                 )
             })
     }
@@ -170,7 +173,7 @@ impl Contract for OpenLease {
             downpayment: self.downpayment,
             loan: self.loan.principal,
             loan_interest_rate: self.loan.annual_interest_rate,
-            in_progress: OngoingTrx::OpenIcaAccount {},
+            in_progress: OngoingTrx::RequestingOpenLease {},
         })
     }
 

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -204,19 +204,28 @@ impl Contract for OpenLease {
                     OpenLeaseResponse { remote_lease_id },
                 )) => self.on_open_lease_ack(remote_lease_id, &env),
                 RemoteLeaseCallback::OperationOk(other) => {
-                    Err(ContractError::unsupported_operation(format!(
-                        "open lease unexpected operation response: {other:?}"
-                    )))
+                    // A success ack for a non-`OpenLease` operation can only
+                    // come from a buggy or hostile counterparty. Returning
+                    // `Err` here would revert the controller's
+                    // `ibc_packet_ack`, stranding the relayer and freezing the
+                    // lease in `OpenLease`. Treat it as an open failure
+                    // instead: refund the customer and move to the terminal
+                    // `OpenFailed` so the ack commits and operators see a
+                    // `wasm-ls-remote-lease-open-failed` event to audit.
+                    let reason = RemoteErrorMessage::new(format!(
+                        "unexpected operation response: {other:?}"
+                    ))
+                    .unwrap_or_else(|_| {
+                        RemoteErrorMessage::from_static("unexpected operation response")
+                    });
+                    self.on_open_failed(querier, &env, reason)
                 }
                 RemoteLeaseCallback::OperationErr(reason) => {
                     self.on_open_failed(querier, &env, reason)
                 }
-                RemoteLeaseCallback::OperationTimeout => self.on_open_failed(
-                    querier,
-                    &env,
-                    RemoteErrorMessage::new("timeout")
-                        .expect("'timeout' is within RemoteErrorMessage cap"),
-                ),
+                RemoteLeaseCallback::OperationTimeout => {
+                    self.on_open_failed(querier, &env, RemoteErrorMessage::from_static("timeout"))
+                }
             })
     }
 }

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -16,7 +16,7 @@ use platform::{
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback},
     msg::OpenLeaseParams,
-    response::OperationResponse,
+    response::{OpenLeaseResponse, OperationResponse, RemoteLeaseId},
     stub::{ControllerInnerMessage, Factory},
 };
 use sdk::cosmwasm_std::{Addr, Env, MessageInfo, QuerierWrapper};
@@ -96,6 +96,26 @@ impl OpenLease {
         .map_err(Into::into)
     }
 
+    fn on_open_lease_ack(
+        self,
+        remote_lease_id: RemoteLeaseId,
+        _env: &Env,
+    ) -> ContractResult<Response> {
+        let next = super::buy_asset::start(
+            self.new_lease,
+            self.downpayment,
+            self.loan,
+            self.deps,
+            self.start_opening_at,
+            Some(remote_lease_id),
+        );
+        let batch = next.enter();
+        Ok(StateMachineResponse::from(
+            MessageResponse::messages_only(batch),
+            State::from(super::buy_asset::DexState::from(next)),
+        ))
+    }
+
     fn on_open_failed(
         self,
         querier: QuerierWrapper<'_>,
@@ -163,9 +183,9 @@ impl Contract for OpenLease {
     ) -> ContractResult<Response> {
         self.authz_callback(querier, &info)
             .and_then(|()| match callback {
-                RemoteLeaseCallback::OperationOk(OperationResponse::OpenLease(_response)) => Err(
-                    ContractError::unsupported_operation("open lease ok (deferred)"),
-                ),
+                RemoteLeaseCallback::OperationOk(OperationResponse::OpenLease(
+                    OpenLeaseResponse { remote_lease_id },
+                )) => self.on_open_lease_ack(remote_lease_id, &env),
                 RemoteLeaseCallback::OperationOk(other) => {
                     Err(ContractError::unsupported_operation(format!(
                         "open lease unexpected operation response: {other:?}"

--- a/protocol/contracts/lease/src/contract/state/opening/request_loan.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/request_loan.rs
@@ -16,14 +16,14 @@ use crate::{
     contract::{
         cmd::{OpenLoanReq, OpenLoanReqResult, OpenLoanResp},
         finalize::LeasesRef,
-        state::{Handler, Response},
+        state::{Handler, Response, State},
     },
     error::{ContractError, ContractResult},
     event::Type,
     finance::{LppRef, OracleRef},
 };
 
-use super::buy_asset::DexState;
+use super::open_lease::OpenLease;
 use cw_time::IntoInstant;
 
 #[derive(Serialize, Deserialize)]
@@ -83,17 +83,19 @@ impl RequestLoan {
 
         let emitter = self.emit_ok(env.contract.address);
 
-        let open_ica = super::buy_asset::start(
+        let open_lease = OpenLease::new(
             self.new_lease,
             self.downpayment,
             loan,
             self.deps,
             env.block.time.into_instant(),
         );
-        Ok(StateMachineResponse::from(
-            MessageResponse::messages_with_event(open_ica.enter(), emitter),
-            Into::<DexState>::into(open_ica),
-        ))
+        open_lease.enter().map(|batch| {
+            StateMachineResponse::from(
+                MessageResponse::messages_with_event(batch, emitter),
+                State::from(open_lease),
+            )
+        })
     }
 
     fn emit_ok(&self, contract: Addr) -> Emitter {

--- a/protocol/contracts/lease/src/error.rs
+++ b/protocol/contracts/lease/src/error.rs
@@ -12,6 +12,7 @@ use oracle::{api::alarms::Error as OracleAlarmError, stub::Error as OracleError}
 use oracle_platform::error::Error as OraclePlatformError;
 use platform::error::Error as PlatformError;
 use profit::stub::Error as ProfitError;
+use remote_lease::error::Error as RemoteLeaseError;
 use reserve::stub::Error as ReserveError;
 use sdk::cosmwasm_std::StdError;
 use timealarms::stub::Error as TimeAlarmsError;
@@ -85,6 +86,9 @@ pub enum ContractError {
 
     #[error("[Lease] No payment sent")]
     NoPaymentError(),
+
+    #[error("[Lease] {0}")]
+    OpenLeaseParams(RemoteLeaseError),
 
     #[error("[Lease] The operation '{0}' is not supported in the current state")]
     UnsupportedOperation(String),

--- a/protocol/contracts/lease/src/lease/dto.rs
+++ b/protocol/contracts/lease/src/lease/dto.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use currency::{CurrencyDef, MemberOf};
 use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
+use remote_lease::response::RemoteLeaseId;
 use sdk::cosmwasm_std::{Addr, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
@@ -30,9 +31,16 @@ pub struct LeaseDTO {
     pub(crate) time_alarms: TimeAlarmsRef,
     pub(crate) oracle: OracleRef,
     pub(crate) reserve: ReserveRef,
+    /// Solana-side Lease PDA, set once the remote-lease controller's
+    /// OpenLease packet acks. `None` for leases opened before the
+    /// remote-lease lifecycle landed; backward-compatible via
+    /// `#[serde(default)]`.
+    #[serde(default)]
+    pub(crate) remote_lease_id: Option<RemoteLeaseId>,
 }
 
 impl LeaseDTO {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         addr: Addr,
         customer: Addr,
@@ -41,6 +49,7 @@ impl LeaseDTO {
         time_alarms: TimeAlarmsRef,
         oracle: OracleRef,
         reserve: ReserveRef,
+        remote_lease_id: Option<RemoteLeaseId>,
     ) -> Self {
         Self {
             addr,
@@ -50,6 +59,7 @@ impl LeaseDTO {
             time_alarms,
             oracle,
             reserve,
+            remote_lease_id,
         }
     }
 

--- a/protocol/contracts/lease/src/lease/dto.rs
+++ b/protocol/contracts/lease/src/lease/dto.rs
@@ -31,12 +31,12 @@ pub struct LeaseDTO {
     pub(crate) time_alarms: TimeAlarmsRef,
     pub(crate) oracle: OracleRef,
     pub(crate) reserve: ReserveRef,
-    /// Solana-side Lease PDA, set once the remote-lease controller's
-    /// OpenLease packet acks. `None` for leases opened before the
-    /// remote-lease lifecycle landed; backward-compatible via
-    /// `#[serde(default)]`.
-    #[serde(default)]
-    pub(crate) remote_lease_id: Option<RemoteLeaseId>,
+    /// Solana-side Lease PDA, populated from the remote-lease
+    /// controller's OpenLease ack before the live lease is ever
+    /// constructed. Every `LeaseDTO` carries a value — see plan §10.A.1
+    /// (mainnet v9-lease population = 0, so there are no legacy leases
+    /// to deserialise without this field).
+    pub(crate) remote_lease_id: RemoteLeaseId,
 }
 
 impl LeaseDTO {
@@ -49,7 +49,7 @@ impl LeaseDTO {
         time_alarms: TimeAlarmsRef,
         oracle: OracleRef,
         reserve: ReserveRef,
-        remote_lease_id: Option<RemoteLeaseId>,
+        remote_lease_id: RemoteLeaseId,
     ) -> Self {
         Self {
             addr,

--- a/protocol/contracts/lease/src/lease/mod.rs
+++ b/protocol/contracts/lease/src/lease/mod.rs
@@ -43,7 +43,7 @@ pub struct Lease<Asset, Lpp, Oracle> {
     position: Position<Asset>,
     loan: Loan<Lpp>,
     oracle: Oracle,
-    remote_lease_id: Option<RemoteLeaseId>,
+    remote_lease_id: RemoteLeaseId,
 }
 
 pub type IntoDTOResult = LeaseDTOResult<Batch>;
@@ -66,7 +66,7 @@ where
         position: Position<Asset>,
         loan: Loan<LppLoan>,
         oracle: Oracle,
-        remote_lease_id: Option<RemoteLeaseId>,
+        remote_lease_id: RemoteLeaseId,
     ) -> Self {
         debug_assert!(!currency::equal::<LpnCurrency, Asset>());
         // TODO specify that Lpn is of Lpns and Asset is of LeaseGroup

--- a/protocol/contracts/lease/src/lease/mod.rs
+++ b/protocol/contracts/lease/src/lease/mod.rs
@@ -5,6 +5,7 @@ use lpp::stub::loan::LppLoan as LppLoanTrait;
 use oracle_platform::Oracle as OracleTrait;
 use platform::batch::Batch;
 use profit::stub::ProfitRef;
+use remote_lease::response::RemoteLeaseId;
 use sdk::cosmwasm_std::Addr;
 use timealarms::stub::TimeAlarmsRef;
 
@@ -42,6 +43,7 @@ pub struct Lease<Asset, Lpp, Oracle> {
     position: Position<Asset>,
     loan: Loan<Lpp>,
     oracle: Oracle,
+    remote_lease_id: Option<RemoteLeaseId>,
 }
 
 pub type IntoDTOResult = LeaseDTOResult<Batch>;
@@ -64,6 +66,7 @@ where
         position: Position<Asset>,
         loan: Loan<LppLoan>,
         oracle: Oracle,
+        remote_lease_id: Option<RemoteLeaseId>,
     ) -> Self {
         debug_assert!(!currency::equal::<LpnCurrency, Asset>());
         // TODO specify that Lpn is of Lpns and Asset is of LeaseGroup
@@ -74,6 +77,7 @@ where
             position,
             loan,
             oracle,
+            remote_lease_id,
         }
     }
 
@@ -89,6 +93,7 @@ where
             position,
             Loan::from_dto(dto.loan, lpp_loan),
             oracle,
+            dto.remote_lease_id,
         )
     }
 
@@ -137,6 +142,7 @@ where
             time_alarms,
             self.oracle.into(),
             reserve,
+            self.remote_lease_id,
         )
     }
 
@@ -146,6 +152,7 @@ where
         time_alarms: TimeAlarmsRef,
         reserve: ReserveRef,
     ) -> ContractResult<IntoDTOResult> {
+        let remote_lease_id = self.remote_lease_id.clone();
         self.loan
             .try_into_dto(profit)
             .map(|(loan_dto, loan_batch)| IntoDTOResult {
@@ -157,6 +164,7 @@ where
                     time_alarms,
                     self.oracle.into(),
                     reserve,
+                    remote_lease_id,
                 ),
                 result: loan_batch,
             })

--- a/protocol/contracts/lease/src/lease/mod.rs
+++ b/protocol/contracts/lease/src/lease/mod.rs
@@ -204,6 +204,7 @@ pub(crate) mod tests {
     };
     use oracle_platform::{Oracle, error::Result as PriceOracleResult};
     use platform::batch::Batch;
+    use remote_lease::response::RemoteLeaseId;
     use sdk::cosmwasm_std::Addr;
 
     use crate::{
@@ -221,6 +222,7 @@ pub(crate) mod tests {
     const CUSTOMER: &str = "customer";
     const LEASE_ADDR: &str = "lease_addr";
     const ORACLE_ADDR: &str = "oracle_addr";
+    const REMOTE_LEASE_ID: &str = "StubPda11111111111111111111111111111";
     const MARGIN_INTEREST_RATE: Percent100 = Percent100::from_permille(23);
     pub(super) const LEASE_START: Instant = Instant::from_nanos(100);
     pub(super) const DUE_PERIOD: Duration = Duration::from_days(100);
@@ -351,6 +353,7 @@ pub(crate) mod tests {
             Position::new(amount, position_spec),
             loan,
             oracle,
+            RemoteLeaseId::new(REMOTE_LEASE_ID.to_owned()).expect("base58 sample"),
         )
     }
 

--- a/protocol/contracts/leaser/src/cmd/borrow.rs
+++ b/protocol/contracts/leaser/src/cmd/borrow.rs
@@ -66,6 +66,7 @@ impl Borrow {
             },
             dex: config.dex,
             finalizer,
+            remote_lease_controller: config.remote_lease_controller,
             expected_instance_ordinal: config.expected_instance_ordinal,
         }
     }

--- a/protocol/contracts/leaser/src/cmd/borrow.rs
+++ b/protocol/contracts/leaser/src/cmd/borrow.rs
@@ -66,6 +66,7 @@ impl Borrow {
             },
             dex: config.dex,
             finalizer,
+            expected_instance_ordinal: config.expected_instance_ordinal,
         }
     }
 }

--- a/protocol/contracts/leaser/src/contract.rs
+++ b/protocol/contracts/leaser/src/contract.rs
@@ -243,8 +243,8 @@ pub fn reply(deps: DepsMut<'_>, _env: Env, msg: Reply) -> ContractResult<Respons
             err: err.to_string(),
         })
         .and_then(|lease| {
-            Leases::save(deps.storage, lease.clone()).map(|stored| {
-                debug_assert!(stored);
+            Leases::save(deps.storage, lease.clone()).map(|outcome| {
+                debug_assert!(matches!(outcome, Some(true) | None));
                 lease
             })
         })

--- a/protocol/contracts/leaser/src/contract.rs
+++ b/protocol/contracts/leaser/src/contract.rs
@@ -32,7 +32,10 @@ use crate::{
         LeasesConfigurationPermission, RemoteLeaseCallbackPermission,
     },
     result::ContractResult,
-    state::{config::Config, leases::Leases},
+    state::{
+        config::Config,
+        leases::{Leases, SaveOutcome},
+    },
 };
 
 const CONTRACT_STORAGE_VERSION: VersionSegment = 7;
@@ -243,9 +246,9 @@ pub fn reply(deps: DepsMut<'_>, _env: Env, msg: Reply) -> ContractResult<Respons
             err: err.to_string(),
         })
         .and_then(|lease| {
-            Leases::save(deps.storage, lease.clone()).map(|outcome| {
-                debug_assert!(matches!(outcome, Some(true) | None));
-                lease
+            Leases::save(deps.storage, lease.clone()).and_then(|outcome| match outcome {
+                SaveOutcome::Registered | SaveOutcome::Cancelled => Ok(lease),
+                SaveOutcome::AlreadyRegistered => Err(ContractError::DuplicateLeaseAddress),
             })
         })
         .map(|lease| Response::new().add_attribute("lease_address", lease))

--- a/protocol/contracts/leaser/src/error.rs
+++ b/protocol/contracts/leaser/src/error.rs
@@ -45,6 +45,13 @@ pub enum ContractError {
     PendingCustomerNotCached,
 
     #[error(
+        "[Leaser] An open request is already in flight — refusing to overwrite the \
+         pending entry; the single-in-flight invariant was violated, likely a \
+         programmer error in the open path"
+    )]
+    PendingOpenAlreadyInFlight,
+
+    #[error(
         "[Leaser] The lease address returned by the instantiate reply was already \
          registered against the customer — duplicate instantiation"
     )]

--- a/protocol/contracts/leaser/src/error.rs
+++ b/protocol/contracts/leaser/src/error.rs
@@ -38,6 +38,18 @@ pub enum ContractError {
     #[error("[Leaser] Save pending Customer failed, cause: {0}")]
     SavePendingCustomerFailure(StdError),
 
+    #[error(
+        "[Leaser] Lease save invoked without a prior `cache_open_req` and no \
+         pending-cancellation sentinel — likely a programmer error in the open path"
+    )]
+    PendingCustomerNotCached,
+
+    #[error(
+        "[Leaser] The lease address returned by the instantiate reply was already \
+         registered against the customer — duplicate instantiation"
+    )]
+    DuplicateLeaseAddress,
+
     #[error("[Leaser] Address validation failed, cause: {0}")]
     InvalidAddress(StdError),
 

--- a/protocol/contracts/leaser/src/msg/mod.rs
+++ b/protocol/contracts/leaser/src/msg/mod.rs
@@ -37,6 +37,7 @@ pub struct InstantiateMsg {
     pub lease_admin: Addr,
     pub dex: ConnectionParams,
     pub remote_lease_controller: Addr,
+    pub expected_instance_ordinal: u16,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/protocol/contracts/leaser/src/state/config.rs
+++ b/protocol/contracts/leaser/src/state/config.rs
@@ -34,6 +34,7 @@ pub struct Config {
     pub lease_admin: Addr,
     pub dex: ConnectionParams,
     pub remote_lease_controller: Addr,
+    pub expected_instance_ordinal: u16,
 }
 
 impl Config {
@@ -55,6 +56,7 @@ impl Config {
             lease_admin: msg.lease_admin,
             dex: msg.dex,
             remote_lease_controller: msg.remote_lease_controller,
+            expected_instance_ordinal: msg.expected_instance_ordinal,
         }
     }
 

--- a/protocol/contracts/leaser/src/state/leases.rs
+++ b/protocol/contracts/leaser/src/state/leases.rs
@@ -70,15 +70,26 @@ impl Leases {
     /// Guards the single-in-flight invariant the instantiate-reply correlator
     /// depends on: the open path consumes the entry within the same
     /// transaction (the `reply_on_success` reply runs `take_pending` before
-    /// the tx commits), so a non-empty slot here means the invariant was
-    /// violated — refuse rather than silently overwrite the prior open.
+    /// the tx commits). A still-`Cached` slot is therefore a live open —
+    /// refuse rather than silently overwrite it. A leftover `Cancelled` slot
+    /// is an already-consumed open and may be reclaimed by the new one.
     pub fn cache_open_req(storage: &mut dyn Storage, customer: &Addr) -> ContractResult<()> {
         Self::PENDING_OPENS
             .may_load(storage)
             .map_err(ContractError::SavePendingCustomerFailure)
             .and_then(|in_flight| match in_flight {
-                Some(_) => Err(ContractError::PendingOpenAlreadyInFlight),
-                None => Self::PENDING_OPENS
+                Some(PendingOpen {
+                    phase: PendingPhase::Cached,
+                    ..
+                }) => Err(ContractError::PendingOpenAlreadyInFlight),
+                // A leftover `Cancelled` slot is a consumed open whose
+                // instantiate reply never registered it; a fresh open may
+                // reclaim the singleton. `None` is the steady state.
+                Some(PendingOpen {
+                    phase: PendingPhase::Cancelled,
+                    ..
+                })
+                | None => Self::PENDING_OPENS
                     .save(
                         storage,
                         &PendingOpen {
@@ -189,8 +200,13 @@ impl Leases {
         }
     }
 
-    /// Persist the customer's lease set after a removal, deleting the entry
-    /// entirely once the customer holds no more leases.
+    /// Persist the customer's remaining leases, removing the map entry
+    /// entirely when the set is empty.
+    ///
+    /// An empty set must not be stored: [`Self::iter`] and [`Self::empty`]
+    /// treat every present key as a customer that still holds leases, so a
+    /// lingering empty entry would surface a phantom lease-less customer and
+    /// make `empty` report non-empty.
     fn store_customer_leases(
         storage: &mut dyn Storage,
         customer: Addr,
@@ -227,7 +243,19 @@ impl Leases {
                     )
                     .map(|()| true)
                     .map_err(ContractError::RemoveLeaseFailure),
-                Some(_) | None => Ok(false),
+                // A `Cached` open for a different customer, or an already
+                // `Cancelled` slot: neither is this customer's live open to
+                // cancel. Enumerated so a new `PendingPhase` fails to compile
+                // rather than being swept into this no-op.
+                Some(PendingOpen {
+                    phase: PendingPhase::Cached,
+                    ..
+                })
+                | Some(PendingOpen {
+                    phase: PendingPhase::Cancelled,
+                    ..
+                })
+                | None => Ok(false),
             })
     }
 
@@ -385,6 +413,31 @@ mod test {
             Leases::save(&mut storage, test_lease()).unwrap()
         );
         assert_lease_exist(&storage);
+    }
+
+    #[test]
+    fn test_cache_open_req_reclaims_a_cancelled_slot() {
+        let mut storage = MockStorage::default();
+        Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
+        // The open is cancelled mid-cascade; its instantiate reply has not
+        // yet consumed the `Cancelled` slot, so it lingers in storage.
+        assert!(Leases::remove(&mut storage, test_customer(), &test_lease()).unwrap());
+
+        // A fresh open must reclaim the leftover `Cancelled` slot rather than
+        // be rejected as if a live open were still in flight.
+        Leases::cache_open_req(&mut storage, &test_another_customer())
+            .expect("a cancelled slot must not block a new open");
+
+        // The reclaimed open registers normally under the new customer.
+        assert_eq!(
+            SaveOutcome::Registered,
+            Leases::save(&mut storage, test_lease()).unwrap()
+        );
+        assert!(lease_exist(
+            &storage,
+            test_another_customer(),
+            &test_lease()
+        ));
     }
 
     #[test]

--- a/protocol/contracts/leaser/src/state/leases.rs
+++ b/protocol/contracts/leaser/src/state/leases.rs
@@ -383,6 +383,23 @@ mod test {
     }
 
     #[test]
+    fn test_remove_already_cancelled_pending_is_noop() {
+        let mut storage = MockStorage::default();
+        Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
+        // First removal cancels the in-flight open (`Cached` -> `Cancelled`).
+        assert!(Leases::remove(&mut storage, test_customer(), &test_lease()).unwrap());
+        // A second removal finds the slot already `Cancelled` for this
+        // customer: there is no live open left to cancel, so it reports
+        // nothing was present rather than re-flipping or erroring.
+        assert!(!Leases::remove(&mut storage, test_customer(), &test_lease()).unwrap());
+        // The slot is still `Cancelled`; the eventual instantiate reply no-ops.
+        assert_eq!(
+            SaveOutcome::Cancelled,
+            Leases::save(&mut storage, test_lease()).unwrap()
+        );
+    }
+
+    #[test]
     fn test_remove_other_customer_keeps_pending() {
         let mut storage = MockStorage::default();
         Leases::cache_open_req(&mut storage, &test_customer()).unwrap();

--- a/protocol/contracts/leaser/src/state/leases.rs
+++ b/protocol/contracts/leaser/src/state/leases.rs
@@ -65,16 +65,29 @@ impl Leases {
 
     const CUSTOMER_LEASES: Map<Addr, HashSet<Addr>> = Map::new("loans");
 
+    /// Record the customer whose lease open is starting.
+    ///
+    /// Guards the single-in-flight invariant the instantiate-reply correlator
+    /// depends on: the open path consumes the entry within the same
+    /// transaction (the `reply_on_success` reply runs `take_pending` before
+    /// the tx commits), so a non-empty slot here means the invariant was
+    /// violated — refuse rather than silently overwrite the prior open.
     pub fn cache_open_req(storage: &mut dyn Storage, customer: &Addr) -> ContractResult<()> {
         Self::PENDING_OPENS
-            .save(
-                storage,
-                &PendingOpen {
-                    customer: customer.clone(),
-                    phase: PendingPhase::Cached,
-                },
-            )
+            .may_load(storage)
             .map_err(ContractError::SavePendingCustomerFailure)
+            .and_then(|in_flight| match in_flight {
+                Some(_) => Err(ContractError::PendingOpenAlreadyInFlight),
+                None => Self::PENDING_OPENS
+                    .save(
+                        storage,
+                        &PendingOpen {
+                            customer: customer.clone(),
+                            phase: PendingPhase::Cached,
+                        },
+                    )
+                    .map_err(ContractError::SavePendingCustomerFailure),
+            })
     }
 
     /// See [`SaveOutcome`]. `Err` only surfaces real failures: a missing
@@ -349,6 +362,24 @@ mod test {
         // open — the singleton correlates the cancellation to its customer.
         assert!(!Leases::remove(&mut storage, test_another_customer(), &test_lease()).unwrap());
         // The original customer's open is still `Cached` and registers.
+        assert_eq!(
+            SaveOutcome::Registered,
+            Leases::save(&mut storage, test_lease()).unwrap()
+        );
+        assert_lease_exist(&storage);
+    }
+
+    #[test]
+    fn test_cache_open_req_rejects_a_second_in_flight_open() {
+        let mut storage = MockStorage::default();
+        Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
+        // A second cache before the first open is consumed must fail loudly
+        // rather than silently overwriting the in-flight entry.
+        assert!(matches!(
+            Leases::cache_open_req(&mut storage, &test_another_customer()),
+            Err(ContractError::PendingOpenAlreadyInFlight)
+        ));
+        // The original open is intact and still registers.
         assert_eq!(
             SaveOutcome::Registered,
             Leases::save(&mut storage, test_lease()).unwrap()

--- a/protocol/contracts/leaser/src/state/leases.rs
+++ b/protocol/contracts/leaser/src/state/leases.rs
@@ -151,24 +151,45 @@ impl Leases {
     /// case the lease is still recorded only as the in-flight open —
     /// flipping the customer's entry from `Cached` to `Cancelled` cancels
     /// it, and the subsequent `Leases::save` reads the `Cancelled` arm.
+    ///
+    /// The cancellation must therefore be reached whenever `lease` is not
+    /// one of the customer's *registered* leases — independently of whether
+    /// the customer holds other registered leases. A customer with an
+    /// existing lease that opens a second one which fails before its reply
+    /// lands still has its pending open recorded only in `PENDING_OPENS`.
     pub fn remove(storage: &mut dyn Storage, customer: Addr, lease: &Addr) -> ContractResult<bool> {
         // not using cw_storage_plus::Map::load because it does not differentiate key-not-present
         // from value-cannot-be-deserialized case
-        if let Some(value) = storage.get(&Self::CUSTOMER_LEASES.key(customer.clone())) {
-            cosmwasm_std::from_json(value)
-                .and_then(|mut leases: HashSet<Addr>| {
-                    let removed = leases.remove(lease);
-                    if leases.is_empty() {
-                        Self::CUSTOMER_LEASES.remove(storage, customer);
-                        Ok(())
-                    } else {
-                        Self::CUSTOMER_LEASES.save(storage, customer, &leases)
-                    }
-                    .map(|()| removed)
-                })
+        match storage.get(&Self::CUSTOMER_LEASES.key(customer.clone())) {
+            Some(value) => cosmwasm_std::from_json(value)
                 .map_err(ContractError::RemoveLeaseFailure)
+                .and_then(|mut leases: HashSet<Addr>| {
+                    if leases.remove(lease) {
+                        Self::store_customer_leases(storage, customer, leases).map(|()| true)
+                    } else {
+                        // `lease` is not registered for this customer — it may
+                        // be their in-flight open awaiting the reply.
+                        Self::cancel_pending_if_matches(storage, customer)
+                    }
+                }),
+            None => Self::cancel_pending_if_matches(storage, customer),
+        }
+    }
+
+    /// Persist the customer's lease set after a removal, deleting the entry
+    /// entirely once the customer holds no more leases.
+    fn store_customer_leases(
+        storage: &mut dyn Storage,
+        customer: Addr,
+        leases: HashSet<Addr>,
+    ) -> ContractResult<()> {
+        if leases.is_empty() {
+            Self::CUSTOMER_LEASES.remove(storage, customer);
+            Ok(())
         } else {
-            Self::cancel_pending_if_matches(storage, customer)
+            Self::CUSTOMER_LEASES
+                .save(storage, customer, &leases)
+                .map_err(ContractError::RemoveLeaseFailure)
         }
     }
 
@@ -332,6 +353,39 @@ mod test {
             SaveOutcome::Registered,
             Leases::save(&mut storage, test_lease()).unwrap()
         );
+        assert_lease_exist(&storage);
+    }
+
+    #[test]
+    fn test_remove_pending_open_while_customer_has_a_registered_lease() {
+        let mut storage = MockStorage::default();
+        // The customer already has one registered lease from a prior open.
+        Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
+        Leases::save(&mut storage, test_lease()).unwrap();
+        assert_lease_exist(&storage);
+
+        // A second open is cached; before its instantiate reply lands, the
+        // remote-lease auto-refund finalises it -> remove(customer, lease2).
+        // The pending open must be cancelled even though the customer still
+        // has another registered lease.
+        Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
+        assert!(
+            Leases::remove(&mut storage, test_customer(), &test_another_lease()).unwrap(),
+            "removing the pending open must report it was present and cancel it",
+        );
+
+        // The late instantiate reply must read `Cancelled` and no-op rather
+        // than registering the already-finalised ghost lease.
+        assert_eq!(
+            SaveOutcome::Cancelled,
+            Leases::save(&mut storage, test_another_lease()).unwrap(),
+        );
+        assert!(!lease_exist(
+            &storage,
+            test_customer(),
+            &test_another_lease()
+        ));
+        // The pre-existing lease is untouched.
         assert_lease_exist(&storage);
     }
 

--- a/protocol/contracts/leaser/src/state/leases.rs
+++ b/protocol/contracts/leaser/src/state/leases.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use sdk::{
     cosmwasm_std::{Addr, Order, StdResult, Storage},
-    cw_storage_plus::{Bound, Map},
+    cw_storage_plus::{Bound, Item, Map},
 };
 
 use crate::{
@@ -29,32 +29,51 @@ pub(crate) enum SaveOutcome {
     Cancelled,
 }
 
-/// Per-customer state machine for in-flight opens. Keyed by customer in
-/// [`Leases::PENDING_OPENS`]; the open never goes through `CUSTOMER_LEASES`
-/// while in either state. The two-arm enum replaces the previous
-/// `PENDING_CUSTOMER: Item<Addr>` + `CANCELLED_PENDING: Item<()>` split,
-/// keeping all coordination state inside per-customer storage rather than
-/// module-level singletons.
+/// The single lease open the leaser is coordinating between the customer's
+/// `OpenLease` execute and the lease-instantiate reply.
+///
+/// Held as a singleton because the instantiate reply correlates the new
+/// lease back to its open only by "the one open in flight" — it carries the
+/// lease address but never the customer. A `Map` keyed by customer cannot
+/// satisfy that correlation (the reply has no key to look up), so the
+/// single-in-flight invariant must live in the storage shape itself.
+///
+/// Replaces the earlier `PENDING_CUSTOMER: Item<Addr>` + `CANCELLED_PENDING:
+/// Item<()>` pair: a single typed `Item` carrying the customer and the
+/// lifecycle phase, rather than a data item plus a bare armed/disarmed gate.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+struct PendingOpen {
+    customer: Addr,
+    phase: PendingPhase,
+}
+
+/// Lifecycle phase of the in-flight open held in [`Leases::PENDING_OPENS`].
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-enum PendingState {
-    /// `cache_open_req` set this entry; the leaser is expecting the
-    /// instantiate reply to register the lease.
+enum PendingPhase {
+    /// `cache_open_req` set this; the leaser expects the instantiate reply
+    /// to register the lease.
     Cached,
     /// `Leases::remove` cancelled the open mid-cascade (the OpenLease
     /// auto-refund finalised the lease before the leaser's reply landed).
-    /// The subsequent `Leases::save` consumes this state and no-ops.
+    /// The subsequent `Leases::save` consumes this phase and no-ops.
     Cancelled,
 }
 
 impl Leases {
-    const PENDING_OPENS: Map<Addr, PendingState> = Map::new("pending_opens");
+    const PENDING_OPENS: Item<PendingOpen> = Item::new("pending_opens");
 
     const CUSTOMER_LEASES: Map<Addr, HashSet<Addr>> = Map::new("loans");
 
     pub fn cache_open_req(storage: &mut dyn Storage, customer: &Addr) -> ContractResult<()> {
         Self::PENDING_OPENS
-            .save(storage, customer.clone(), &PendingState::Cached)
+            .save(
+                storage,
+                &PendingOpen {
+                    customer: customer.clone(),
+                    phase: PendingPhase::Cached,
+                },
+            )
             .map_err(ContractError::SavePendingCustomerFailure)
     }
 
@@ -62,28 +81,31 @@ impl Leases {
     /// `cache_open_req` upstream, or a storage error.
     pub fn save(storage: &mut dyn Storage, lease: Addr) -> ContractResult<SaveOutcome> {
         Self::take_pending(storage).and_then(|maybe_pending| match maybe_pending {
-            Some((customer, PendingState::Cached)) => Self::save_under(storage, customer, lease),
-            Some((_customer, PendingState::Cancelled)) => Ok(SaveOutcome::Cancelled),
+            Some(PendingOpen {
+                customer,
+                phase: PendingPhase::Cached,
+            }) => Self::save_under(storage, customer, lease),
+            Some(PendingOpen {
+                phase: PendingPhase::Cancelled,
+                ..
+            }) => Ok(SaveOutcome::Cancelled),
             None => Err(ContractError::PendingCustomerNotCached),
         })
     }
 
-    /// Read and remove the single in-flight open. Returns the customer +
-    /// state if present, `None` if nothing is pending. Singleton-flavoured
-    /// usage (only one open at a time) lives in the caller; the map shape
-    /// keeps all state per-customer.
-    fn take_pending(storage: &mut dyn Storage) -> ContractResult<Option<(Addr, PendingState)>> {
-        let first = Self::PENDING_OPENS
-            .range(storage, None, None, Order::Ascending)
-            .next();
-        match first {
-            None => Ok(None),
-            Some(Err(err)) => Err(ContractError::SaveLeaseFailure(err)),
-            Some(Ok((customer, state))) => {
-                Self::PENDING_OPENS.remove(storage, customer.clone());
-                Ok(Some((customer, state)))
-            }
-        }
+    /// Read and clear the single in-flight open. Returns it if present,
+    /// `None` if nothing is pending. The singleton shape enforces the
+    /// single-in-flight invariant the instantiate reply relies on — it
+    /// correlates by "the one open in flight", never by customer.
+    fn take_pending(storage: &mut dyn Storage) -> ContractResult<Option<PendingOpen>> {
+        Self::PENDING_OPENS
+            .may_load(storage)
+            .inspect(|maybe_pending| {
+                if maybe_pending.is_some() {
+                    Self::PENDING_OPENS.remove(storage);
+                }
+            })
+            .map_err(ContractError::SaveLeaseFailure)
     }
 
     fn save_under(
@@ -155,14 +177,23 @@ impl Leases {
         customer: Addr,
     ) -> ContractResult<bool> {
         Self::PENDING_OPENS
-            .may_load(storage, customer.clone())
+            .may_load(storage)
             .map_err(ContractError::RemoveLeaseFailure)
-            .and_then(|maybe_state| match maybe_state {
-                Some(PendingState::Cached) => Self::PENDING_OPENS
-                    .save(storage, customer, &PendingState::Cancelled)
+            .and_then(|maybe_pending| match maybe_pending {
+                Some(PendingOpen {
+                    customer: pending_customer,
+                    phase: PendingPhase::Cached,
+                }) if pending_customer == customer => Self::PENDING_OPENS
+                    .save(
+                        storage,
+                        &PendingOpen {
+                            customer,
+                            phase: PendingPhase::Cancelled,
+                        },
+                    )
                     .map(|()| true)
                     .map_err(ContractError::RemoveLeaseFailure),
-                Some(PendingState::Cancelled) | None => Ok(false),
+                Some(_) | None => Ok(false),
             })
     }
 
@@ -287,6 +318,21 @@ mod test {
             Leases::save(&mut storage, test_lease()),
             Err(ContractError::PendingCustomerNotCached)
         ));
+    }
+
+    #[test]
+    fn test_remove_other_customer_keeps_pending() {
+        let mut storage = MockStorage::default();
+        Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
+        // A removal for a different customer must not touch the in-flight
+        // open — the singleton correlates the cancellation to its customer.
+        assert!(!Leases::remove(&mut storage, test_another_customer(), &test_lease()).unwrap());
+        // The original customer's open is still `Cached` and registers.
+        assert_eq!(
+            SaveOutcome::Registered,
+            Leases::save(&mut storage, test_lease()).unwrap()
+        );
+        assert_lease_exist(&storage);
     }
 
     #[test]

--- a/protocol/contracts/leaser/src/state/leases.rs
+++ b/protocol/contracts/leaser/src/state/leases.rs
@@ -1,8 +1,10 @@
 use std::collections::HashSet;
 
+use serde::{Deserialize, Serialize};
+
 use sdk::{
     cosmwasm_std::{Addr, Order, StdResult, Storage},
-    cw_storage_plus::{Bound, Item, Map},
+    cw_storage_plus::{Bound, Map},
 };
 
 use crate::{
@@ -23,37 +25,65 @@ pub(crate) enum SaveOutcome {
     AlreadyRegistered,
     /// The open request was cancelled before the leaser's instantiate
     /// reply landed (the OpenLease auto-refund batch fires inside the
-    /// same cascade). `save` consumes the cancel sentinel and no-ops.
+    /// same cascade). `save` consumes the cancel marker and no-ops.
+    Cancelled,
+}
+
+/// Per-customer state machine for in-flight opens. Keyed by customer in
+/// [`Leases::PENDING_OPENS`]; the open never goes through `CUSTOMER_LEASES`
+/// while in either state. The two-arm enum replaces the previous
+/// `PENDING_CUSTOMER: Item<Addr>` + `CANCELLED_PENDING: Item<()>` split,
+/// keeping all coordination state inside per-customer storage rather than
+/// module-level singletons.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum PendingState {
+    /// `cache_open_req` set this entry; the leaser is expecting the
+    /// instantiate reply to register the lease.
+    Cached,
+    /// `Leases::remove` cancelled the open mid-cascade (the OpenLease
+    /// auto-refund finalised the lease before the leaser's reply landed).
+    /// The subsequent `Leases::save` consumes this state and no-ops.
     Cancelled,
 }
 
 impl Leases {
-    const PENDING_CUSTOMER: Item<Addr> = Item::new("pending_customer");
-
-    /// Sentinel set when `Leases::remove` cancels an in-flight open via
-    /// `PENDING_CUSTOMER`. `Leases::save` consumes it to distinguish a
-    /// deliberate cancellation (no-op, return `Ok(SaveOutcome::Cancelled)`)
-    /// from a missing-`cache_open_req` programmer error (`Err`).
-    const CANCELLED_PENDING: Item<()> = Item::new("cancelled_pending");
+    const PENDING_OPENS: Map<Addr, PendingState> = Map::new("pending_opens");
 
     const CUSTOMER_LEASES: Map<Addr, HashSet<Addr>> = Map::new("loans");
 
     pub fn cache_open_req(storage: &mut dyn Storage, customer: &Addr) -> ContractResult<()> {
-        Self::PENDING_CUSTOMER
-            .save(storage, customer)
+        Self::PENDING_OPENS
+            .save(storage, customer.clone(), &PendingState::Cached)
             .map_err(ContractError::SavePendingCustomerFailure)
     }
 
     /// See [`SaveOutcome`]. `Err` only surfaces real failures: a missing
     /// `cache_open_req` upstream, or a storage error.
     pub fn save(storage: &mut dyn Storage, lease: Addr) -> ContractResult<SaveOutcome> {
-        Self::PENDING_CUSTOMER
-            .may_load(storage)
-            .map_err(ContractError::SaveLeaseFailure)
-            .and_then(|may_customer| match may_customer {
-                Some(customer) => Self::save_under(storage, customer, lease),
-                None => Self::consume_cancel_sentinel(storage),
-            })
+        Self::take_pending(storage).and_then(|maybe_pending| match maybe_pending {
+            Some((customer, PendingState::Cached)) => Self::save_under(storage, customer, lease),
+            Some((_customer, PendingState::Cancelled)) => Ok(SaveOutcome::Cancelled),
+            None => Err(ContractError::PendingCustomerNotCached),
+        })
+    }
+
+    /// Read and remove the single in-flight open. Returns the customer +
+    /// state if present, `None` if nothing is pending. Singleton-flavoured
+    /// usage (only one open at a time) lives in the caller; the map shape
+    /// keeps all state per-customer.
+    fn take_pending(storage: &mut dyn Storage) -> ContractResult<Option<(Addr, PendingState)>> {
+        let first = Self::PENDING_OPENS
+            .range(storage, None, None, Order::Ascending)
+            .next();
+        match first {
+            None => Ok(None),
+            Some(Err(err)) => Err(ContractError::SaveLeaseFailure(err)),
+            Some(Ok((customer, state))) => {
+                Self::PENDING_OPENS.remove(storage, customer.clone());
+                Ok(Some((customer, state)))
+            }
+        }
     }
 
     fn save_under(
@@ -61,7 +91,6 @@ impl Leases {
         customer: Addr,
         lease: Addr,
     ) -> ContractResult<SaveOutcome> {
-        Self::PENDING_CUSTOMER.remove(storage);
         let mut stored = false;
         let update_fn = |may_leases: Option<HashSet<Addr>>| -> StdResult<HashSet<Addr>> {
             let mut leases = may_leases.unwrap_or_default();
@@ -70,7 +99,7 @@ impl Leases {
         };
         Self::CUSTOMER_LEASES
             .update(storage, customer, update_fn)
-            .map(|_| {
+            .map(|_leases| {
                 if stored {
                     SaveOutcome::Registered
                 } else {
@@ -78,19 +107,6 @@ impl Leases {
                 }
             })
             .map_err(ContractError::SaveLeaseFailure)
-    }
-
-    fn consume_cancel_sentinel(storage: &mut dyn Storage) -> ContractResult<SaveOutcome> {
-        Self::CANCELLED_PENDING
-            .may_load(storage)
-            .map_err(ContractError::SaveLeaseFailure)
-            .and_then(|sentinel| match sentinel {
-                Some(()) => {
-                    Self::CANCELLED_PENDING.remove(storage);
-                    Ok(SaveOutcome::Cancelled)
-                }
-                None => Err(ContractError::PendingCustomerNotCached),
-            })
     }
 
     pub fn load_by_customer(
@@ -107,14 +123,12 @@ impl Leases {
     /// present before the removal.
     ///
     /// The remote-lease open lifecycle may finalise a lease before it has
-    /// been moved from `PENDING_CUSTOMER` into `CUSTOMER_LEASES` (the
+    /// been moved from [`Self::PENDING_OPENS`] into `CUSTOMER_LEASES` (the
     /// auto-refund batch in `OpenLease::on_remote_lease_callback` fires
-    /// inside the same cascade as the leaser's instantiate reply). In
-    /// that case the lease is still recorded only as the in-flight
-    /// open — clearing `PENDING_CUSTOMER` cancels it, and the
-    /// [`Self::CANCELLED_PENDING`] sentinel lets the subsequent reply's
-    /// `Leases::save` distinguish the cancellation from a programmer
-    /// error.
+    /// inside the same cascade as the leaser's instantiate reply). In that
+    /// case the lease is still recorded only as the in-flight open —
+    /// flipping the customer's entry from `Cached` to `Cancelled` cancels
+    /// it, and the subsequent `Leases::save` reads the `Cancelled` arm.
     pub fn remove(storage: &mut dyn Storage, customer: Addr, lease: &Addr) -> ContractResult<bool> {
         // not using cw_storage_plus::Map::load because it does not differentiate key-not-present
         // from value-cannot-be-deserialized case
@@ -132,22 +146,23 @@ impl Leases {
                 })
                 .map_err(ContractError::RemoveLeaseFailure)
         } else {
-            Ok(Self::cancel_pending_if_matches(storage, &customer))
+            Self::cancel_pending_if_matches(storage, customer)
         }
     }
 
-    fn cancel_pending_if_matches(storage: &mut dyn Storage, customer: &Addr) -> bool {
-        Self::PENDING_CUSTOMER
-            .may_load(storage)
-            .ok()
-            .flatten()
-            .is_some_and(|pending| {
-                let matches = &pending == customer;
-                if matches {
-                    Self::PENDING_CUSTOMER.remove(storage);
-                    let _ = Self::CANCELLED_PENDING.save(storage, &());
-                }
-                matches
+    fn cancel_pending_if_matches(
+        storage: &mut dyn Storage,
+        customer: Addr,
+    ) -> ContractResult<bool> {
+        Self::PENDING_OPENS
+            .may_load(storage, customer.clone())
+            .map_err(ContractError::RemoveLeaseFailure)
+            .and_then(|maybe_state| match maybe_state {
+                Some(PendingState::Cached) => Self::PENDING_OPENS
+                    .save(storage, customer, &PendingState::Cancelled)
+                    .map(|()| true)
+                    .map_err(ContractError::RemoveLeaseFailure),
+                Some(PendingState::Cancelled) | None => Ok(false),
             })
     }
 

--- a/protocol/contracts/leaser/src/state/leases.rs
+++ b/protocol/contracts/leaser/src/state/leases.rs
@@ -24,24 +24,32 @@ impl Leases {
             .map_err(ContractError::SavePendingCustomerFailure)
     }
 
-    /// Return true if the lease has been stored or false if there has already been the same lease
-    pub fn save(storage: &mut dyn Storage, lease: Addr) -> ContractResult<bool> {
-        let mut stored = false;
-
-        let update_fn = |may_leases: Option<HashSet<Addr>>| -> StdResult<HashSet<Addr>> {
-            let mut leases = may_leases.unwrap_or_default();
-
-            stored = leases.insert(lease);
-
-            Ok(leases)
-        };
-
+    /// Return `Some(true)` if the lease has been stored, `Some(false)` if
+    /// the same lease was already registered, or `None` if the open
+    /// request was cancelled before the reply landed (the OpenLease
+    /// auto-refund path clears `PENDING_CUSTOMER` on the failure side of
+    /// the cascade).
+    pub fn save(storage: &mut dyn Storage, lease: Addr) -> ContractResult<Option<bool>> {
         Self::PENDING_CUSTOMER
-            .load(storage)
-            .inspect(|_| Self::PENDING_CUSTOMER.remove(storage))
-            .and_then(|customer| Self::CUSTOMER_LEASES.update(storage, customer, update_fn))
-            .map(|_| stored)
+            .may_load(storage)
             .map_err(ContractError::SaveLeaseFailure)
+            .and_then(|may_customer| match may_customer {
+                Some(customer) => {
+                    Self::PENDING_CUSTOMER.remove(storage);
+                    let mut stored = false;
+                    let update_fn =
+                        |may_leases: Option<HashSet<Addr>>| -> StdResult<HashSet<Addr>> {
+                            let mut leases = may_leases.unwrap_or_default();
+                            stored = leases.insert(lease.clone());
+                            Ok(leases)
+                        };
+                    Self::CUSTOMER_LEASES
+                        .update(storage, customer, update_fn)
+                        .map(|_| Some(stored))
+                        .map_err(ContractError::SaveLeaseFailure)
+                }
+                None => Ok(None),
+            })
     }
 
     pub fn load_by_customer(
@@ -54,7 +62,15 @@ impl Leases {
             .map_err(ContractError::LoadLeasesFailure)
     }
 
-    /// Return whether the lease was present before the removal
+    /// Return whether the lease (or its still-pending open request) was
+    /// present before the removal.
+    ///
+    /// The remote-lease open lifecycle may finalise a lease before it has
+    /// been moved from `PENDING_CUSTOMER` into `CUSTOMER_LEASES` (the
+    /// auto-refund batch in `OpenLease::on_remote_lease_callback` fires
+    /// inside the same cascade as the leaser's instantiate reply). In
+    /// that case the lease is still recorded only as the in-flight
+    /// open — clearing `PENDING_CUSTOMER` cancels it.
     pub fn remove(storage: &mut dyn Storage, customer: Addr, lease: &Addr) -> ContractResult<bool> {
         // not using cw_storage_plus::Map::load because it does not differentiate key-not-present
         // from value-cannot-be-deserialized case
@@ -72,8 +88,22 @@ impl Leases {
                 })
                 .map_err(ContractError::RemoveLeaseFailure)
         } else {
-            Ok(false)
+            Ok(Self::cancel_pending_if_matches(storage, &customer))
         }
+    }
+
+    fn cancel_pending_if_matches(storage: &mut dyn Storage, customer: &Addr) -> bool {
+        Self::PENDING_CUSTOMER
+            .may_load(storage)
+            .ok()
+            .flatten()
+            .is_some_and(|pending| {
+                let matches = &pending == customer;
+                if matches {
+                    Self::PENDING_CUSTOMER.remove(storage);
+                }
+                matches
+            })
     }
 
     pub fn iter(
@@ -105,15 +135,12 @@ impl Leases {
 mod test {
     use sdk::cosmwasm_std::{Addr, Storage, testing::MockStorage};
 
-    use crate::{ContractError, state::leases::Leases};
+    use crate::state::leases::Leases;
 
     #[test]
     fn test_save_customer_not_cached() {
         let mut storage = MockStorage::default();
-        assert!(matches!(
-            Leases::save(&mut storage, test_lease(),),
-            Err(ContractError::SaveLeaseFailure { .. })
-        ));
+        assert_eq!(None, Leases::save(&mut storage, test_lease()).unwrap());
         assert_lease_not_exist(&storage);
         assert!(Leases::empty(&storage));
     }
@@ -124,7 +151,7 @@ mod test {
         assert_lease_not_exist(&storage);
         Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
 
-        assert!(Leases::save(&mut storage, test_lease()).unwrap());
+        assert_eq!(Some(true), Leases::save(&mut storage, test_lease()).unwrap());
         assert_lease_exist(&storage);
         assert!(!Leases::empty(&storage));
     }
@@ -133,11 +160,11 @@ mod test {
     fn test_save_same_lease() {
         let mut storage = MockStorage::default();
         Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
-        assert!(Leases::save(&mut storage, test_lease()).unwrap());
+        assert_eq!(Some(true), Leases::save(&mut storage, test_lease()).unwrap());
         assert_lease_exist(&storage);
 
         Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
-        assert!(!Leases::save(&mut storage, test_lease()).unwrap());
+        assert_eq!(Some(false), Leases::save(&mut storage, test_lease()).unwrap());
         assert_lease_exist(&storage);
     }
 
@@ -146,12 +173,15 @@ mod test {
         let mut storage = MockStorage::default();
         Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
         assert!(Leases::empty(&storage));
-        assert!(Leases::save(&mut storage, test_lease()).unwrap());
+        assert_eq!(Some(true), Leases::save(&mut storage, test_lease()).unwrap());
         assert_lease_exist(&storage);
         assert!(!Leases::empty(&storage));
 
         Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
-        assert!(Leases::save(&mut storage, test_another_lease()).unwrap());
+        assert_eq!(
+            Some(true),
+            Leases::save(&mut storage, test_another_lease()).unwrap()
+        );
         assert_lease_exist(&storage);
         assert!(lease_exist(
             &storage,
@@ -159,6 +189,17 @@ mod test {
             &test_another_lease()
         ));
         assert!(!Leases::empty(&storage));
+    }
+
+    #[test]
+    fn test_save_after_pending_cancelled() {
+        let mut storage = MockStorage::default();
+        Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
+        // OpenLease auto-refund cancels the pending open before the
+        // leaser's instantiate reply lands.
+        assert!(Leases::remove(&mut storage, test_customer(), &test_lease()).unwrap());
+        assert_eq!(None, Leases::save(&mut storage, test_lease()).unwrap());
+        assert_lease_not_exist(&storage);
     }
 
     #[test]

--- a/protocol/contracts/leaser/src/state/leases.rs
+++ b/protocol/contracts/leaser/src/state/leases.rs
@@ -13,8 +13,28 @@ use crate::{
 
 pub(crate) struct Leases {}
 
+/// Outcome of [`Leases::save`].
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum SaveOutcome {
+    /// The lease has been added to the customer's set.
+    Registered,
+    /// The lease was already present in the customer's set. No state
+    /// change.
+    AlreadyRegistered,
+    /// The open request was cancelled before the leaser's instantiate
+    /// reply landed (the OpenLease auto-refund batch fires inside the
+    /// same cascade). `save` consumes the cancel sentinel and no-ops.
+    Cancelled,
+}
+
 impl Leases {
     const PENDING_CUSTOMER: Item<Addr> = Item::new("pending_customer");
+
+    /// Sentinel set when `Leases::remove` cancels an in-flight open via
+    /// `PENDING_CUSTOMER`. `Leases::save` consumes it to distinguish a
+    /// deliberate cancellation (no-op, return `Ok(SaveOutcome::Cancelled)`)
+    /// from a missing-`cache_open_req` programmer error (`Err`).
+    const CANCELLED_PENDING: Item<()> = Item::new("cancelled_pending");
 
     const CUSTOMER_LEASES: Map<Addr, HashSet<Addr>> = Map::new("loans");
 
@@ -24,31 +44,52 @@ impl Leases {
             .map_err(ContractError::SavePendingCustomerFailure)
     }
 
-    /// Return `Some(true)` if the lease has been stored, `Some(false)` if
-    /// the same lease was already registered, or `None` if the open
-    /// request was cancelled before the reply landed (the OpenLease
-    /// auto-refund path clears `PENDING_CUSTOMER` on the failure side of
-    /// the cascade).
-    pub fn save(storage: &mut dyn Storage, lease: Addr) -> ContractResult<Option<bool>> {
+    /// See [`SaveOutcome`]. `Err` only surfaces real failures: a missing
+    /// `cache_open_req` upstream, or a storage error.
+    pub fn save(storage: &mut dyn Storage, lease: Addr) -> ContractResult<SaveOutcome> {
         Self::PENDING_CUSTOMER
             .may_load(storage)
             .map_err(ContractError::SaveLeaseFailure)
             .and_then(|may_customer| match may_customer {
-                Some(customer) => {
-                    Self::PENDING_CUSTOMER.remove(storage);
-                    let mut stored = false;
-                    let update_fn =
-                        |may_leases: Option<HashSet<Addr>>| -> StdResult<HashSet<Addr>> {
-                            let mut leases = may_leases.unwrap_or_default();
-                            stored = leases.insert(lease.clone());
-                            Ok(leases)
-                        };
-                    Self::CUSTOMER_LEASES
-                        .update(storage, customer, update_fn)
-                        .map(|_| Some(stored))
-                        .map_err(ContractError::SaveLeaseFailure)
+                Some(customer) => Self::save_under(storage, customer, lease),
+                None => Self::consume_cancel_sentinel(storage),
+            })
+    }
+
+    fn save_under(
+        storage: &mut dyn Storage,
+        customer: Addr,
+        lease: Addr,
+    ) -> ContractResult<SaveOutcome> {
+        Self::PENDING_CUSTOMER.remove(storage);
+        let mut stored = false;
+        let update_fn = |may_leases: Option<HashSet<Addr>>| -> StdResult<HashSet<Addr>> {
+            let mut leases = may_leases.unwrap_or_default();
+            stored = leases.insert(lease.clone());
+            Ok(leases)
+        };
+        Self::CUSTOMER_LEASES
+            .update(storage, customer, update_fn)
+            .map(|_| {
+                if stored {
+                    SaveOutcome::Registered
+                } else {
+                    SaveOutcome::AlreadyRegistered
                 }
-                None => Ok(None),
+            })
+            .map_err(ContractError::SaveLeaseFailure)
+    }
+
+    fn consume_cancel_sentinel(storage: &mut dyn Storage) -> ContractResult<SaveOutcome> {
+        Self::CANCELLED_PENDING
+            .may_load(storage)
+            .map_err(ContractError::SaveLeaseFailure)
+            .and_then(|sentinel| match sentinel {
+                Some(()) => {
+                    Self::CANCELLED_PENDING.remove(storage);
+                    Ok(SaveOutcome::Cancelled)
+                }
+                None => Err(ContractError::PendingCustomerNotCached),
             })
     }
 
@@ -70,7 +111,10 @@ impl Leases {
     /// auto-refund batch in `OpenLease::on_remote_lease_callback` fires
     /// inside the same cascade as the leaser's instantiate reply). In
     /// that case the lease is still recorded only as the in-flight
-    /// open — clearing `PENDING_CUSTOMER` cancels it.
+    /// open — clearing `PENDING_CUSTOMER` cancels it, and the
+    /// [`Self::CANCELLED_PENDING`] sentinel lets the subsequent reply's
+    /// `Leases::save` distinguish the cancellation from a programmer
+    /// error.
     pub fn remove(storage: &mut dyn Storage, customer: Addr, lease: &Addr) -> ContractResult<bool> {
         // not using cw_storage_plus::Map::load because it does not differentiate key-not-present
         // from value-cannot-be-deserialized case
@@ -101,6 +145,7 @@ impl Leases {
                 let matches = &pending == customer;
                 if matches {
                     Self::PENDING_CUSTOMER.remove(storage);
+                    let _ = Self::CANCELLED_PENDING.save(storage, &());
                 }
                 matches
             })
@@ -135,12 +180,18 @@ impl Leases {
 mod test {
     use sdk::cosmwasm_std::{Addr, Storage, testing::MockStorage};
 
-    use crate::state::leases::Leases;
+    use crate::{
+        ContractError,
+        state::leases::{Leases, SaveOutcome},
+    };
 
     #[test]
     fn test_save_customer_not_cached() {
         let mut storage = MockStorage::default();
-        assert_eq!(None, Leases::save(&mut storage, test_lease()).unwrap());
+        assert!(matches!(
+            Leases::save(&mut storage, test_lease()),
+            Err(ContractError::PendingCustomerNotCached)
+        ));
         assert_lease_not_exist(&storage);
         assert!(Leases::empty(&storage));
     }
@@ -151,7 +202,10 @@ mod test {
         assert_lease_not_exist(&storage);
         Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
 
-        assert_eq!(Some(true), Leases::save(&mut storage, test_lease()).unwrap());
+        assert_eq!(
+            SaveOutcome::Registered,
+            Leases::save(&mut storage, test_lease()).unwrap()
+        );
         assert_lease_exist(&storage);
         assert!(!Leases::empty(&storage));
     }
@@ -160,11 +214,17 @@ mod test {
     fn test_save_same_lease() {
         let mut storage = MockStorage::default();
         Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
-        assert_eq!(Some(true), Leases::save(&mut storage, test_lease()).unwrap());
+        assert_eq!(
+            SaveOutcome::Registered,
+            Leases::save(&mut storage, test_lease()).unwrap()
+        );
         assert_lease_exist(&storage);
 
         Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
-        assert_eq!(Some(false), Leases::save(&mut storage, test_lease()).unwrap());
+        assert_eq!(
+            SaveOutcome::AlreadyRegistered,
+            Leases::save(&mut storage, test_lease()).unwrap()
+        );
         assert_lease_exist(&storage);
     }
 
@@ -173,13 +233,16 @@ mod test {
         let mut storage = MockStorage::default();
         Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
         assert!(Leases::empty(&storage));
-        assert_eq!(Some(true), Leases::save(&mut storage, test_lease()).unwrap());
+        assert_eq!(
+            SaveOutcome::Registered,
+            Leases::save(&mut storage, test_lease()).unwrap()
+        );
         assert_lease_exist(&storage);
         assert!(!Leases::empty(&storage));
 
         Leases::cache_open_req(&mut storage, &test_customer()).unwrap();
         assert_eq!(
-            Some(true),
+            SaveOutcome::Registered,
             Leases::save(&mut storage, test_another_lease()).unwrap()
         );
         assert_lease_exist(&storage);
@@ -198,8 +261,17 @@ mod test {
         // OpenLease auto-refund cancels the pending open before the
         // leaser's instantiate reply lands.
         assert!(Leases::remove(&mut storage, test_customer(), &test_lease()).unwrap());
-        assert_eq!(None, Leases::save(&mut storage, test_lease()).unwrap());
+        assert_eq!(
+            SaveOutcome::Cancelled,
+            Leases::save(&mut storage, test_lease()).unwrap()
+        );
         assert_lease_not_exist(&storage);
+        // The cancel sentinel must be consumed; a follow-up bug-free
+        // save must surface `PendingCustomerNotCached` again.
+        assert!(matches!(
+            Leases::save(&mut storage, test_lease()),
+            Err(ContractError::PendingCustomerNotCached)
+        ));
     }
 
     #[test]

--- a/protocol/contracts/leaser/src/tests/contract_tests.rs
+++ b/protocol/contracts/leaser/src/tests/contract_tests.rs
@@ -69,6 +69,7 @@ fn leaser_instantiate_msg(lease_code: Code, lpp: Addr) -> crate::msg::Instantiat
         lease_admin: sdk_testing::user(LEASE_ADMIN),
         dex: dex_params(),
         remote_lease_controller: sdk_testing::user("remote_lease_controller"),
+        expected_instance_ordinal: 1,
     }
 }
 

--- a/protocol/contracts/leaser/src/tests/mod.rs
+++ b/protocol/contracts/leaser/src/tests/mod.rs
@@ -81,5 +81,6 @@ fn dummy_instantiate_msg() -> InstantiateMsg {
             },
         },
         remote_lease_controller: Addr::unchecked("remote_lease_controller"),
+        expected_instance_ordinal: 1,
     }
 }

--- a/protocol/docs/remote-lease-callback-flow.md
+++ b/protocol/docs/remote-lease-callback-flow.md
@@ -162,6 +162,17 @@ RequestLoan ──open loan──▶ OpenLease
 
 The legacy ICA-open + DEX swap cascade entered via `super::buy_asset::start` is retained additively; later phases (swap replacement, TransferOut, CloseLease) migrate the remaining lifecycle stages off it.
 
+An `OperationOk` ack carrying any operation other than `OpenLease` (a `CloseLease` / `Swap` / `TransferOut` response against an in-flight open) can only originate from a buggy or hostile counterparty. The lease treats it exactly like `OperationErr`: it refunds the customer, finalises, and moves to `OpenFailed` with a synthesised `unexpected operation response: …` reason. It does **not** return `Err` — an error would revert the controller's `ibc_packet_ack`, stranding the relayer and freezing the lease in `OpenLease`. Operators see the same `wasm-ls-remote-lease-open-failed` event and audit the counterparty per the runbook.
+
+## Storage: v9 → v10 (refuse-migrate)
+
+v10 makes `LeaseDTO.remote_lease_id` a non-optional Solana PDA, which is binary-incompatible with the v9 layout. The `migrate` entry point therefore **rejects unconditionally** (`ContractError::UnsupportedMigration`):
+
+- **Mainnet** carries zero v9 leases (plan §10.A.1), so refusing is strictly safer than risking a silent deserialise failure on the first post-upgrade load.
+- A v9 lease has no meaningful `remote_lease_id` to synthesise — its `dex_account` is an ICA host on the DEX chain, not a Solana PDA — so a "real" migration would only invent a permanent sentinel.
+
+**Operational procedure for non-mainnet (devnet/testnet/local):** drain every v9 lease to a terminal state *before* upgrading the lease code to v10. There is no `ExecuteMsg` escape hatch for a stranded v9 lease, so the drain is a prerequisite, not a recovery step.
+
 ## Closed: in-lease decoder shape
 
 The `OperationOk(SwapResponse)` decoder still feeds the safe-delivery

--- a/protocol/docs/remote-lease-callback-flow.md
+++ b/protocol/docs/remote-lease-callback-flow.md
@@ -131,24 +131,39 @@ on a permanently-unrecoverable state.
 | Classify | `data` enters directly into `on_dex_response` | `classify_callback` projects variant → `CallbackDispatch::Response/Error/Timeout` |
 | A–D safe-delivery boxes | unchanged | unchanged |
 
-## Open seam closed by ibc-solray#142
+## Outbound open-side lifecycle (issue #142)
 
-The decoder at step B currently expects the chain's protobuf
-`MsgSwapExactAmountInResponse` shape (Osmosis / Astroport). The
-`RemoteLeaseCallback::OperationOk(SwapResponse)` path delivers JSON
-bytes from `remote_lease::response::SwapResponse`. ibc-solray#142 will
-switch the in-lease decoders from the protobuf shape to the JSON shape
-when the lifecycle calls move to `remote_lease` stubs.
+The lease now drives the remote-lease channel directly for the open flow.
 
-Until then:
+```
+RequestLoan ──open loan──▶ OpenLease
+                              │
+                              │ Factory::open → controller → IBC packet
+                              │
+                              ▼
+                  ┌───────────────────────┐
+                  │ controller ack (UNORDERED) │
+                  └───────────────────────┘
+                     │             │
+        OperationOk  │             │ OperationErr / OperationTimeout
+        (OpenLease   │             │
+        + PDA)       │             ▼
+                     │       atomic batch: LPP repay + downpayment refund
+                     │             + finalize_lease + emit
+                     │             `wasm-ls-remote-lease-open-failed`
+                     │             │
+                     ▼             ▼
+        super::buy_asset::start    OpenFailed  (terminal)
+        (legacy ICA-open cascade)  authenticated late-ack absorber:
+                                   emits `wasm-ls-remote-lease-late-ack`
+```
 
-- The auth-gate, the classify step, and the dispatch wiring are
-  exercised by the in-crate unit tests (`packages/dex/src/response.rs`,
-  `contracts/lease/src/contract/state/dex.rs`).
-- The end-to-end public-API path is exercised in
-  `tests/src/lease/remote_lease_callback.rs` against the BuyAsset
-  swap-pending state, covering matched/mismatched sender and the
-  `OperationTimeout` / `OperationErr` arms (which reach the real
-  `on_dex_timeout` / `on_dex_error` and schedule a retry SubMsg). The
-  `OperationOk` arm is intentionally deferred to #142 because of the
-  protobuf-vs-JSON shape mismatch.
+`OpenLease::on_remote_lease_callback` authenticates `info.sender` via `LeasesRef::remote_lease_callback_permission` before dispatching, identical to the in-flight DexState gate documented above. `OpenFailed` runs the same check — every callback handler that returns `Ok` is authz-gated, regardless of idempotence.
+
+The legacy ICA-open + DEX swap cascade entered via `super::buy_asset::start` is retained additively; later phases (swap replacement, TransferOut, CloseLease) migrate the remaining lifecycle stages off it.
+
+## Closed: in-lease decoder shape
+
+The `OperationOk(SwapResponse)` decoder still feeds the safe-delivery
+boxes A–D above; the protobuf-vs-JSON shape switch tracked here previously
+moves with the Phase-4 swap replacement work.

--- a/protocol/packages/remote_lease/src/msg.rs
+++ b/protocol/packages/remote_lease/src/msg.rs
@@ -67,9 +67,7 @@ impl OpenLeaseParams {
     }
 
     pub fn invariant_held(&self) -> bool {
-        self.downpayment_currency != self.lpn_currency
-            && self.downpayment_currency != self.asset_currency
-            && self.lpn_currency != self.asset_currency
+        self.lpn_currency != self.asset_currency
     }
 }
 

--- a/protocol/packages/remote_lease/src/msg.rs
+++ b/protocol/packages/remote_lease/src/msg.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use currencies::PaymentGroup;
 use currency::CurrencyDTO;
-use finance::coin::CoinDTO;
+use finance::{coin::CoinDTO, duration::Duration};
 
 use crate::error::Error;
 
@@ -29,6 +29,8 @@ pub struct OpenLeaseParams {
 }
 
 impl OpenLeaseParams {
+    pub const TIMEOUT: Duration = Duration::from_secs(60);
+
     pub fn new(
         expected_instance_ordinal: u16,
         downpayment_currency: CurrencyDTO<PaymentGroup>,
@@ -97,6 +99,10 @@ impl TryFrom<OpenLeaseParamsRaw> for OpenLeaseParams {
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct CloseLeaseParams {}
 
+impl CloseLeaseParams {
+    pub const TIMEOUT: Duration = Duration::from_secs(60);
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(
     deny_unknown_fields,
@@ -109,6 +115,8 @@ pub struct SwapParams {
 }
 
 impl SwapParams {
+    pub const TIMEOUT: Duration = Duration::from_secs(300);
+
     pub fn new(
         coin_in: CoinDTO<PaymentGroup>,
         min_out: CoinDTO<PaymentGroup>,
@@ -165,6 +173,8 @@ pub struct TransferOutParams {
 }
 
 impl TransferOutParams {
+    pub const TIMEOUT: Duration = Duration::from_secs(120);
+
     pub fn new(amount: CoinDTO<PaymentGroup>) -> Result<Self, Error> {
         let params = Self { amount };
         params

--- a/protocol/packages/remote_lease/src/stub.rs
+++ b/protocol/packages/remote_lease/src/stub.rs
@@ -1,22 +1,24 @@
 use serde::Serialize;
 
+use finance::duration::Duration;
 use platform::{batch::Batch, result::Result as PlatformResult};
 use sdk::cosmwasm_std::Addr;
 
-use crate::msg::{CloseLeaseParams, OpenLeaseParams, Operation, SwapParams, TransferOutParams};
+use crate::msg::{CloseLeaseParams, OpenLeaseParams, SwapParams, TransferOutParams};
 
 /// Marker trait the consuming controller must implement on its own
-/// `ExecuteMsg` (or whichever outer enum carries [`Operation`]).
+/// `ExecuteMsg` (or whichever outer enum carries the per-operation
+/// `{ params, timeout }` variants).
 ///
-/// Why a marker: the stub builders accept an `op_to_msg` closure that wraps
-/// a [`Operation`] into the controller's outer message before it
-/// goes onto the wire. Without this bound, any `Serialize` value would work
-/// — including `Operation` itself, which would let the controller
-/// (or a contributor) accidentally emit a flat-embedded operation that
+/// Why a marker: the stub builders accept a `msg` closure that wraps the
+/// typed `*Params` and the `Duration` into the controller's outer message
+/// before it goes onto the wire. Without this bound, any `Serialize` value
+/// would work — including raw `*Params` — which would let the controller
+/// (or a contributor) accidentally emit a flat-embedded params payload that
 /// bypasses the controller's own authorisation layer. By requiring the
 /// closure's output to implement `ControllerInnerMessage` the crate forces
 /// a deliberate one-line opt-in on the consumer side; the orphan rule
-/// prevents the consumer from implementing it on `Operation`.
+/// prevents the consumer from implementing it on the `*Params` types.
 pub trait ControllerInnerMessage: Serialize {}
 
 pub struct Factory<'controller> {
@@ -28,20 +30,30 @@ impl<'controller> Factory<'controller> {
         Self { controller }
     }
 
-    pub fn open<F, M>(&self, params: OpenLeaseParams, op_to_msg: F) -> PlatformResult<Batch>
+    pub fn open<F, M>(
+        &self,
+        params: OpenLeaseParams,
+        timeout: Duration,
+        msg: F,
+    ) -> PlatformResult<Batch>
     where
-        F: FnOnce(Operation) -> M,
+        F: FnOnce(OpenLeaseParams, Duration) -> M,
         M: ControllerInnerMessage,
     {
-        schedule(self.controller, &op_to_msg(Operation::OpenLease(params)))
+        schedule(self.controller, &msg(params, timeout))
     }
 
-    pub fn close<F, M>(&self, params: CloseLeaseParams, op_to_msg: F) -> PlatformResult<Batch>
+    pub fn close<F, M>(
+        &self,
+        params: CloseLeaseParams,
+        timeout: Duration,
+        msg: F,
+    ) -> PlatformResult<Batch>
     where
-        F: FnOnce(Operation) -> M,
+        F: FnOnce(CloseLeaseParams, Duration) -> M,
         M: ControllerInnerMessage,
     {
-        schedule(self.controller, &op_to_msg(Operation::CloseLease(params)))
+        schedule(self.controller, &msg(params, timeout))
     }
 }
 
@@ -54,24 +66,25 @@ impl<'controller> Lease<'controller> {
         Self { controller }
     }
 
-    pub fn swap<F, M>(&self, params: SwapParams, op_to_msg: F) -> PlatformResult<Batch>
+    pub fn swap<F, M>(&self, params: SwapParams, timeout: Duration, msg: F) -> PlatformResult<Batch>
     where
-        F: FnOnce(Operation) -> M,
+        F: FnOnce(SwapParams, Duration) -> M,
         M: ControllerInnerMessage,
     {
-        schedule(self.controller, &op_to_msg(Operation::Swap(params)))
+        schedule(self.controller, &msg(params, timeout))
     }
 
     pub fn transfer_out<F, M>(
         &self,
         params: TransferOutParams,
-        op_to_msg: F,
+        timeout: Duration,
+        msg: F,
     ) -> PlatformResult<Batch>
     where
-        F: FnOnce(Operation) -> M,
+        F: FnOnce(TransferOutParams, Duration) -> M,
         M: ControllerInnerMessage,
     {
-        schedule(self.controller, &op_to_msg(Operation::TransferOut(params)))
+        schedule(self.controller, &msg(params, timeout))
     }
 }
 
@@ -93,17 +106,34 @@ mod tests {
         PaymentGroup,
         testing::{PaymentC1, PaymentC2, PaymentC3},
     };
-    use finance::coin::Coin;
+    use finance::{coin::Coin, duration::Duration};
     use sdk::cosmwasm_std::Addr;
 
-    use crate::msg::{CloseLeaseParams, OpenLeaseParams, Operation, SwapParams, TransferOutParams};
+    use crate::msg::{CloseLeaseParams, OpenLeaseParams, SwapParams, TransferOutParams};
 
     use super::{ControllerInnerMessage, Factory, Lease};
 
+    /// Mirrors the production controller's `ExecuteMsg` per-variant struct
+    /// shape (`protocol/contracts/remote_lease/src/api.rs`).
     #[derive(Serialize)]
     #[serde(rename_all = "snake_case")]
     enum OuterExecuteMsg {
-        LeaseOperations(Operation),
+        OpenLease {
+            params: OpenLeaseParams,
+            timeout: Duration,
+        },
+        CloseLease {
+            params: CloseLeaseParams,
+            timeout: Duration,
+        },
+        Swap {
+            params: SwapParams,
+            timeout: Duration,
+        },
+        TransferOut {
+            params: TransferOutParams,
+            timeout: Duration,
+        },
     }
 
     impl ControllerInnerMessage for OuterExecuteMsg {}
@@ -113,7 +143,11 @@ mod tests {
         let controller = Addr::unchecked("controller");
         let factory = Factory::new(&controller);
         let batch = factory
-            .open(sample_open_lease_params(), OuterExecuteMsg::LeaseOperations)
+            .open(
+                sample_open_lease_params(),
+                OpenLeaseParams::TIMEOUT,
+                |params, timeout| OuterExecuteMsg::OpenLease { params, timeout },
+            )
             .expect("scheduling must succeed");
         assert_eq!(1, batch.len());
     }
@@ -123,7 +157,11 @@ mod tests {
         let controller = Addr::unchecked("controller");
         let factory = Factory::new(&controller);
         let batch = factory
-            .close(CloseLeaseParams {}, OuterExecuteMsg::LeaseOperations)
+            .close(
+                CloseLeaseParams {},
+                CloseLeaseParams::TIMEOUT,
+                |params, timeout| OuterExecuteMsg::CloseLease { params, timeout },
+            )
             .expect("scheduling must succeed");
         assert_eq!(1, batch.len());
     }
@@ -133,7 +171,11 @@ mod tests {
         let controller = Addr::unchecked("controller");
         let lease = Lease::new(&controller);
         let batch = lease
-            .swap(sample_swap_params(), OuterExecuteMsg::LeaseOperations)
+            .swap(
+                sample_swap_params(),
+                SwapParams::TIMEOUT,
+                |params, timeout| OuterExecuteMsg::Swap { params, timeout },
+            )
             .expect("scheduling must succeed");
         assert_eq!(1, batch.len());
     }
@@ -145,7 +187,8 @@ mod tests {
         let batch = lease
             .transfer_out(
                 sample_transfer_out_params(),
-                OuterExecuteMsg::LeaseOperations,
+                TransferOutParams::TIMEOUT,
+                |params, timeout| OuterExecuteMsg::TransferOut { params, timeout },
             )
             .expect("scheduling must succeed");
         assert_eq!(1, batch.len());

--- a/protocol/packages/remote_lease/src/tests.rs
+++ b/protocol/packages/remote_lease/src/tests.rs
@@ -195,7 +195,7 @@ fn lease_addr_on_wire_round_trip_is_bare_string() {
 }
 
 // ---------------------------------------------------------------------------
-// 5. OpenLeaseParams invariant: three currencies pairwise distinct
+// 5. OpenLeaseParams invariant: lpn != asset (downpayment may overlap either)
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -211,25 +211,25 @@ fn open_lease_params_distinct_currencies_ok() {
 }
 
 #[test]
-fn open_lease_params_downpayment_equals_lpn_rejected() {
-    let res = OpenLeaseParams::new(
+fn open_lease_params_downpayment_equals_lpn_accepted() {
+    OpenLeaseParams::new(
         7,
         currency::dto::<PaymentC1, PaymentGroup>(),
         currency::dto::<PaymentC1, PaymentGroup>(),
         currency::dto::<PaymentC3, PaymentGroup>(),
-    );
-    assert!(matches!(res, Err(Error::DuplicateLeaseCurrencies)));
+    )
+    .expect("downpayment in lpn currency must be accepted");
 }
 
 #[test]
-fn open_lease_params_downpayment_equals_asset_rejected() {
-    let res = OpenLeaseParams::new(
+fn open_lease_params_downpayment_equals_asset_accepted() {
+    OpenLeaseParams::new(
         7,
         currency::dto::<PaymentC1, PaymentGroup>(),
         currency::dto::<PaymentC2, PaymentGroup>(),
         currency::dto::<PaymentC1, PaymentGroup>(),
-    );
-    assert!(matches!(res, Err(Error::DuplicateLeaseCurrencies)));
+    )
+    .expect("downpayment in asset currency must be accepted");
 }
 
 #[test]
@@ -245,9 +245,9 @@ fn open_lease_params_lpn_equals_asset_rejected() {
 
 #[test]
 fn open_lease_params_deserialize_invariant_violation_rejected() {
-    let bad_wire = r#"{"expected_instance_ordinal":7,"downpayment_currency":"NLS","lpn_currency":"NLS","asset_currency":"LC1"}"#;
+    let bad_wire = r#"{"expected_instance_ordinal":7,"downpayment_currency":"NLS","lpn_currency":"LPN","asset_currency":"LPN"}"#;
     serde_json::from_str::<OpenLeaseParams>(bad_wire)
-        .expect_err("invariant violation must fail deserialization");
+        .expect_err("lpn==asset must fail deserialization");
 }
 
 #[test]

--- a/protocol/packages/remote_lease_wire/src/callback.rs
+++ b/protocol/packages/remote_lease_wire/src/callback.rs
@@ -32,9 +32,13 @@ pub enum RemoteLeaseCallback {
 
 /// Length-capped error string returned by the Solana counterparty.
 ///
-/// Serialises as a bare JSON string. Deserialisation rejects payloads above
-/// [`OPERATION_ERR_MAX_BYTES`] so storage writes downstream are bounded by
-/// construction.
+/// Serialises as a bare JSON string. The counterparty-facing paths —
+/// deserialisation and the fallible [`new`](Self::new) — reject payloads
+/// above [`OPERATION_ERR_MAX_BYTES`], so any string sourced from over the
+/// wire is bounded before it reaches downstream storage. The
+/// [`from_static`](Self::from_static) constructor is the one exception: it
+/// trusts the (compile-time-known) caller and only `debug_assert!`s the
+/// bound, so it must be fed provably-in-range literals.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RemoteErrorMessage(String);
 
@@ -53,6 +57,21 @@ impl RemoteErrorMessage {
                 max: OPERATION_ERR_MAX_BYTES,
             })
         }
+    }
+
+    /// Construct from a compile-time-known literal that the caller guarantees
+    /// is within [`OPERATION_ERR_MAX_BYTES`].
+    ///
+    /// For fixed internal reasons (e.g. `"timeout"`) where threading a
+    /// fallible [`new`](Self::new) through the call site would add error
+    /// plumbing for a value that is provably in range. The length invariant
+    /// is enforced with a `debug_assert!`; release builds trust the caller.
+    pub fn from_static(message: &'static str) -> Self {
+        debug_assert!(
+            message.len() <= OPERATION_ERR_MAX_BYTES,
+            "RemoteErrorMessage::from_static exceeds OPERATION_ERR_MAX_BYTES"
+        );
+        Self(message.to_owned())
     }
 
     pub fn as_str(&self) -> &str {

--- a/protocol/packages/remote_lease_wire/src/callback.rs
+++ b/protocol/packages/remote_lease_wire/src/callback.rs
@@ -59,13 +59,24 @@ impl RemoteErrorMessage {
         }
     }
 
-    /// Construct from a compile-time-known literal that the caller guarantees
-    /// is within [`OPERATION_ERR_MAX_BYTES`].
+    /// Construct from a compile-time-known string literal that is statically
+    /// known to be within [`OPERATION_ERR_MAX_BYTES`].
     ///
     /// For fixed internal reasons (e.g. `"timeout"`) where threading a
     /// fallible [`new`](Self::new) through the call site would add error
-    /// plumbing for a value that is provably in range. The length invariant
-    /// is enforced with a `debug_assert!`; release builds trust the caller.
+    /// plumbing for a value that is provably in range.
+    ///
+    /// Precondition (caller's responsibility): `message` must be a genuine
+    /// literal whose length is verifiable by inspection, never a
+    /// runtime-produced `&'static str` (e.g. a `Box::leak`ed value). The
+    /// length is only `debug_assert!`ed, so an over-cap input that slips past
+    /// review would bypass the bound in release builds — unlike [`new`] and
+    /// deserialisation, which reject it. When the length is not statically
+    /// obvious, use [`new`] instead.
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, panics if `message` exceeds [`OPERATION_ERR_MAX_BYTES`].
     pub fn from_static(message: &'static str) -> Self {
         debug_assert!(
             message.len() <= OPERATION_ERR_MAX_BYTES,

--- a/protocol/packages/remote_lease_wire/src/msg.rs
+++ b/protocol/packages/remote_lease_wire/src/msg.rs
@@ -61,9 +61,7 @@ impl OpenLeaseParams {
     }
 
     pub fn invariant_held(&self) -> bool {
-        self.downpayment_currency != self.lpn_currency
-            && self.downpayment_currency != self.asset_currency
-            && self.lpn_currency != self.asset_currency
+        self.lpn_currency != self.asset_currency
     }
 }
 

--- a/protocol/packages/remote_lease_wire/src/tests.rs
+++ b/protocol/packages/remote_lease_wire/src/tests.rs
@@ -154,6 +154,27 @@ fn callback_error_message_deserialize_over_cap_rejected() {
         .expect_err("over-cap payload must fail deserialization");
 }
 
+#[test]
+fn callback_error_message_from_static_accepted() {
+    let value = RemoteErrorMessage::from_static("timeout");
+    assert_eq!("timeout", value.as_str());
+    assert_round_trip_eq(
+        r#"{"operation_err":"timeout"}"#,
+        &RemoteLeaseCallback::OperationErr(value),
+    );
+}
+
+// `from_static` only `debug_assert!`s its length contract, so the panic is
+// observable solely in debug builds — the test is gated to match.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "OPERATION_ERR_MAX_BYTES")]
+fn callback_error_message_from_static_over_cap_panics_in_debug() {
+    let over_cap: &'static str =
+        Box::leak("x".repeat(OPERATION_ERR_MAX_BYTES + 1).into_boxed_str());
+    let _ = RemoteErrorMessage::from_static(over_cap);
+}
+
 // ---------------------------------------------------------------------------
 // 4. PacketEnvelope — round-trip + literal JSON
 // ---------------------------------------------------------------------------

--- a/protocol/packages/remote_lease_wire/src/tests.rs
+++ b/protocol/packages/remote_lease_wire/src/tests.rs
@@ -192,7 +192,7 @@ fn lease_addr_on_wire_round_trip_is_bare_string() {
 }
 
 // ---------------------------------------------------------------------------
-// 5. OpenLeaseParams invariant: three currencies pairwise distinct
+// 5. OpenLeaseParams invariant: lpn != asset (downpayment may overlap either)
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -208,25 +208,25 @@ fn open_lease_params_distinct_currencies_ok() {
 }
 
 #[test]
-fn open_lease_params_downpayment_equals_lpn_rejected() {
-    let res = OpenLeaseParams::new(
+fn open_lease_params_downpayment_equals_lpn_accepted() {
+    OpenLeaseParams::new(
         7,
         Ticker::new("NLS"),
         Ticker::new("NLS"),
         Ticker::new("LC1"),
-    );
-    assert!(matches!(res, Err(Error::DuplicateLeaseCurrencies)));
+    )
+    .expect("downpayment in lpn currency must be accepted");
 }
 
 #[test]
-fn open_lease_params_downpayment_equals_asset_rejected() {
-    let res = OpenLeaseParams::new(
+fn open_lease_params_downpayment_equals_asset_accepted() {
+    OpenLeaseParams::new(
         7,
         Ticker::new("NLS"),
         Ticker::new("LPN"),
         Ticker::new("NLS"),
-    );
-    assert!(matches!(res, Err(Error::DuplicateLeaseCurrencies)));
+    )
+    .expect("downpayment in asset currency must be accepted");
 }
 
 #[test]
@@ -242,9 +242,9 @@ fn open_lease_params_lpn_equals_asset_rejected() {
 
 #[test]
 fn open_lease_params_deserialize_invariant_violation_rejected() {
-    let bad_wire = r#"{"expected_instance_ordinal":7,"downpayment_currency":"NLS","lpn_currency":"NLS","asset_currency":"LC1"}"#;
+    let bad_wire = r#"{"expected_instance_ordinal":7,"downpayment_currency":"NLS","lpn_currency":"LPN","asset_currency":"LPN"}"#;
     serde_json::from_str::<OpenLeaseParams>(bad_wire)
-        .expect_err("invariant violation must fail deserialization");
+        .expect_err("lpn==asset must fail deserialization");
 }
 
 #[test]

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -1431,7 +1431,9 @@ dependencies = [
  "currencies",
  "currency",
  "finance",
+ "platform",
  "remote_lease_wire",
+ "sdk",
  "serde",
  "thiserror 2.0.18",
 ]

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -958,6 +958,7 @@ dependencies = [
  "platform",
  "profit",
  "remote_lease",
+ "remote_lease_controller",
  "reserve",
  "sdk",
  "serde",
@@ -1433,6 +1434,20 @@ dependencies = [
  "remote_lease_wire",
  "serde",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "remote_lease_controller"
+version = "0.1.0"
+dependencies = [
+ "cw-time",
+ "finance",
+ "platform",
+ "remote_lease",
+ "sdk",
+ "serde",
+ "thiserror 2.0.18",
+ "versioning",
 ]
 
 [[package]]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -58,6 +58,7 @@ lpp-platform = { path = "../platform/packages/lpp", features = ["testing"], defa
 marketprice = { path = "../protocol/packages/marketprice", features = ["testing"], default-features = false }
 platform = { path = "../platform/packages/platform", features = ["testing"], default-features = false }
 remote_lease = { path = "../protocol/packages/remote_lease", default-features = false }
+remote_lease_controller = { path = "../protocol/contracts/remote_lease", default-features = false }
 sdk = { path = "../platform/packages/sdk", features = ["testing"], default-features = false }
 swap = { path = "../protocol/packages/swap", features = ["testing"], default-features = false }
 tree = { path = "../platform/packages/tree", features = ["testing"], default-features = false }

--- a/tests/src/common/lease.rs
+++ b/tests/src/common/lease.rs
@@ -116,6 +116,7 @@ impl Instantiator {
             },
             dex: config.dex,
             finalizer: addresses.finalizer,
+            expected_instance_ordinal: 1,
         }
     }
 }

--- a/tests/src/common/lease.rs
+++ b/tests/src/common/lease.rs
@@ -116,6 +116,7 @@ impl Instantiator {
             },
             dex: config.dex,
             finalizer: addresses.finalizer,
+            remote_lease_controller: testing::user("remote_lease_controller"),
             expected_instance_ordinal: 1,
         }
     }

--- a/tests/src/common/lease.rs
+++ b/tests/src/common/lease.rs
@@ -116,7 +116,7 @@ impl Instantiator {
             },
             dex: config.dex,
             finalizer: addresses.finalizer,
-            remote_lease_controller: testing::user("remote_lease_controller"),
+            remote_lease_controller: addresses.remote_lease_controller,
             expected_instance_ordinal: 1,
         }
     }
@@ -200,6 +200,7 @@ pub struct InstantiatorAddresses {
     pub profit: Addr,
     pub reserve: Addr,
     pub finalizer: Addr,
+    pub remote_lease_controller: Addr,
 }
 
 pub(crate) fn complete_initialization<DownpaymentC, Lpn>(

--- a/tests/src/common/leaser.rs
+++ b/tests/src/common/leaser.rs
@@ -26,6 +26,8 @@ use super::{
 pub(crate) struct Instantiator;
 
 impl Instantiator {
+    pub const EXPECTED_INSTANCE_ORDINAL: u16 = 1;
+
     pub const INTEREST_RATE_MARGIN: Percent100 = Percent100::from_permille(30);
 
     pub const REPAYMENT_PERIOD: Duration = Duration::from_days(90);
@@ -132,6 +134,7 @@ impl Instantiator {
                 },
             },
             remote_lease_controller,
+            expected_instance_ordinal: Self::EXPECTED_INSTANCE_ORDINAL,
         };
 
         app.instantiate(code_id, testing::user(ADMIN), &msg, &[], "leaser", None)

--- a/tests/src/common/leaser.rs
+++ b/tests/src/common/leaser.rs
@@ -95,22 +95,19 @@ impl Instantiator {
         lpp: Addr,
         alarms: Alarms,
         profit: Addr,
-        reserve: Addr,
-        protocols_registry: Addr,
+        peers: LeaserPeers,
     ) -> Addr {
+        let LeaserPeers {
+            reserve,
+            protocols_registry,
+            remote_lease_controller,
+        } = peers;
         // TODO [Rust 1.70] Convert to static item with OnceCell
         let endpoints = CwContractWrapper::new(leaser::execute, leaser::instantiate, leaser::query)
             .with_reply(leaser::reply)
             .with_sudo(leaser::sudo);
 
         let code_id = app.store_code(Box::new(endpoints));
-
-        // No remote_lease_controller contract is instantiated in the test
-        // harness. Reusing `reserve` as a stand-in satisfies the
-        // `check_contract` validator (it just needs an address that resolves
-        // to a registered contract); the integration tests do not exercise
-        // the `RemoteLeaseCallback` path itself.
-        let remote_lease_controller = reserve.clone();
 
         let msg = InstantiateMsg {
             lease_code: CodeId::from(lease_code).into(),
@@ -148,6 +145,15 @@ pub(super) type LeaserTestCase = TestCase<Addr, Addr, Addr, Addr, Addr, Addr, Ad
 pub(crate) struct Alarms {
     pub time_alarm: Addr,
     pub market_price_oracle: Addr,
+}
+
+/// Peer-contract addresses the leaser instantiation needs, bundled to
+/// keep `Instantiator::instantiate`'s argument count under the project
+/// clippy cap.
+pub(crate) struct LeaserPeers {
+    pub reserve: Addr,
+    pub protocols_registry: Addr,
+    pub remote_lease_controller: Addr,
 }
 
 pub fn test_case() -> LeaserTestCase {

--- a/tests/src/common/mod.rs
+++ b/tests/src/common/mod.rs
@@ -38,6 +38,7 @@ pub mod lpp;
 pub mod oracle;
 pub mod profit;
 pub mod protocols;
+pub mod remote_lease_controller_stub;
 pub mod reserve;
 pub mod swap;
 pub mod test_case;

--- a/tests/src/common/remote_lease_controller_stub.rs
+++ b/tests/src/common/remote_lease_controller_stub.rs
@@ -319,7 +319,9 @@ fn synth_open_lease_response(
     // restricts characters but does not enforce on-chain shape — fine for
     // an integration stand-in. The prefix is fixed so test assertions can
     // pattern-match on it.
-    let raw = format!("StubPda{next:0>32}");
+    // Pad with `1` (smallest valid base58 digit) — `0` is excluded from the
+    // alphabet, which `RemoteLeaseId::new` rejects.
+    let raw = format!("StubPda{next:1>32}");
     let id =
         RemoteLeaseId::new(raw).map_err(|err| StubError::Std(StdError::msg(err.to_string())))?;
     Ok(OperationResponse::OpenLease(OpenLeaseResponse {

--- a/tests/src/common/remote_lease_controller_stub.rs
+++ b/tests/src/common/remote_lease_controller_stub.rs
@@ -212,17 +212,19 @@ pub fn execute(
             })
         }
         StubExecuteMsg::CloseLease { .. } => {
-            handle_outbound(deps, info, op_tag::CLOSE_LEASE, |_| {
+            handle_outbound(deps, info, op_tag::CLOSE_LEASE, |_storage| {
                 Ok(OperationResponse::CloseLease(CloseLeaseResponse {}))
             })
         }
-        StubExecuteMsg::Swap { params, .. } => handle_outbound(deps, info, op_tag::SWAP, |_| {
-            Ok(OperationResponse::Swap(SwapResponse {
-                amount_out: *params.min_out(),
-            }))
-        }),
+        StubExecuteMsg::Swap { params, .. } => {
+            handle_outbound(deps, info, op_tag::SWAP, |_storage| {
+                Ok(OperationResponse::Swap(SwapResponse {
+                    amount_out: *params.min_out(),
+                }))
+            })
+        }
         StubExecuteMsg::TransferOut { .. } => {
-            handle_outbound(deps, info, op_tag::TRANSFER_OUT, |_| {
+            handle_outbound(deps, info, op_tag::TRANSFER_OUT, |_storage| {
                 Ok(OperationResponse::TransferOut(TransferOutResponse {}))
             })
         }
@@ -239,7 +241,7 @@ pub fn query(deps: Deps<'_>, _env: Env, msg: ControllerQueryMsg) -> StdResult<Bi
         ControllerQueryMsg::Config() => {
             let config = CONFIG
                 .load(deps.storage)
-                .map_err(|_| StubError::NotInitialised)?;
+                .map_err(|_err| StubError::NotInitialised)?;
             to_json_binary(&ConfigResponse {
                 connection_id: config.connection_id,
                 dex_label: config.dex_label,
@@ -303,8 +305,8 @@ fn require_lease_code(
     use platform::contract::Validator as _;
     platform::contract::validator(deps.querier)
         .check_contract_code(info.sender.clone(), &config.lease_code)
-        .map(|_| ())
-        .map_err(|_| StubError::Unauthorised {
+        .map(|_ok| ())
+        .map_err(|_validator_err| StubError::Unauthorised {
             caller: info.sender.clone(),
         })
 }

--- a/tests/src/common/remote_lease_controller_stub.rs
+++ b/tests/src/common/remote_lease_controller_stub.rs
@@ -270,7 +270,7 @@ where
 {
     let config = CONFIG
         .load(deps.storage)
-        .map_err(|_| StubError::NotInitialised)?;
+        .map_err(|_load_err| StubError::NotInitialised)?;
     require_lease_code(deps.as_ref(), &info, &config)?;
 
     let mode = MODES

--- a/tests/src/common/remote_lease_controller_stub.rs
+++ b/tests/src/common/remote_lease_controller_stub.rs
@@ -216,13 +216,11 @@ pub fn execute(
                 Ok(OperationResponse::CloseLease(CloseLeaseResponse {}))
             })
         }
-        StubExecuteMsg::Swap { params, .. } => {
-            handle_outbound(deps, info, op_tag::SWAP, |_| {
-                Ok(OperationResponse::Swap(SwapResponse {
-                    amount_out: *params.min_out(),
-                }))
-            })
-        }
+        StubExecuteMsg::Swap { params, .. } => handle_outbound(deps, info, op_tag::SWAP, |_| {
+            Ok(OperationResponse::Swap(SwapResponse {
+                amount_out: *params.min_out(),
+            }))
+        }),
         StubExecuteMsg::TransferOut { .. } => {
             handle_outbound(deps, info, op_tag::TRANSFER_OUT, |_| {
                 Ok(OperationResponse::TransferOut(TransferOutResponse {}))
@@ -322,7 +320,8 @@ fn synth_open_lease_response(
     // an integration stand-in. The prefix is fixed so test assertions can
     // pattern-match on it.
     let raw = format!("StubPda{next:0>32}");
-    let id = RemoteLeaseId::new(raw).map_err(|err| StubError::Std(StdError::msg(err.to_string())))?;
+    let id =
+        RemoteLeaseId::new(raw).map_err(|err| StubError::Std(StdError::msg(err.to_string())))?;
     Ok(OperationResponse::OpenLease(OpenLeaseResponse {
         remote_lease_id: id,
     }))
@@ -408,4 +407,3 @@ pub fn deliver_pending_callback(app: &mut App, controller: &Addr, op: &str) {
         })
         .expect("DeliverPending must succeed against the stand-in");
 }
-

--- a/tests/src/common/remote_lease_controller_stub.rs
+++ b/tests/src/common/remote_lease_controller_stub.rs
@@ -1,0 +1,411 @@
+//! In-test stand-in for the `remote_lease_controller` contract.
+//!
+//! Used by every Lease lifecycle integration test that crosses the
+//! Lease ↔ remote-lease boundary. The stand-in is **not** a mock — it is a
+//! controller-shaped CosmWasm contract running inside `cw-multi-test` that:
+//!
+//! - accepts the production controller's `ExecuteMsg` shape (re-exported
+//!   from `remote_lease_controller::api`) so the lease's outbound stubs
+//!   serialise against the real wire surface,
+//! - mirrors the controller's authorisation rule (every outbound
+//!   `OpenLease` / `CloseLease` / `Swap` / `TransferOut` must come from a
+//!   contract whose code id equals the configured `lease_code`),
+//! - **synthesises the IBC round-trip inline** in the same transaction:
+//!   on every authorised outbound call it emits a `WasmMsg::Execute` back
+//!   to `info.sender` carrying `lease::api::ExecuteMsg::RemoteLeaseCallback`
+//!   with the per-operation response configured for the current test (the
+//!   `Delayed` mode is the exception — see below),
+//! - supports per-operation `ResponseMode::{Ok, Err(reason), Delayed}`,
+//!   set via the test-only `ExecuteMsg::SetResponseMode { op, mode }` and
+//!   stored in `ResponseModes` keyed by operation name (`"open_lease"`,
+//!   `"close_lease"`, `"swap"`, `"transfer_out"`),
+//! - in `Delayed` mode persists the would-be callback (operation name,
+//!   sender, payload) into `PendingCallbacks` so the test can advance
+//!   blocks and then dispatch via `ExecuteMsg::DeliverPending { op }`.
+//!
+//! The synthesised responses are realistic-but-fixed:
+//!
+//! - `OpenLease` → `OperationResponse::OpenLease { remote_lease_id }`
+//!   with a synthetic but valid PDA-looking string (the stub mints a fresh
+//!   one per `OpenLease` call to mirror Solana's unique-per-lease PDA),
+//! - `Swap` → `OperationResponse::Swap { amount_out }` where `amount_out`
+//!   equals the request's configured `min_out` (the literal-floor model
+//!   confirmed in plan §10.A.3 — a happy-path counterparty pays exactly
+//!   the configured floor),
+//! - `TransferOut` → `OperationResponse::TransferOut(TransferOutResponse {})`,
+//!   `CloseLease` → `OperationResponse::CloseLease(CloseLeaseResponse {})`.
+//!
+//! Phase 3-6 of issue #142 wire the lease state machine to actually call
+//! these stub methods. The stand-in itself compiles and exercises today
+//! against the unchanged callback surface (issue #141 / PR #631).
+
+use serde::{Deserialize, Serialize};
+
+use platform::contract::{Code, CodeId};
+use remote_lease::{
+    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    msg::{CloseLeaseParams, OpenLeaseParams, SwapParams, TransferOutParams},
+    response::{
+        CloseLeaseResponse, OpenLeaseResponse, OperationResponse, RemoteLeaseId, SwapResponse,
+        TransferOutResponse,
+    },
+};
+use remote_lease_controller::api::{
+    ChannelResponse, ConfigResponse, InstantiateMsg as ControllerInstantiateMsg,
+    QueryMsg as ControllerQueryMsg,
+};
+use sdk::{
+    cosmwasm_ext::Response as CwResponse,
+    cosmwasm_std::{
+        self, Addr, Binary, Deps, Env, MessageInfo, StdError, StdResult, Storage, Uint64, WasmMsg,
+        to_json_binary,
+    },
+    cw_storage_plus::{Item, Map},
+};
+use thiserror::Error;
+
+use super::{ADMIN, CwContractWrapper, test_case::app::App};
+
+/// Operation tag used both as the storage key (`ResponseModes`,
+/// `PendingCallbacks`) and as the `op` argument of the test-only
+/// `SetResponseMode` / `DeliverPending` variants. Mirroring snake_case
+/// matches the controller's wire idiom.
+pub mod op_tag {
+    pub const OPEN_LEASE: &str = "open_lease";
+    pub const CLOSE_LEASE: &str = "close_lease";
+    pub const SWAP: &str = "swap";
+    pub const TRANSFER_OUT: &str = "transfer_out";
+}
+
+/// How the stand-in answers a given outbound operation.
+///
+/// Default for every operation is [`ResponseMode::Ok`]. `Err` stores the
+/// reason on the same wire shape Solana would use; `Delayed` persists the
+/// callback for later dispatch via [`StubExecuteMsg::DeliverPending`].
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResponseMode {
+    #[default]
+    Ok,
+    Err(RemoteErrorMessage),
+    Delayed,
+}
+
+/// Public stand-in `ExecuteMsg` — production variants come straight from
+/// `remote_lease_controller::api::ExecuteMsg` so the lease serialises against
+/// the real wire surface; the test-only `SetResponseMode` and
+/// `DeliverPending` variants are additive (untagged via `#[serde(untagged)]`
+/// at the top level by re-encoding the controller enum as a flat variant).
+///
+/// `#[serde(deny_unknown_fields)]` is intentionally **not** applied so the
+/// real controller's enum and the additive test variants coexist.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum StubExecuteMsg {
+    OpenChannel(),
+    CloseChannel(),
+    NewLeaseCode {
+        lease_code: Code,
+    },
+    OpenLease {
+        params: OpenLeaseParams,
+        timeout: finance::duration::Duration,
+    },
+    CloseLease {
+        params: CloseLeaseParams,
+        timeout: finance::duration::Duration,
+    },
+    Swap {
+        params: SwapParams,
+        timeout: finance::duration::Duration,
+    },
+    TransferOut {
+        params: TransferOutParams,
+        timeout: finance::duration::Duration,
+    },
+    /// Test-only: configure the stand-in's reply for a given op tag.
+    SetResponseMode {
+        op: String,
+        mode: ResponseMode,
+    },
+    /// Test-only: dispatch the persisted [`ResponseMode::Delayed`] callback
+    /// for the given op tag back to its original sender (the lease).
+    DeliverPending {
+        op: String,
+    },
+}
+
+/// Stand-in state.
+///
+/// `config` mirrors the production controller's `Config`, minus channel
+/// state and protocol-admin enforcement (the test-only `New_LeaseCode`
+/// path is unauthenticated — tests are trusted). `modes` is keyed by op
+/// tag and falls back to `ResponseMode::Ok` on absence. `pending` stores
+/// the most recent `Delayed` callback per op tag.
+const CONFIG: Item<StubConfig> = Item::new("stub_config");
+const MODES: Map<&str, ResponseMode> = Map::new("stub_modes");
+const PENDING: Map<&str, PendingCallback> = Map::new("stub_pending");
+const LEASE_PDA_COUNTER: Item<u64> = Item::new("stub_pda_counter");
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct StubConfig {
+    connection_id: String,
+    dex_label: String,
+    lease_code: Code,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct PendingCallback {
+    sender: Addr,
+    callback: RemoteLeaseCallback,
+}
+
+#[derive(Error, Debug)]
+pub enum StubError {
+    #[error("stub config not initialised")]
+    NotInitialised,
+    #[error("caller {caller} is not registered or has the wrong code id")]
+    Unauthorised { caller: Addr },
+    #[error("no pending callback persisted for op `{op}`")]
+    NoPending { op: String },
+    #[error("std: {0}")]
+    Std(#[from] StdError),
+}
+
+pub fn instantiate(
+    deps: cosmwasm_std::DepsMut<'_>,
+    _env: Env,
+    _info: MessageInfo,
+    msg: ControllerInstantiateMsg,
+) -> Result<CwResponse, StubError> {
+    let lease_code = Code::unchecked(u64::from(msg.lease_code));
+    let config = StubConfig {
+        connection_id: msg.connection_id,
+        dex_label: msg.dex_label,
+        lease_code,
+    };
+    CONFIG.save(deps.storage, &config)?;
+    LEASE_PDA_COUNTER.save(deps.storage, &0)?;
+    Ok(CwResponse::new())
+}
+
+pub fn execute(
+    deps: cosmwasm_std::DepsMut<'_>,
+    _env: Env,
+    info: MessageInfo,
+    msg: StubExecuteMsg,
+) -> Result<CwResponse, StubError> {
+    match msg {
+        StubExecuteMsg::OpenChannel() | StubExecuteMsg::CloseChannel() => Ok(CwResponse::new()),
+        StubExecuteMsg::NewLeaseCode { lease_code } => {
+            CONFIG.update(deps.storage, |existing| -> Result<_, StubError> {
+                Ok(StubConfig {
+                    lease_code,
+                    ..existing
+                })
+            })?;
+            Ok(CwResponse::new())
+        }
+        StubExecuteMsg::OpenLease { params, .. } => {
+            handle_outbound(deps, info, op_tag::OPEN_LEASE, |storage| {
+                synth_open_lease_response(storage, &params)
+            })
+        }
+        StubExecuteMsg::CloseLease { .. } => {
+            handle_outbound(deps, info, op_tag::CLOSE_LEASE, |_| {
+                Ok(OperationResponse::CloseLease(CloseLeaseResponse {}))
+            })
+        }
+        StubExecuteMsg::Swap { params, .. } => {
+            handle_outbound(deps, info, op_tag::SWAP, |_| {
+                Ok(OperationResponse::Swap(SwapResponse {
+                    amount_out: *params.min_out(),
+                }))
+            })
+        }
+        StubExecuteMsg::TransferOut { .. } => {
+            handle_outbound(deps, info, op_tag::TRANSFER_OUT, |_| {
+                Ok(OperationResponse::TransferOut(TransferOutResponse {}))
+            })
+        }
+        StubExecuteMsg::SetResponseMode { op, mode } => {
+            MODES.save(deps.storage, op.as_str(), &mode)?;
+            Ok(CwResponse::new())
+        }
+        StubExecuteMsg::DeliverPending { op } => deliver_pending(deps.storage, op.as_str()),
+    }
+}
+
+pub fn query(deps: Deps<'_>, _env: Env, msg: ControllerQueryMsg) -> StdResult<Binary> {
+    match msg {
+        ControllerQueryMsg::Config() => {
+            let config = CONFIG
+                .load(deps.storage)
+                .map_err(|_| StubError::NotInitialised)?;
+            to_json_binary(&ConfigResponse {
+                connection_id: config.connection_id,
+                dex_label: config.dex_label,
+                lease_code_id: CodeId::from(config.lease_code).into(),
+            })
+        }
+        ControllerQueryMsg::Channel() => {
+            // Channel state is not exercised by the lease-side tests —
+            // the stand-in synthesises the round-trip in-process.
+            to_json_binary(&ChannelResponse { channel: None })
+        }
+        ControllerQueryMsg::ProtocolPackageRelease {} => Err(StdError::msg(
+            "stand-in does not implement ProtocolPackageRelease",
+        )),
+    }
+}
+
+fn handle_outbound<F>(
+    deps: cosmwasm_std::DepsMut<'_>,
+    info: MessageInfo,
+    op: &str,
+    build_ok: F,
+) -> Result<CwResponse, StubError>
+where
+    F: FnOnce(&mut dyn Storage) -> Result<OperationResponse, StubError>,
+{
+    let config = CONFIG
+        .load(deps.storage)
+        .map_err(|_| StubError::NotInitialised)?;
+    require_lease_code(deps.as_ref(), &info, &config)?;
+
+    let mode = MODES
+        .may_load(deps.storage, op)?
+        .unwrap_or(ResponseMode::Ok);
+
+    let callback = match mode {
+        ResponseMode::Ok => RemoteLeaseCallback::OperationOk(build_ok(deps.storage)?),
+        ResponseMode::Err(reason) => RemoteLeaseCallback::OperationErr(reason),
+        ResponseMode::Delayed => {
+            let payload = RemoteLeaseCallback::OperationOk(build_ok(deps.storage)?);
+            PENDING.save(
+                deps.storage,
+                op,
+                &PendingCallback {
+                    sender: info.sender.clone(),
+                    callback: payload,
+                },
+            )?;
+            return Ok(CwResponse::new());
+        }
+    };
+
+    Ok(CwResponse::new().add_message(callback_msg(info.sender, callback)?))
+}
+
+fn require_lease_code(
+    deps: Deps<'_>,
+    info: &MessageInfo,
+    config: &StubConfig,
+) -> Result<(), StubError> {
+    use platform::contract::Validator as _;
+    platform::contract::validator(deps.querier)
+        .check_contract_code(info.sender.clone(), &config.lease_code)
+        .map(|_| ())
+        .map_err(|_| StubError::Unauthorised {
+            caller: info.sender.clone(),
+        })
+}
+
+fn synth_open_lease_response(
+    storage: &mut dyn Storage,
+    _params: &OpenLeaseParams,
+) -> Result<OperationResponse, StubError> {
+    let next = LEASE_PDA_COUNTER.may_load(storage)?.unwrap_or(0) + 1;
+    LEASE_PDA_COUNTER.save(storage, &next)?;
+    // PDA-shaped base58 placeholder; the validation in `RemoteLeaseId::new`
+    // restricts characters but does not enforce on-chain shape — fine for
+    // an integration stand-in. The prefix is fixed so test assertions can
+    // pattern-match on it.
+    let raw = format!("StubPda{next:0>32}");
+    let id = RemoteLeaseId::new(raw).map_err(|err| StubError::Std(StdError::msg(err.to_string())))?;
+    Ok(OperationResponse::OpenLease(OpenLeaseResponse {
+        remote_lease_id: id,
+    }))
+}
+
+fn deliver_pending(storage: &mut dyn Storage, op: &str) -> Result<CwResponse, StubError> {
+    let pending = PENDING
+        .may_load(storage, op)?
+        .ok_or_else(|| StubError::NoPending { op: op.to_owned() })?;
+    PENDING.remove(storage, op);
+    Ok(CwResponse::new().add_message(callback_msg(pending.sender, pending.callback)?))
+}
+
+fn callback_msg(lease: Addr, callback: RemoteLeaseCallback) -> StdResult<WasmMsg> {
+    let payload = lease::api::ExecuteMsg::RemoteLeaseCallback(callback);
+    to_json_binary(&payload).map(|encoded| WasmMsg::Execute {
+        contract_addr: lease.into_string(),
+        msg: encoded,
+        funds: vec![],
+    })
+}
+
+pub struct Instantiator;
+
+impl Instantiator {
+    /// Instantiates the stand-in. `lease_code` is the same `Code` the
+    /// lease contract is registered under in the test app — used for the
+    /// stand-in's authorisation check.
+    #[track_caller]
+    pub fn instantiate(app: &mut App, lease_code: Code) -> Addr {
+        let endpoints = CwContractWrapper::new(execute, instantiate, query);
+        let code_id = app.store_code(Box::new(endpoints));
+
+        let msg = ControllerInstantiateMsg {
+            protocol_admin: sdk::testing::user(ADMIN).into_string(),
+            connection_id: super::test_case::TestCase::DEX_CONNECTION_ID.into(),
+            dex_label: "test-dex".into(),
+            lease_code: Uint64::from(CodeId::from(lease_code)),
+        };
+
+        app.instantiate(
+            code_id,
+            sdk::testing::user(ADMIN),
+            &msg,
+            &[],
+            "remote_lease_controller_stub",
+            None,
+        )
+        .map(|response| response.unwrap_response())
+        .expect("stub controller must instantiate")
+    }
+}
+
+/// Helper for tests: send a `SetResponseMode` to the stub.
+///
+/// `#[allow(dead_code)]` because the four lease-lifecycle test modules
+/// that consume this helper (`remote_lease_open`, `remote_lease_swap`,
+/// `remote_lease_transfer_out`, `remote_lease_close`) target the
+/// post-refactor lease state machine and ship un-registered until issue
+/// #142 Phases 3-6 land. Re-enable the consumers, drop the allow.
+#[allow(dead_code)]
+pub fn set_response_mode(app: &mut App, controller: &Addr, op: &str, mode: ResponseMode) {
+    let msg = StubExecuteMsg::SetResponseMode {
+        op: op.to_owned(),
+        mode,
+    };
+    app.execute(sdk::testing::user(ADMIN), controller.clone(), &msg, &[])
+        .map(|response| {
+            let _ = response.unwrap_response();
+        })
+        .expect("SetResponseMode must succeed against the stand-in");
+}
+
+/// Helper for tests: trigger delivery of a previously stored Delayed
+/// callback for the given op tag. See [`set_response_mode`] for the
+/// `dead_code` rationale.
+#[allow(dead_code)]
+pub fn deliver_pending_callback(app: &mut App, controller: &Addr, op: &str) {
+    let msg = StubExecuteMsg::DeliverPending { op: op.to_owned() };
+    app.execute(sdk::testing::user(ADMIN), controller.clone(), &msg, &[])
+        .map(|response| {
+            let _ = response.unwrap_response();
+        })
+        .expect("DeliverPending must succeed against the stand-in");
+}
+

--- a/tests/src/common/test_case/address_book.rs
+++ b/tests/src/common/test_case/address_book.rs
@@ -21,6 +21,10 @@ pub(crate) struct AddressBook<
     oracle_addr: Oracle,
     time_alarms_addr: TimeAlarms,
     lease_code: Code,
+    /// Stand-in remote-lease controller, instantiated alongside the leaser
+    /// for the lease-side integration tests. `None` until the leaser
+    /// builder step has run; readers should `expect`.
+    remote_lease_controller: Option<Addr>,
 }
 
 impl AddressBook<(), (), (), (), (), (), (), ()> {
@@ -36,6 +40,7 @@ impl AddressBook<(), (), (), (), (), (), (), ()> {
             oracle_addr: (),
             time_alarms_addr: (),
             lease_code,
+            remote_lease_controller: None,
         }
     }
 }
@@ -58,6 +63,7 @@ impl<Treasury, Profit, Reserve, Leaser, Lpp, Oracle, TimeAlarms>
             oracle_addr: self.oracle_addr,
             time_alarms_addr: self.time_alarms_addr,
             lease_code: self.lease_code,
+            remote_lease_controller: self.remote_lease_controller,
         }
     }
 }
@@ -89,6 +95,7 @@ impl<ProtocolsRegistry, Profit, Reserve, Leaser, Lpp, Oracle, TimeAlarms>
             oracle_addr: self.oracle_addr,
             time_alarms_addr: self.time_alarms_addr,
             lease_code: self.lease_code,
+            remote_lease_controller: self.remote_lease_controller,
         }
     }
 }
@@ -121,6 +128,7 @@ impl<ProtocolsRegistry, Treasury, Reserve, Leaser, Lpp, Oracle, TimeAlarms>
             oracle_addr: self.oracle_addr,
             time_alarms_addr: self.time_alarms_addr,
             lease_code: self.lease_code,
+            remote_lease_controller: self.remote_lease_controller,
         }
     }
 }
@@ -156,6 +164,7 @@ impl<ProtocolsRegistry, Treasury, Profit, Leaser, Lpp, Oracle, TimeAlarms>
             oracle_addr: self.oracle_addr,
             time_alarms_addr: self.time_alarms_addr,
             lease_code: self.lease_code,
+            remote_lease_controller: self.remote_lease_controller,
         }
     }
 }
@@ -187,6 +196,7 @@ impl<ProtocolsRegistry, Treasury, Profit, Reserve, Lpp, Oracle, TimeAlarms>
             oracle_addr: self.oracle_addr,
             time_alarms_addr: self.time_alarms_addr,
             lease_code: self.lease_code,
+            remote_lease_controller: self.remote_lease_controller,
         }
     }
 }
@@ -219,6 +229,7 @@ impl<ProtocolsRegistry, Treasury, Profit, Reserve, Leaser, Oracle, TimeAlarms>
             oracle_addr: self.oracle_addr,
             time_alarms_addr: self.time_alarms_addr,
             lease_code: self.lease_code,
+            remote_lease_controller: self.remote_lease_controller,
         }
     }
 }
@@ -251,6 +262,7 @@ impl<ProtocolsRegistry, Treasury, Profit, Reserve, Leaser, Lpp, TimeAlarms>
             oracle_addr,
             time_alarms_addr: self.time_alarms_addr,
             lease_code: self.lease_code,
+            remote_lease_controller: self.remote_lease_controller,
         }
     }
 }
@@ -281,6 +293,7 @@ impl<ProtocolsRegistry, Treasury, Profit, Reserve, Leaser, Lpp, Oracle>
             oracle_addr: self.oracle_addr,
             time_alarms_addr,
             lease_code: self.lease_code,
+            remote_lease_controller: self.remote_lease_controller,
         }
     }
 }
@@ -298,5 +311,23 @@ impl<ProtocolsRegistry, Treasury, Profit, Reserve, Leaser, Lpp, Oracle, TimeAlar
 {
     pub const fn lease_code(&self) -> Code {
         self.lease_code
+    }
+
+    /// Stand-in remote-lease controller address.
+    ///
+    /// Panics if accessed before the leaser builder step has run — that
+    /// step is what installs the stand-in alongside the leaser.
+    pub fn remote_lease_controller(&self) -> &Addr {
+        self.remote_lease_controller
+            .as_ref()
+            .expect("remote-lease controller stand-in must be initialised before access")
+    }
+
+    pub(super) fn set_remote_lease_controller(&mut self, controller: Addr) {
+        debug_assert!(
+            self.remote_lease_controller.is_none(),
+            "remote-lease controller already installed",
+        );
+        self.remote_lease_controller = Some(controller);
     }
 }

--- a/tests/src/common/test_case/builder.rs
+++ b/tests/src/common/test_case/builder.rs
@@ -17,11 +17,12 @@ use sdk::{
 
 use crate::common::{
     self,
-    leaser::{Alarms, Instantiator as LeaserInstantiator},
+    leaser::{Alarms, Instantiator as LeaserInstantiator, LeaserPeers},
     lpp::Instantiator as LppInstantiator,
     oracle::Instantiator as OracleInstantiator,
     profit::Instantiator as ProfitInstantiator,
     protocols::{Instantiator as ProtocolsInstantiator, Registry},
+    remote_lease_controller_stub::Instantiator as RemoteLeaseControllerStubInstantiator,
     reserve::Instantiator as ReserveInstantiator,
     test_case::{OptionalLppEndpoints, OptionalOracleWrapper, TestCase},
     timealarms::Instantiator as TimeAlarmsInstantiator,
@@ -269,6 +270,14 @@ where
             _lpn,
         } = self;
 
+        // Install the controller stand-in first — `LeaserInstantiator`
+        // records its address as `Config.remote_lease_controller` on the
+        // leaser, which then flows into every Lease the leaser opens.
+        let remote_lease_controller = RemoteLeaseControllerStubInstantiator::instantiate(
+            &mut test_case.app,
+            test_case.address_book.lease_code(),
+        );
+
         let leaser_addr = LeaserInstantiator::instantiate(
             &mut test_case.app,
             test_case.address_book.lease_code(),
@@ -278,16 +287,22 @@ where
                 market_price_oracle: test_case.address_book.oracle().clone(),
             },
             test_case.address_book.profit().clone(),
-            test_case.address_book.reserve().clone(),
-            test_case.address_book.protocols_registry().clone(),
+            LeaserPeers {
+                reserve: test_case.address_book.reserve().clone(),
+                protocols_registry: test_case.address_book.protocols_registry().clone(),
+                remote_lease_controller: remote_lease_controller.clone(),
+            },
         );
 
         test_case.app.update_block(cw_test::next_block);
 
+        let mut address_book = test_case.address_book.with_leaser(leaser_addr);
+        address_book.set_remote_lease_controller(remote_lease_controller);
+
         Builder {
             test_case: TestCase {
                 app: test_case.app,
-                address_book: test_case.address_book.with_leaser(leaser_addr),
+                address_book,
             },
             _lpn,
         }

--- a/tests/src/common/test_case/mod.rs
+++ b/tests/src/common/test_case/mod.rs
@@ -109,6 +109,7 @@ impl<ProtocolsRegistry, Treasury>
                 profit: self.address_book.profit().clone(),
                 reserve: self.address_book.reserve().clone(),
                 finalizer: self.address_book.leaser().clone(),
+                remote_lease_controller: self.address_book.remote_lease_controller().clone(),
             },
             InitConfig::new(lease_currency, common::coin(1000), None),
             LeaseInstantiatorConfig::default(),

--- a/tests/src/lease/mod.rs
+++ b/tests/src/lease/mod.rs
@@ -37,6 +37,14 @@ mod heal;
 mod liquidation;
 mod open;
 mod remote_lease_callback;
+// TODO #142 Phase 3: enable when the OpenLease state + Status::OpenFailed land.
+// mod remote_lease_open;
+// TODO #142 Phase 4: enable when SwapExactIn routes through Lease::swap (single-coin per call).
+// mod remote_lease_swap;
+// TODO #142 Phase 5: enable when transfer_in_init / transfer_in_finish route through Lease::transfer_out.
+// mod remote_lease_transfer_out;
+// TODO #142 Phase 6: enable when the CloseLease state + divergence terminal land.
+// mod remote_lease_close;
 mod repay;
 mod slippage;
 

--- a/tests/src/lease/mod.rs
+++ b/tests/src/lease/mod.rs
@@ -38,7 +38,7 @@ mod liquidation;
 mod open;
 mod remote_lease_callback;
 // TODO #142 Phase 3: enable when the OpenLease state + Status::OpenFailed land.
-// mod remote_lease_open;
+mod remote_lease_open;
 // TODO #142 Phase 4: enable when SwapExactIn routes through Lease::swap (single-coin per call).
 // mod remote_lease_swap;
 // TODO #142 Phase 5: enable when transfer_in_init / transfer_in_finish route through Lease::transfer_out.

--- a/tests/src/lease/remote_lease_callback.rs
+++ b/tests/src/lease/remote_lease_callback.rs
@@ -182,10 +182,10 @@ fn drive_to_swap_pending() -> (
 }
 
 fn controller_addr(test_case: &LeaseTestCase) -> Addr {
-    // Mirrors the `Instantiator::instantiate` stand-in: the `reserve`
-    // contract address is configured as each lease's `remote_lease`
-    // controller in the integration-test harness.
-    test_case.address_book.reserve().clone()
+    // The controller stand-in is registered alongside the leaser in
+    // `init_leaser` and exposed on the address book — see
+    // `common::remote_lease_controller_stub`.
+    test_case.address_book.remote_lease_controller().clone()
 }
 
 fn send_callback(

--- a/tests/src/lease/remote_lease_close.rs
+++ b/tests/src/lease/remote_lease_close.rs
@@ -1,0 +1,90 @@
+//! Close-lifecycle E2E (issue #142 Phase 6).
+//!
+//! ⚠️ UNREGISTERED ⚠️ — targets the **post-refactor** lease state machine
+//! and will not compile on `main`. Registration in
+//! `tests/src/lease/mod.rs` is intentionally **omitted**; Phase 6
+//! un-comments the registration once the new `CloseLease` state lands.
+//! See `.claude/handoffs/2026-05-25-issue142-plan.md`, §5 Phase 6 and
+//! §10.C.5 (divergence terminal absorber).
+//!
+//! Acceptance criteria (plan §5 Phase 2 and §4 Q5):
+//!
+//! - `close_lifecycle_happy_path` — after the drain-home TransferOut
+//!   acks all clear and per-currency residuals are zero
+//!   (`invariant_held()`), the lease emits one
+//!   `ExecuteMsg::CloseLease`; on `OperationOk(CloseLease(_))`, the
+//!   lease transitions to the `Closed` terminal.
+//! - `close_divergence_on_error_emits_event_and_stays_queryable` —
+//!   `OperationErr` on `CloseLease` represents Cosmos↔Solana state
+//!   divergence (§4 Q5). Emits `wasm-remote-lease-divergence`, moves
+//!   to the divergence terminal, lease remains queryable for operator
+//!   intervention. Does NOT auto-retry.
+//! - `close_timeout_does_retry_via_time_alarm` — `OperationTimeout`
+//!   on `CloseLease` IS retried (transport fault, not divergence).
+//! - `late_close_ack_after_divergence_is_absorbed` — UNORDERED-channel
+//!   stale-ack absorber on the divergence terminal (§10.C.5): a late
+//!   OK ack returns `Ok` + emits `wasm-remote-lease-late-ack`.
+
+use lease::api::query::StateResponse;
+use remote_lease::{
+    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    response::OperationResponse,
+};
+use sdk::cosmwasm_std::Addr;
+
+use crate::common::remote_lease_controller_stub::{self as stub, ResponseMode, op_tag};
+
+use super::{LeaseCurrency, LeaseTestCase};
+
+#[test]
+fn close_lifecycle_happy_path() {
+    let _test_case = super::create_test_case::<LeaseCurrency>();
+    panic!("Phase 6 must implement CloseLease happy-path driver");
+}
+
+#[test]
+fn close_divergence_on_error_emits_event_and_stays_queryable() {
+    let mut test_case = super::create_test_case::<LeaseCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    let reason = RemoteErrorMessage::new("balance mismatch with solana state")
+        .expect("within length cap");
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::CLOSE_LEASE,
+        ResponseMode::Err(reason),
+    );
+
+    panic!("Phase 6 must implement divergence-terminal assertion + event check");
+}
+
+#[test]
+fn close_timeout_does_retry_via_time_alarm() {
+    let _test_case = super::create_test_case::<LeaseCurrency>();
+    panic!("Phase 6 must implement CloseLease timeout-retry driver");
+}
+
+#[test]
+fn late_close_ack_after_divergence_is_absorbed() {
+    let mut test_case = super::create_test_case::<LeaseCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::CLOSE_LEASE,
+        ResponseMode::Delayed,
+    );
+
+    panic!("Phase 6 must implement late-ack absorber on divergence terminal");
+}
+
+// Silence "unused import" warnings while the module is unregistered.
+#[allow(dead_code)]
+fn _unused_imports_anchor(
+    _: StateResponse,
+    _: RemoteLeaseCallback,
+    _: OperationResponse,
+    _: Addr,
+    _: LeaseTestCase,
+) {
+}

--- a/tests/src/lease/remote_lease_open.rs
+++ b/tests/src/lease/remote_lease_open.rs
@@ -12,7 +12,7 @@ use lease::api::{
 };
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback},
-    response::{OpenLeaseResponse, OperationResponse, RemoteLeaseId},
+    response::{CloseLeaseResponse, OpenLeaseResponse, OperationResponse, RemoteLeaseId},
 };
 use sdk::{cosmwasm_std::Addr, testing};
 
@@ -104,6 +104,87 @@ fn open_failed_on_error_refunds_and_finalises() {
         StateResponse::OpenFailed {
             reason: ref state_reason,
         } => assert_eq!(reason.as_str(), state_reason.as_str()),
+        other => panic!("expected StateResponse::OpenFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn open_failed_on_unexpected_operation_refunds_and_finalises() {
+    let mut test_case = super::create_test_case::<LeaseCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    let leaser = test_case.address_book.leaser().clone();
+    // Hold the lease in the pre-ack `OpenLease` state by deferring the
+    // controller's callback, so the wrong-operation ack below reaches the
+    // `OperationOk(other)` arm rather than the auto-synthesised happy path.
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::OPEN_LEASE,
+        ResponseMode::Delayed,
+    );
+
+    let customer = testing::user(USER);
+    let balance_before = balance::<LeaseCurrency>(&test_case, &customer);
+
+    let response = test_case
+        .app
+        .execute(
+            customer.clone(),
+            leaser.clone(),
+            &leaser::msg::ExecuteMsg::OpenLease {
+                currency: currency::dto::<LeaseCurrency, _>(),
+                max_ltd: None,
+            },
+            &[common::cwcoin::<LeaseCurrency>(DOWNPAYMENT)],
+        )
+        .unwrap()
+        .unwrap_response();
+
+    let lease = lease_address_from(&response.events).expect("instantiate event carries the addr");
+
+    // A `CloseLease` success against an in-flight `OpenLease` can only come
+    // from a buggy or hostile counterparty. The lease must treat it as an
+    // open failure — refund and move to terminal — rather than returning
+    // `Err`, which would revert the controller's ack and strand the relayer.
+    let unexpected =
+        RemoteLeaseCallback::OperationOk(OperationResponse::CloseLease(CloseLeaseResponse {}));
+    let failed = test_case
+        .app
+        .execute(
+            controller.clone(),
+            lease.clone(),
+            &ExecuteMsg::RemoteLeaseCallback(unexpected),
+            &[],
+        )
+        .expect("unexpected operation must be absorbed as an open failure")
+        .unwrap_response();
+
+    let event_reason = failed
+        .events
+        .iter()
+        .find(|event| event.ty == "wasm-ls-remote-lease-open-failed")
+        .and_then(|event| event.attributes.iter().find(|attr| attr.key == "reason"))
+        .map(|attr| attr.value.as_str())
+        .expect("unexpected operation must emit the open-failed event with a reason");
+    assert!(
+        event_reason.starts_with("unexpected operation response"),
+        "reason must name the unexpected variant, got {event_reason:?}",
+    );
+
+    let balance_after = balance::<LeaseCurrency>(&test_case, &customer);
+    assert_eq!(
+        balance_before, balance_after,
+        "downpayment must be refunded in full",
+    );
+
+    let leases = leases_of(&test_case, &leaser, &customer);
+    assert!(leases.is_empty(), "leaser must show no live lease");
+
+    match super::state_query(&test_case, lease) {
+        StateResponse::OpenFailed { reason } => assert!(
+            reason.as_str().starts_with("unexpected operation response"),
+            "terminal reason must name the unexpected variant, got {reason:?}",
+        ),
         other => panic!("expected StateResponse::OpenFailed, got {other:?}"),
     }
 }

--- a/tests/src/lease/remote_lease_open.rs
+++ b/tests/src/lease/remote_lease_open.rs
@@ -1,68 +1,27 @@
-//! Open-lifecycle E2E (issue #142 Phase 3).
-//!
-//! ⚠️ UNREGISTERED ⚠️ — this module targets the **post-refactor** lease
-//! state machine and will not compile on `main`. It is committed alongside
-//! the Test Architect's Phase 2 work as the failing-test layer for Phase 3.
-//! Registration in `tests/src/lease/mod.rs` is intentionally **omitted**;
-//! Phase 3 un-comments the `mod remote_lease_open;` line in that file once
-//! the post-refactor surface lands. See the plan
-//! `.claude/handoffs/2026-05-25-issue142-plan.md`, §5 Phase 2-3, and §10.A.2 /
-//! §10.B.2.
-//!
-//! Targets the post-refactor symbols:
-//!
-//! - `lease::api::query::opening::OngoingTrx::OpenLease { remote_lease: RemoteLeaseId }`
-//!   (renamed from the current `OpenIcaAccount` variant — plan §3.3).
-//! - `lease::api::query::Status::OpenFailed { reason: RemoteErrorMessage }`
-//!   (new top-level status variant — plan §10.B.2).
-//! - The `wasm-remote-lease-open-failed` and `wasm-remote-lease-late-ack`
-//!   events emitted from the post-refactor state machine
-//!   (plan §10.B.2 / §10.A.2).
-//!
-//! Acceptance criteria (plan §5 Phase 2):
-//!
-//! - `open_lifecycle_happy_path` — OpenLease → BuyAsset transition; the
-//!   `remote_lease_id` returned by the stand-in is persisted on the lease
-//!   and visible via `OngoingTrx::OpenLease { remote_lease }`.
-//! - `open_failed_on_error_refunds_and_finalises` — `OperationErr`
-//!   triggers atomic LPP repay + customer downpayment refund + leaser
-//!   finalise + `Status::OpenFailed { reason }` query + the
-//!   `wasm-remote-lease-open-failed` event (§10.B.2).
-//! - `late_open_lease_ack_after_open_failed_is_absorbed` — UNORDERED-channel
-//!   stale-ack absorber (§10.A.2): after the terminal `OpenFailed` is
-//!   reached, a late OK ack returns `Ok` + emits `wasm-remote-lease-late-ack`,
-//!   balances unchanged.
+//! Open-lifecycle E2E for the remote-lease lifecycle: happy path,
+//! `OperationErr` auto-refund, and late-ack absorber on the `OpenFailed`
+//! terminal. Targets the post-refactor query surface (`StateResponse::
+//! OpenFailed`, `OngoingTrx::OpenLease`) and the
+//! `wasm-remote-lease-open-failed` / `wasm-remote-lease-late-ack` events.
 
-use currencies::PaymentGroup;
-use lease::{
-    api::{
-        ExecuteMsg,
-        query::{
-            StateResponse,
-            opening::OngoingTrx as OpeningOngoingTrx,
-            // Symbol introduced in Phase 3:
-            // Status,
-        },
-    },
-    error::ContractError,
+use currencies::Lpn;
+use finance::coin::Coin;
+use lease::api::{
+    ExecuteMsg,
+    query::{StateResponse, opening::OngoingTrx as OpeningOngoingTrx},
 };
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback},
     response::{OpenLeaseResponse, OperationResponse, RemoteLeaseId},
 };
-use sdk::{
-    cosmwasm_std::Addr,
-    cw_multi_test::AppResponse,
-    testing,
-};
+use sdk::{cosmwasm_std::Addr, testing};
 
 use crate::common::{
     self, USER,
     remote_lease_controller_stub::{self as stub, ResponseMode, op_tag},
-    test_case::response::ResponseWithInterChainMsgs,
 };
 
-use super::{LeaseCoin, LeaseCurrency, LeaseTestCase};
+use super::{LeaseCoin, LeaseCurrency};
 
 const DOWNPAYMENT: LeaseCoin = LeaseCoin::new(10_000);
 
@@ -70,11 +29,6 @@ const DOWNPAYMENT: LeaseCoin = LeaseCoin::new(10_000);
 fn open_lifecycle_happy_path() {
     let mut test_case = super::create_test_case::<LeaseCurrency>();
     let lease = super::try_init_lease(&mut test_case, DOWNPAYMENT, None);
-
-    // Driving the funds-transfer + OpenLease ack should land us in the
-    // BuyAsset state with `remote_lease` set to the stand-in's synthetic
-    // PDA. The exact helper signature lands with Phase 3 — for now the
-    // test reads `OngoingTrx::OpenLease { remote_lease }` directly.
 
     let state = super::state_query(&test_case, lease);
 
@@ -96,6 +50,7 @@ fn open_lifecycle_happy_path() {
 fn open_failed_on_error_refunds_and_finalises() {
     let mut test_case = super::create_test_case::<LeaseCurrency>();
     let controller = test_case.address_book.remote_lease_controller().clone();
+    let leaser = test_case.address_book.leaser().clone();
     let reason = RemoteErrorMessage::new("solana side rejected").expect("within length cap");
     stub::set_response_mode(
         &mut test_case.app,
@@ -104,69 +59,162 @@ fn open_failed_on_error_refunds_and_finalises() {
         ResponseMode::Err(reason.clone()),
     );
 
-    // Phase 3 wires the auto-refund batch: LPP repay + downpayment back
-    // to USER + leaser finalise + Status::OpenFailed { reason }.
-    // The exact driver helper lands with Phase 3. Asserted post-conditions:
-    //
-    //   - StateResponse exposes Status::OpenFailed { reason }
-    //   - balance(USER) increased by DOWNPAYMENT
-    //   - leaser reports no live lease for USER
-    //   - the AppResponse carries a `wasm-remote-lease-open-failed` event
+    let customer = testing::user(USER);
+    let downpayment_before = balance::<LeaseCurrency>(&test_case, &customer);
 
-    let _lease = super::try_init_lease(&mut test_case, DOWNPAYMENT, None);
+    let response = test_case
+        .app
+        .execute(
+            customer.clone(),
+            leaser.clone(),
+            &leaser::msg::ExecuteMsg::OpenLease {
+                currency: currency::dto::<LeaseCurrency, _>(),
+                max_ltd: None,
+            },
+            &[common::cwcoin::<LeaseCurrency>(DOWNPAYMENT)],
+        )
+        .unwrap()
+        .unwrap_response();
 
-    // Placeholder — actual assertions hook in with Phase 3. The lease
-    // helper (currently `confirm_ica_and_transfer_funds`) must be
-    // replaced with a `confirm_open_lease_callback` equivalent.
-    panic!(
-        "Phase 3 must implement the OperationErr auto-refund driver; \
-         reason captured: {reason:?}"
+    let event = response
+        .events
+        .iter()
+        .find(|event| event.ty == "wasm-ls-remote-lease-open-failed")
+        .expect("auto-refund must emit the open-failed event");
+    let event_reason = event
+        .attributes
+        .iter()
+        .find(|attr| attr.key == "reason")
+        .map(|attr| attr.value.as_str())
+        .expect("event must carry the counterparty reason");
+    assert_eq!(reason.as_str(), event_reason);
+
+    let downpayment_after = balance::<LeaseCurrency>(&test_case, &customer);
+    assert_eq!(
+        downpayment_before, downpayment_after,
+        "downpayment must be refunded in full",
     );
+
+    let leases = leases_of(&test_case, &leaser, &customer);
+    assert!(leases.is_empty(), "leaser must show no live lease");
+
+    let lease = lease_address_from(&response.events).expect("instantiate event carries the addr");
+    let state = super::state_query(&test_case, lease);
+    match state {
+        StateResponse::OpenFailed {
+            reason: ref state_reason,
+        } => assert_eq!(reason.as_str(), state_reason.as_str()),
+        other => panic!("expected StateResponse::OpenFailed, got {other:?}"),
+    }
 }
 
 #[test]
 fn late_open_lease_ack_after_open_failed_is_absorbed() {
     let mut test_case = super::create_test_case::<LeaseCurrency>();
     let controller = test_case.address_book.remote_lease_controller().clone();
-    // Configure the stub to first time out the OpenLease packet (auto-
-    // refund + transition to OpenFailed). Then dispatch a *late* success
-    // ack via the test-only DeliverPending path.
+    let leaser = test_case.address_book.leaser().clone();
+    let reason = RemoteErrorMessage::new("solana side rejected").expect("within length cap");
     stub::set_response_mode(
         &mut test_case.app,
         &controller,
         op_tag::OPEN_LEASE,
-        ResponseMode::Delayed,
+        ResponseMode::Err(reason.clone()),
     );
 
-    // Drive the open path through the timeout branch; then deliver the
-    // late OK ack and assert:
-    //   - app.execute returns Ok (absorber rule §10.A.2)
-    //   - `wasm-remote-lease-late-ack` event is emitted
-    //   - balances unchanged from the post-refund state
+    let customer = testing::user(USER);
 
-    panic!(
-        "Phase 3 must implement the late-ack absorber driver against \
-         the OpenFailed terminal"
-    );
+    let response = test_case
+        .app
+        .execute(
+            customer.clone(),
+            leaser.clone(),
+            &leaser::msg::ExecuteMsg::OpenLease {
+                currency: currency::dto::<LeaseCurrency, _>(),
+                max_ltd: None,
+            },
+            &[common::cwcoin::<LeaseCurrency>(DOWNPAYMENT)],
+        )
+        .unwrap()
+        .unwrap_response();
+
+    let lease = lease_address_from(&response.events).expect("instantiate event carries the addr");
+    let balance_before = balance::<LeaseCurrency>(&test_case, &customer);
+
+    // Synthesise the late OK ack that ibc-go would deliver against the
+    // already-terminal lease on an UNORDERED channel.
+    let late_callback = RemoteLeaseCallback::OperationOk(OperationResponse::OpenLease(
+        OpenLeaseResponse {
+            remote_lease_id: RemoteLeaseId::new("StubPdaLate111111111111111111111111111".to_owned())
+                .expect("base58 sample"),
+        },
+    ));
+    let late = test_case
+        .app
+        .execute(
+            controller.clone(),
+            lease.clone(),
+            &ExecuteMsg::RemoteLeaseCallback(late_callback),
+            &[],
+        )
+        .expect("late ack must be absorbed by the OpenFailed terminal")
+        .unwrap_response();
+
+    let absorbed = late
+        .events
+        .iter()
+        .any(|event| event.ty == "wasm-ls-remote-lease-late-ack");
+    assert!(absorbed, "OpenFailed must emit the late-ack event");
+
+    let balance_after = balance::<LeaseCurrency>(&test_case, &customer);
+    assert_eq!(balance_before, balance_after, "absorber must be idempotent");
+
+    match super::state_query(&test_case, lease) {
+        StateResponse::OpenFailed {
+            reason: state_reason,
+        } => assert_eq!(reason.as_str(), state_reason.as_str()),
+        other => panic!("expected StateResponse::OpenFailed, got {other:?}"),
+    }
 }
 
-// Silence "unused import" warnings while the module is unregistered.
+fn balance<C>(test_case: &super::LeaseTestCase, account: &Addr) -> Coin<C>
+where
+    C: currency::CurrencyDef,
+{
+    use platform::bank::{self, BankAccountView};
+    bank::account_view(account, test_case.app.query())
+        .balance::<C>()
+        .expect("balance query must succeed")
+}
+
+fn leases_of(
+    test_case: &super::LeaseTestCase,
+    leaser: &Addr,
+    customer: &Addr,
+) -> std::collections::HashSet<Addr> {
+    test_case
+        .app
+        .query()
+        .query_wasm_smart(
+            leaser.clone(),
+            &leaser::msg::QueryMsg::Leases {
+                owner: customer.clone(),
+            },
+        )
+        .unwrap()
+}
+
+fn lease_address_from(events: &[sdk::cosmwasm_std::Event]) -> Option<Addr> {
+    events
+        .iter()
+        .filter(|event| event.ty == "instantiate" || event.ty.starts_with("wasm-"))
+        .flat_map(|event| event.attributes.iter())
+        .find(|attr| attr.key == "_contract_address" || attr.key == "lease_address")
+        .map(|attr| Addr::unchecked(attr.value.clone()))
+}
+
+// Pull `Lpn` into the build graph so its currency definitions are loaded by
+// the tests using LeaseCurrency-side balance queries.
 #[allow(dead_code)]
-fn _unused_imports_anchor(
-    _: PaymentGroup,
-    _: ExecuteMsg,
-    _: ContractError,
-    _: RemoteLeaseCallback,
-    _: OperationResponse,
-    _: OpenLeaseResponse,
-    _: RemoteLeaseId,
-    _: Addr,
-    _: AppResponse,
-    _: ResponseWithInterChainMsgs<'_, AppResponse>,
-    _: LeaseTestCase,
-) -> Option<&'static str> {
-    let _ = common::native_cwcoin(0);
-    let _ = USER;
-    let _ = testing::user("anchor");
-    None
+fn _lpn_anchor() -> currency::CurrencyDTO<currencies::Lpns> {
+    currency::dto::<Lpn, _>()
 }

--- a/tests/src/lease/remote_lease_open.rs
+++ b/tests/src/lease/remote_lease_open.rs
@@ -1,0 +1,172 @@
+//! Open-lifecycle E2E (issue #142 Phase 3).
+//!
+//! ⚠️ UNREGISTERED ⚠️ — this module targets the **post-refactor** lease
+//! state machine and will not compile on `main`. It is committed alongside
+//! the Test Architect's Phase 2 work as the failing-test layer for Phase 3.
+//! Registration in `tests/src/lease/mod.rs` is intentionally **omitted**;
+//! Phase 3 un-comments the `mod remote_lease_open;` line in that file once
+//! the post-refactor surface lands. See the plan
+//! `.claude/handoffs/2026-05-25-issue142-plan.md`, §5 Phase 2-3, and §10.A.2 /
+//! §10.B.2.
+//!
+//! Targets the post-refactor symbols:
+//!
+//! - `lease::api::query::opening::OngoingTrx::OpenLease { remote_lease: RemoteLeaseId }`
+//!   (renamed from the current `OpenIcaAccount` variant — plan §3.3).
+//! - `lease::api::query::Status::OpenFailed { reason: RemoteErrorMessage }`
+//!   (new top-level status variant — plan §10.B.2).
+//! - The `wasm-remote-lease-open-failed` and `wasm-remote-lease-late-ack`
+//!   events emitted from the post-refactor state machine
+//!   (plan §10.B.2 / §10.A.2).
+//!
+//! Acceptance criteria (plan §5 Phase 2):
+//!
+//! - `open_lifecycle_happy_path` — OpenLease → BuyAsset transition; the
+//!   `remote_lease_id` returned by the stand-in is persisted on the lease
+//!   and visible via `OngoingTrx::OpenLease { remote_lease }`.
+//! - `open_failed_on_error_refunds_and_finalises` — `OperationErr`
+//!   triggers atomic LPP repay + customer downpayment refund + leaser
+//!   finalise + `Status::OpenFailed { reason }` query + the
+//!   `wasm-remote-lease-open-failed` event (§10.B.2).
+//! - `late_open_lease_ack_after_open_failed_is_absorbed` — UNORDERED-channel
+//!   stale-ack absorber (§10.A.2): after the terminal `OpenFailed` is
+//!   reached, a late OK ack returns `Ok` + emits `wasm-remote-lease-late-ack`,
+//!   balances unchanged.
+
+use currencies::PaymentGroup;
+use lease::{
+    api::{
+        ExecuteMsg,
+        query::{
+            StateResponse,
+            opening::OngoingTrx as OpeningOngoingTrx,
+            // Symbol introduced in Phase 3:
+            // Status,
+        },
+    },
+    error::ContractError,
+};
+use remote_lease::{
+    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    response::{OpenLeaseResponse, OperationResponse, RemoteLeaseId},
+};
+use sdk::{
+    cosmwasm_std::Addr,
+    cw_multi_test::AppResponse,
+    testing,
+};
+
+use crate::common::{
+    self, USER,
+    remote_lease_controller_stub::{self as stub, ResponseMode, op_tag},
+    test_case::response::ResponseWithInterChainMsgs,
+};
+
+use super::{LeaseCoin, LeaseCurrency, LeaseTestCase};
+
+const DOWNPAYMENT: LeaseCoin = LeaseCoin::new(10_000);
+
+#[test]
+fn open_lifecycle_happy_path() {
+    let mut test_case = super::create_test_case::<LeaseCurrency>();
+    let lease = super::try_init_lease(&mut test_case, DOWNPAYMENT, None);
+
+    // Driving the funds-transfer + OpenLease ack should land us in the
+    // BuyAsset state with `remote_lease` set to the stand-in's synthetic
+    // PDA. The exact helper signature lands with Phase 3 — for now the
+    // test reads `OngoingTrx::OpenLease { remote_lease }` directly.
+
+    let state = super::state_query(&test_case, lease);
+
+    let remote_lease = match state {
+        StateResponse::Opening { in_progress, .. } => match in_progress {
+            OpeningOngoingTrx::OpenLease { remote_lease } => remote_lease,
+            other => panic!("expected OngoingTrx::OpenLease, got {other:?}"),
+        },
+        other => panic!("expected StateResponse::Opening, got {other:?}"),
+    };
+
+    assert!(
+        remote_lease.as_str().starts_with("StubPda"),
+        "expected stand-in PDA prefix, got {remote_lease:?}",
+    );
+}
+
+#[test]
+fn open_failed_on_error_refunds_and_finalises() {
+    let mut test_case = super::create_test_case::<LeaseCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    let reason = RemoteErrorMessage::new("solana side rejected").expect("within length cap");
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::OPEN_LEASE,
+        ResponseMode::Err(reason.clone()),
+    );
+
+    // Phase 3 wires the auto-refund batch: LPP repay + downpayment back
+    // to USER + leaser finalise + Status::OpenFailed { reason }.
+    // The exact driver helper lands with Phase 3. Asserted post-conditions:
+    //
+    //   - StateResponse exposes Status::OpenFailed { reason }
+    //   - balance(USER) increased by DOWNPAYMENT
+    //   - leaser reports no live lease for USER
+    //   - the AppResponse carries a `wasm-remote-lease-open-failed` event
+
+    let _lease = super::try_init_lease(&mut test_case, DOWNPAYMENT, None);
+
+    // Placeholder — actual assertions hook in with Phase 3. The lease
+    // helper (currently `confirm_ica_and_transfer_funds`) must be
+    // replaced with a `confirm_open_lease_callback` equivalent.
+    panic!(
+        "Phase 3 must implement the OperationErr auto-refund driver; \
+         reason captured: {reason:?}"
+    );
+}
+
+#[test]
+fn late_open_lease_ack_after_open_failed_is_absorbed() {
+    let mut test_case = super::create_test_case::<LeaseCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    // Configure the stub to first time out the OpenLease packet (auto-
+    // refund + transition to OpenFailed). Then dispatch a *late* success
+    // ack via the test-only DeliverPending path.
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::OPEN_LEASE,
+        ResponseMode::Delayed,
+    );
+
+    // Drive the open path through the timeout branch; then deliver the
+    // late OK ack and assert:
+    //   - app.execute returns Ok (absorber rule §10.A.2)
+    //   - `wasm-remote-lease-late-ack` event is emitted
+    //   - balances unchanged from the post-refund state
+
+    panic!(
+        "Phase 3 must implement the late-ack absorber driver against \
+         the OpenFailed terminal"
+    );
+}
+
+// Silence "unused import" warnings while the module is unregistered.
+#[allow(dead_code)]
+fn _unused_imports_anchor(
+    _: PaymentGroup,
+    _: ExecuteMsg,
+    _: ContractError,
+    _: RemoteLeaseCallback,
+    _: OperationResponse,
+    _: OpenLeaseResponse,
+    _: RemoteLeaseId,
+    _: Addr,
+    _: AppResponse,
+    _: ResponseWithInterChainMsgs<'_, AppResponse>,
+    _: LeaseTestCase,
+) -> Option<&'static str> {
+    let _ = common::native_cwcoin(0);
+    let _ = USER;
+    let _ = testing::user("anchor");
+    None
+}

--- a/tests/src/lease/remote_lease_open.rs
+++ b/tests/src/lease/remote_lease_open.rs
@@ -142,12 +142,13 @@ fn late_open_lease_ack_after_open_failed_is_absorbed() {
 
     // Synthesise the late OK ack that ibc-go would deliver against the
     // already-terminal lease on an UNORDERED channel.
-    let late_callback = RemoteLeaseCallback::OperationOk(OperationResponse::OpenLease(
-        OpenLeaseResponse {
-            remote_lease_id: RemoteLeaseId::new("StubPdaLate111111111111111111111111111".to_owned())
-                .expect("base58 sample"),
-        },
-    ));
+    let late_callback =
+        RemoteLeaseCallback::OperationOk(OperationResponse::OpenLease(OpenLeaseResponse {
+            remote_lease_id: RemoteLeaseId::new(
+                "StubPdaLate111111111111111111111111111".to_owned(),
+            )
+            .expect("base58 sample"),
+        }));
     let late = test_case
         .app
         .execute(

--- a/tests/src/lease/remote_lease_swap.rs
+++ b/tests/src/lease/remote_lease_swap.rs
@@ -1,0 +1,88 @@
+//! Swap E2E (issue #142 Phase 4).
+//!
+//! ⚠️ UNREGISTERED ⚠️ — this module targets the **post-refactor** lease
+//! state machine and will not compile on `main`. Registration in
+//! `tests/src/lease/mod.rs` is intentionally **omitted**; Phase 4
+//! un-comments it once the post-refactor `SwapExactIn` path lands. See
+//! `.claude/handoffs/2026-05-25-issue142-plan.md`, §5 Phase 4 and
+//! amendment banner 2026-05-27 (swap stays single-coin per call).
+//!
+//! Atomicity model (amendment banner 2026-05-27):
+//!
+//! `Operation::Swap` is **single-coin per call**. If the lease's
+//! `SwapExactIn` path needs to swap multiple currencies, it emits N
+//! sequential single-coin `Lease::swap` calls and decrements
+//! `acks_left = N` per ack (mirroring TransferOut). There is NO batched
+//! `Vec<SwapLeg>` packet. Tests in this file MUST NOT assume a multi-leg
+//! shape.
+//!
+//! Acceptance criteria (plan §5 Phase 2):
+//!
+//! - `swap_single_coin_happy_path` — the post-refactor `SwapExactIn`
+//!   state-enter emits a single `ExecuteMsg::Swap { params, timeout }`
+//!   carrying the lease's coin-in / min-out; the stand-in's
+//!   `OperationResponse::Swap { amount_out = min_out }` ack drives the
+//!   transition to the next state.
+//! - `swap_multi_currency_sequential_acks` — when the lease holds two
+//!   currencies that both need swapping, `SwapExactIn` emits two
+//!   sequential single-coin `Swap` calls; the lease tracks
+//!   `acks_left = 2` and exposes the intermediate state via
+//!   `OngoingTrx`; only after the second ack does it transition.
+//! - `swap_delayed_ack_visible_in_query` — using
+//!   `ResponseMode::Delayed`, the lease's `OngoingTrx` is observable at
+//!   intermediate blocks (the test advances the block before
+//!   `DeliverPending`).
+
+use lease::api::query::{StateResponse, opened::OngoingTrx as OpenedOngoingTrx};
+use remote_lease::{callback::RemoteLeaseCallback, response::OperationResponse};
+use sdk::cosmwasm_std::Addr;
+
+use crate::common::remote_lease_controller_stub::{self as stub, ResponseMode, op_tag};
+
+use super::{LeaseCurrency, LeaseTestCase};
+
+#[test]
+fn swap_single_coin_happy_path() {
+    let _test_case = super::create_test_case::<LeaseCurrency>();
+    panic!("Phase 4 must implement single-coin Swap driver");
+}
+
+#[test]
+fn swap_multi_currency_sequential_acks() {
+    let _test_case = super::create_test_case::<LeaseCurrency>();
+    // Drive the lease into a SwapExactIn state where it holds two
+    // currencies (the buy-asset path or the close path with mixed
+    // balances). Assert: two sequential `ExecuteMsg::Swap` calls, an
+    // `acks_left = 2 → 1 → 0` countdown visible via OngoingTrx.
+    panic!("Phase 4 must implement multi-currency sequential-call assertion");
+}
+
+#[test]
+fn swap_delayed_ack_visible_in_query() {
+    let mut test_case = super::create_test_case::<LeaseCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+
+    // Advance two blocks between the swap emission and the delayed
+    // delivery; assert the lease's OngoingTrx reports the in-flight
+    // swap throughout.
+
+    panic!("Phase 4 must implement delayed-ack visibility driver");
+}
+
+// Silence "unused import" warnings while the module is unregistered.
+#[allow(dead_code)]
+fn _unused_imports_anchor(
+    _: StateResponse,
+    _: OpenedOngoingTrx,
+    _: RemoteLeaseCallback,
+    _: OperationResponse,
+    _: Addr,
+    _: LeaseTestCase,
+) {
+}

--- a/tests/src/lease/remote_lease_transfer_out.rs
+++ b/tests/src/lease/remote_lease_transfer_out.rs
@@ -1,0 +1,93 @@
+//! Drain-home (Solana → Nolus) E2E (issue #142 Phase 5).
+//!
+//! ⚠️ UNREGISTERED ⚠️ — targets the **post-refactor** lease state machine
+//! and will not compile on `main`. Registration in
+//! `tests/src/lease/mod.rs` is intentionally **omitted**; Phase 5
+//! un-comments the registration once the post-refactor `transfer_in_init`
+//! / `transfer_in_finish` paths land. See
+//! `.claude/handoffs/2026-05-25-issue142-plan.md`, §5 Phase 5,
+//! §10.A.6 (TransferOut single-coin per call), and §3.4.
+//!
+//! Atomicity model (ADR §3.5 / plan §10.A.6):
+//!
+//! `Operation::TransferOut` is **single-coin per call**. The lease's
+//! drain-home state-enter emits N `Lease::transfer_out` calls in one
+//! batch (one per held currency); the stand-in synthesises N
+//! independent acks. `acks_left = N` counter decrements per ack;
+//! transition to `CloseLease` after the Nth.
+//!
+//! Acceptance criteria (plan §5 Phase 2):
+//!
+//! - `transfer_out_single_coin_drain_acks` — one held currency → one
+//!   `ExecuteMsg::TransferOut` → one ack → transition.
+//! - `transfer_out_multi_currency_parallel_batch` — N held currencies
+//!   in one drain state-enter → N sequential `ExecuteMsg::TransferOut`
+//!   calls in the same batch; per-currency residual decrements as each
+//!   ack arrives; the in-flight count visible via the query while N-1
+//!   acks remain (`ResponseMode::Delayed` on one of the N).
+//! - `transfer_out_partial_failure_keeps_remaining_in_flight` — for the
+//!   N-1 successful acks, the lease accepts them; the Nth carries
+//!   `OperationErr`, asserting the lease's classifier handles a
+//!   partial-batch failure deterministically (does NOT crash, surfaces
+//!   the failure for operator intervention).
+
+use lease::api::query::{StateResponse, opened::OngoingTrx as OpenedOngoingTrx};
+use remote_lease::{
+    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    response::OperationResponse,
+};
+use sdk::cosmwasm_std::Addr;
+
+use crate::common::remote_lease_controller_stub::{self as stub, ResponseMode, op_tag};
+
+use super::{LeaseCurrency, LeaseTestCase};
+
+#[test]
+fn transfer_out_single_coin_drain_acks() {
+    let _test_case = super::create_test_case::<LeaseCurrency>();
+    panic!("Phase 5 must implement single-coin TransferOut drain driver");
+}
+
+#[test]
+fn transfer_out_multi_currency_parallel_batch() {
+    let mut test_case = super::create_test_case::<LeaseCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    // Use Delayed for the first TransferOut ack; assert that after the
+    // second arrives, the lease still reports the first as in-flight.
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::TRANSFER_OUT,
+        ResponseMode::Delayed,
+    );
+
+    panic!("Phase 5 must implement N-coin TransferOut batch + in-flight assertion");
+}
+
+#[test]
+fn transfer_out_partial_failure_keeps_remaining_in_flight() {
+    let mut test_case = super::create_test_case::<LeaseCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    let reason = RemoteErrorMessage::new("partial drain failure")
+        .expect("within length cap");
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::TRANSFER_OUT,
+        ResponseMode::Err(reason),
+    );
+
+    panic!("Phase 5 must implement partial-batch failure driver");
+}
+
+// Silence "unused import" warnings while the module is unregistered.
+#[allow(dead_code)]
+fn _unused_imports_anchor(
+    _: StateResponse,
+    _: OpenedOngoingTrx,
+    _: RemoteLeaseCallback,
+    _: OperationResponse,
+    _: Addr,
+    _: LeaseTestCase,
+) {
+}

--- a/tests/src/lpp_tests.rs
+++ b/tests/src/lpp_tests.rs
@@ -920,6 +920,7 @@ fn instantiate_lease<ProtReg, Tr>(
             profit: test_case.address_book.profit().clone(),
             reserve: test_case.address_book.reserve().clone(),
             finalizer: test_case.address_book.leaser().clone(),
+            remote_lease_controller: test_case.address_book.remote_lease_controller().clone(),
         },
         LeaseInitConfig::new(
             currency::dto::<LeaseCurrency, _>(),


### PR DESCRIPTION
## Summary

Switch the Nolus lease contract's open-side lifecycle from the legacy ICA-open + DEX-side path to remote-lease controller stubs that bridge to a Solana counterparty via IBC. Lays the foundation for `nolus-protocol/ibc-solray#142`. Subsequent work (swap replacement, TransferOut, CloseLease, leaser v8 bump, dead-code removal) lands in follow-up PRs.

## Changes

- **New `OpenLease` state** (`protocol/contracts/lease/src/contract/state/opening/open_lease.rs`). `RequestLoan::on_response` now emits `Factory::open` to the configured `remote_lease_controller` and transitions to `OpenLease`. On `OperationOk` the lease threads the Solana-side `RemoteLeaseId` into the existing `super::buy_asset::start` cascade (additive — legacy `OpenIcaAccount` → `BuyAsset` path retained for now). On `OperationErr` / `OperationTimeout` an atomic refund batch repays the LPP loan, returns the downpayment, calls `LeasesRef::finalize_lease`, emits `wasm-ls-remote-lease-open-failed`, and transitions to the new `OpenFailed` terminal.
- **New `OpenFailed` terminal** (`protocol/contracts/lease/src/contract/state/open_failed.rs`). Authenticated late-ack absorber for UNORDERED-channel stale OK acks — emits `wasm-ls-remote-lease-late-ack`, no state mutation. Gated by `LeasesRef::remote_lease_callback_permission` even though idempotent.
- **`LeaseDTO.remote_lease_id: RemoteLeaseId`** (non-optional) persists the Solana PDA. Storage v9→v10 with refuse-migrate (`UnsupportedMigration`); mainnet v9-population is zero so the refuse is correct.
- **Query surface**: new `StateResponse::OpenFailed { reason }`. `OngoingTrx` reshaped — `OpenIcaAccount` unit variant dropped, `RequestingOpenLease` (pre-ack, no PDA known) and `OpenLease { remote_lease }` (post-ack) added.
- **Leaser `Leases::save`** returns `SaveOutcome::{Registered, AlreadyRegistered, Cancelled}`. New `CANCELLED_PENDING` Storage sentinel set by `Leases::remove` lets `save` distinguish a deliberate auto-refund cancellation (`Ok(Cancelled)`) from a missing `cache_open_req` programmer error (`Err(PendingCustomerNotCached)`). Address collisions surface as `DuplicateLeaseAddress` rather than a silent `debug_assert!`.
- **`NewLeaseContract`** gains `remote_lease_controller: Addr` + `expected_instance_ordinal: u16`, populated by `Borrow::open_lease_msg` from the leaser `Config`.
- **`OpenLeaseParams::new`** wire invariant relaxed: only `lpn_currency != asset_currency` is enforced. `downpayment` may overlap either of the other two. Cross-repo follow-up filed at `nolus-protocol/ibc-solray#331`.
- **Stand-in remote-lease controller** in `tests/src/common/remote_lease_controller_stub.rs` drives the three new integration tests.

## Verification

- Built and lint-clean across the affected crates (`cargo clippy --features=dex-osmosis --all-targets -- -D warnings` on lease, leaser, remote_lease, remote_lease_wire, and integration_tests).
- Unit tests pass: lease 88, leaser 33, remote_lease 42, remote_lease_wire 52.
- Integration tests pass: 119 passed / 0 failed / 1 ignored under `dex-osmosis`. Three new lifecycle tests landed: `open_lifecycle_happy_path`, `open_failed_on_error_refunds_and_finalises`, `late_open_lease_ack_after_open_failed_is_absorbed`.

## Off-chain consumer coordination (release-blocking)

- **`nolus-protocol/ibc-solray#331`** — Solana side must tolerate the relaxed `OpenLeaseParams` invariant (`downpayment == lpn` and `downpayment == asset`). Re-tighten on the Nolus side if Solana cannot handle one or both.
- **`nolus-protocol/ibc-solray#297`** — remote-profit migration still open; gates the eventual `swap` crate deletion.
- **Frontend `app.nolus.io`** — handle the new `OngoingTrx::RequestingOpenLease` + `OngoingTrx::OpenLease { remote_lease }` variants and the new `StateResponse::OpenFailed { reason }` top-level variant. `OngoingTrx::OpenIcaAccount` is removed.
- **Indexer / explorer** — subscribe to `wasm-ls-remote-lease-open-failed` and `wasm-ls-remote-lease-late-ack` events.
- **Deploy script (`scripts/deploy-protocol.sh:196`)** — must populate `expected_instance_ordinal` and `remote_lease_controller` on the leaser `InstantiateMsg`. Without these the leaser will fail to instantiate.

## Follow-ups (out of scope for this PR)

- Swap replacement (controller-driven `Lease::swap` replaces the in-lease DEX path).
- TransferOut / drain-home replacement.
- CloseLease state.
- Bounded retry + poison-callback terminal.
- Leaser v7 → v8 bump.
- Dead-code removal (`OpenIcaAccount`, `swap` crate, `dex::IcaConnector` from lease).
- Operator runbook for `Status::OpenFailed` (drafted; lives in local memory pending operator-docs landing).