### PR TITLE
feat(remote-lease): pair the transfer channel in the handshake version

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -29,14 +29,45 @@ Tried first (did not work): `cargo build` from the bare worktree; setting `SOFTW
 
 **Fix:** Put developer-local env in `protocol/.cargo/config.toml` (or any nested workspace `.cargo/config.toml`). `.gitignore:13` already excludes `**/.cargo` while keeping the tracked root file (`!/.cargo/`), so the override is automatically ignored. Cargo merges nested files over the root one when invoked from the protocol workspace.
 
-Example `protocol/.cargo/config.toml`:
+Example `protocol/.cargo/config.toml` (the `PROTOCOL_*` trio is read by the
+workspace-wide gates; the values mirror `ci/Containerfile`'s `ENV` block):
 
 ```
 [env]
 SOFTWARE_RELEASE_ID = "dev-release"
+PROTOCOL_NETWORK = "ci-network"
+PROTOCOL_NAME = "ci-protocol"
+PROTOCOL_RELEASE_ID = "ci-protocol-release"
 ```
 
 Tried first (rejected at review): editing the tracked `/.cargo/config.toml`.
+
+### Local clippy (1.95) diverges from CI clippy (1.94)
+
+**Symptom:** `cargo lint` / `cargo lint-all` fails locally on lints CI does not
+run (e.g. `unnecessary_sort_by` in the untouched oracle contract), or passes
+locally while CI fails — the verdicts differ on identical code.
+
+**Cause:** There is no `rust-toolchain.toml`; CI pins its toolchain via the
+`rust_image_digest` build argument in `ci/Containerfile` (currently 1.94),
+while the local default toolchain follows `rustup` (currently 1.95). Clippy
+adds and tightens lints between minor releases.
+
+**Fix:** Run the gate on the CI-pinned toolchain:
+
+```
+rustup toolchain install 1.94.0
+cargo +1.94.0 lint
+cargo +1.94.0 lint-all
+cargo +1.94.0 run-test
+```
+
+A local-only finding from a newer clippy is not a gate failure — fix it only
+if it survives on 1.94. Bump the pinned version here in lockstep with
+`ci/Containerfile`.
+
+Tried first (did not work): treating local 1.95-only findings as CI blockers
+and patching untouched code to silence them.
 
 ## CosmWasm
 

--- a/docs/remote-lease-wire-contract.md
+++ b/docs/remote-lease-wire-contract.md
@@ -5,6 +5,7 @@ The `remote_lease` crate defines the IBC packet types exchanged between the Nolu
 ## Pinned constants
 
 - Protocol version: `nls-remote-lease.v1` (`remote_lease::VERSION`). Encoded on every packet as the `ProtocolVersion` ZST; mismatches are rejected at deserialisation, not in business code.
+- Channel handshake version: `nls-remote-lease.v1+transfer=channel-<N>` — the protocol version extended with the Solana-side ICS-20 transfer channel paired with the lease channel (ADR-0002 §3.3, ibc-solray#322/#388). The controller composes it from its `transfer_channel` config at `MsgChannelOpenInit`, requires it on every handshake callback, and verifies the counterparty's echoed version on `OpenAck`; the responder validates the suffix and persists the binding. `channel-<N>` is canonical: `channel-` prefix, decimal ordinal, no sign or leading zeros, within `u16` range. The suffix exists at the handshake layer only — the per-packet `ProtocolVersion` pin stays bare.
 - IBC port: `nls-remote-lease.<dex>` — built via `remote_lease::port_id_for`.
 - Callback error payload: max 512 bytes (`OPERATION_ERR_MAX_BYTES`); enforced in the `RemoteErrorMessage` visitor before allocation.
 - Remote-lease id: the Solana lease PDA, carried on `OperationResponse::OpenLease.remote_lease_id` as a `RemoteLeaseId`. The Solana Remote Lease App MUST emit it as the canonical base58 encoding of the 32-byte PDA pubkey (32–44 chars); the controller rejects any non-base58 or over-64-byte value (`REMOTE_LEASE_ID_MAX_BYTES`) at ack-decode. This id is **load-bearing** — it is the recipient of the Nolus→Solana funds push, not merely observability — so a non-conforming value fails closed (the lease strands at the OpenLease ack, before any funds move) rather than risk a transfer to a bad address. A conforming counterparty never trips the check; the only path to a reject is a Solana-side bug, which the light-client trust model already excludes from normal operation.
@@ -52,7 +53,7 @@ On `ibc_packet_ack` and `ibc_packet_timeout` the controller decodes the original
 
 mapping the IBC outcomes:
 
-- `StdAck::Success(data)` → `RemoteLeaseCallback::OperationOk(OperationResponse)` (decoded from `data`).
+- `StdAck::Success(data)` → `RemoteLeaseCallback::OperationOk(OperationResponse)` — decoded from `data` as the **wire shape only** (#637): the controller validates that the payload is a well-formed response, while currency-registry validation belongs to the addressee lease, which absorbs content failures so the ack commits.
 - `StdAck::Error(message)` → `RemoteLeaseCallback::OperationErr(RemoteErrorMessage)` (rejected if > 512 bytes).
 - timeout → `RemoteLeaseCallback::OperationTimeout` (unit; the original `Operation` is recoverable from the lease's own pending-state).
 

--- a/protocol/contracts/lease/src/api/mod.rs
+++ b/protocol/contracts/lease/src/api/mod.rs
@@ -121,7 +121,7 @@ pub enum FinalizerExecuteMsg {
 mod test {
     use remote_lease::{
         callback::{RemoteErrorMessage, RemoteLeaseCallback},
-        response::{CloseLeaseResponse, OperationResponse},
+        response::{CloseLeaseResponse, WireOperationResponse},
     };
     use sdk::cosmwasm_std;
 
@@ -149,7 +149,7 @@ mod test {
     #[test]
     fn test_remote_lease_callback_operation_ok_representation() {
         let msg = ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback::OperationOk(
-            OperationResponse::CloseLease(CloseLeaseResponse {}),
+            WireOperationResponse::CloseLease(CloseLeaseResponse {}),
         ));
         let bin = cosmwasm_std::to_json_vec(&msg).expect("serialization failed");
         assert_eq!(

--- a/protocol/contracts/lease/src/api/mod.rs
+++ b/protocol/contracts/lease/src/api/mod.rs
@@ -88,17 +88,16 @@ pub enum ExecuteMsg {
     ///
     /// Invoked by the configured `remote_lease` controller contract after it
     /// receives an IBC ack or timeout for an operation it dispatched on this
-    /// lease's behalf. Only the currently-pending dex sub-state of the lease
-    /// accepts the callback; it authorises `info.sender == remote_lease`,
-    /// classifies the variant, and forwards it through the existing
-    /// `on_dex_response` / `on_dex_error` / `on_dex_timeout` pipeline — which
-    /// itself enters the `ResponseDelivery` + `DexCallback` safe-delivery
-    /// machinery. Synchronous failures (auth mismatch, serialisation,
-    /// pre-`ResponseDelivery` storage faults) propagate as `Err` and revert
-    /// the controller's `ibc_packet_ack`, letting the relayer retry the same
-    /// ack; once `ResponseDelivery` state is persisted the controller's ack
-    /// commits and the inner work runs via the lease's own time-alarm
-    /// fallback on error.
+    /// lease's behalf. The lease authorises the caller through its leaser
+    /// (`CheckRemoteLeaseCallbackPermission`), classifies the variant, and
+    /// routes it into the state's dedicated `on_remote_response` /
+    /// `on_remote_error` / `on_remote_timeout` entry points: the leg that
+    /// scheduled the remote operation processes the acknowledgment directly,
+    /// while every other state absorbs the callback with an event — never an
+    /// `Err` — so the controller's `ibc_packet_ack` commits. Only synchronous
+    /// faults whose retry belongs to the relayer (auth mismatch,
+    /// serialisation, storage) propagate as `Err` and revert the controller's
+    /// ack.
     RemoteLeaseCallback(RemoteLeaseCallback),
 
     /// Heal a lease past a middleware failure

--- a/protocol/contracts/lease/src/contract/state/dex.rs
+++ b/protocol/contracts/lease/src/contract/state/dex.rs
@@ -6,7 +6,7 @@ use finance::instant::Instant;
 use platform::{ica::ErrorResponse as ICAErrorResponse, state_machine};
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback},
-    response::OperationResponse,
+    response::WireOperationResponse,
 };
 use sdk::cosmwasm_std::{self, Binary, Env, MessageInfo, QuerierWrapper, Reply};
 
@@ -178,7 +178,7 @@ where
 
     fn deliver_remote_ok(
         self,
-        response: &OperationResponse,
+        response: &WireOperationResponse,
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> ContractResult<Response> {

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -16,7 +16,7 @@ use platform::{
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback},
     msg::OpenLeaseParams,
-    response::{OpenLeaseResponse, OperationResponse, RemoteLeaseId},
+    response::{OpenLeaseResponse, RemoteLeaseId, WireOperationResponse},
     stub::{ControllerInnerMessage, Factory},
 };
 use sdk::cosmwasm_std::{Addr, Env, MessageInfo, QuerierWrapper};
@@ -222,7 +222,7 @@ impl Contract for OpenLease {
     ) -> ContractResult<Response> {
         self.authz_callback(querier, &info)
             .and_then(|()| match callback {
-                RemoteLeaseCallback::OperationOk(OperationResponse::OpenLease(
+                RemoteLeaseCallback::OperationOk(WireOperationResponse::OpenLease(
                     OpenLeaseResponse { remote_lease_id },
                 )) => self.on_open_lease_ack(remote_lease_id, querier, &env),
                 RemoteLeaseCallback::OperationOk(_unexpected) => {

--- a/protocol/contracts/remote_lease/src/api.rs
+++ b/protocol/contracts/remote_lease/src/api.rs
@@ -123,9 +123,10 @@ pub struct ChannelResponse {
 
 #[cfg(test)]
 mod test {
-    use platform::tests as platform_tests;
+    use platform::{contract::Code, tests as platform_tests};
+    use sdk::cosmwasm_std::Uint64;
 
-    use super::QueryMsg;
+    use super::{ConfigResponse, QueryMsg};
 
     #[test]
     fn release() {
@@ -133,5 +134,19 @@ mod test {
             QueryMsg::ProtocolPackageRelease {},
             platform_tests::ser_de(&versioning::query::ProtocolPackage::Release {}).unwrap(),
         );
+    }
+
+    #[test]
+    fn config_response_new() {
+        let response = ConfigResponse::new(
+            "connection-7".into(),
+            "osmosis".into(),
+            "channel-3".into(),
+            Code::unchecked(9),
+        );
+        assert_eq!("connection-7", response.connection_id);
+        assert_eq!("osmosis", response.dex_label);
+        assert_eq!("channel-3", response.transfer_channel);
+        assert_eq!(Uint64::new(9), response.lease_code_id);
     }
 }

--- a/protocol/contracts/remote_lease/src/api.rs
+++ b/protocol/contracts/remote_lease/src/api.rs
@@ -13,6 +13,10 @@ pub struct InstantiateMsg {
     pub protocol_admin: String,
     pub connection_id: String,
     pub dex_label: String,
+    /// The Solana-side ICS-20 transfer channel paired with this protocol's lease
+    /// channel, in canonical `channel-<N>` form. Proposed to the counterparty in
+    /// the lease channel's handshake version (ADR-0002 §3.3).
+    pub transfer_channel: String,
     // External system API — accept `Uint64`; the contract wraps it in `Code` after validation.
     pub lease_code: Uint64,
 }
@@ -73,14 +77,21 @@ pub enum QueryMsg {
 pub struct ConfigResponse {
     pub connection_id: String,
     pub dex_label: String,
+    pub transfer_channel: String,
     pub lease_code_id: Uint64,
 }
 
 impl ConfigResponse {
-    pub fn new(connection_id: String, dex_label: String, lease_code: Code) -> Self {
+    pub fn new(
+        connection_id: String,
+        dex_label: String,
+        transfer_channel: String,
+        lease_code: Code,
+    ) -> Self {
         Self {
             connection_id,
             dex_label,
+            transfer_channel,
             lease_code_id: CodeId::from(lease_code).into(),
         }
     }

--- a/protocol/contracts/remote_lease/src/contract.rs
+++ b/protocol/contracts/remote_lease/src/contract.rs
@@ -47,6 +47,7 @@ pub fn instantiate(
 ) -> Result<CwResponse> {
     require_non_empty("connection_id", &new_controller.connection_id)
         .and_then(|()| require_non_empty("dex_label", &new_controller.dex_label))
+        .and_then(|()| require_canonical_transfer_channel(&new_controller.transfer_channel))
         .and_then(|()| {
             deps.api
                 .addr_validate(new_controller.protocol_admin.as_str())
@@ -72,6 +73,7 @@ pub fn instantiate(
             Config::new(
                 new_controller.connection_id,
                 new_controller.dex_label,
+                new_controller.transfer_channel,
                 lease_code,
             )
             .store(deps.storage)
@@ -166,6 +168,25 @@ fn require_non_empty(field: &'static str, value: &str) -> Result<()> {
     } else {
         Ok(())
     }
+}
+
+const TRANSFER_CHANNEL_NAME_PREFIX: &str = "channel-";
+
+/// Accept only the canonical decimal rendering of a `u16` ordinal — the
+/// counterparty's responder rejects leading zeros, signs, and ordinals beyond
+/// its 16-bit entity range, so a non-canonical id would fail the handshake
+/// cross-chain instead of failing here at instantiation.
+fn require_canonical_transfer_channel(channel_id: &str) -> Result<()> {
+    channel_id
+        .strip_prefix(TRANSFER_CHANNEL_NAME_PREFIX)
+        .and_then(|ordinal| {
+            ordinal
+                .parse::<u16>()
+                .ok()
+                .filter(|parsed| parsed.to_string() == ordinal)
+        })
+        .map(|_ordinal| ())
+        .ok_or_else(|| Error::NonCanonicalTransferChannel(channel_id.to_string()))
 }
 
 fn authorize_protocol_admin_only(store: &dyn Storage, call_message: &MessageInfo) -> Result<()> {

--- a/protocol/contracts/remote_lease/src/contract.rs
+++ b/protocol/contracts/remote_lease/src/contract.rs
@@ -1,4 +1,7 @@
-use std::ops::{Deref, DerefMut};
+use std::{
+    mem,
+    ops::{Deref, DerefMut},
+};
 
 use access_control::SingleUserAccess;
 use cosmwasm_std::Storage;
@@ -94,8 +97,12 @@ pub fn migrate(
 ) -> Result<CwResponse> {
     migrate_from
         .update_software(&CURRENT_RELEASE, &to_release)
-        .map(|()| response::empty_response())
         .map_err(Error::UpdateSoftware)
+        // Probe the stored config against the current schema: an instance whose
+        // config predates a required field must fail here, reverting the
+        // upgrade, rather than brick on the first post-upgrade load.
+        .and_then(|()| Config::load(deps.storage).map(mem::drop))
+        .map(|()| response::empty_response())
         .inspect_err(platform_error::log(deps.api))
 }
 

--- a/protocol/contracts/remote_lease/src/contract.rs
+++ b/protocol/contracts/remote_lease/src/contract.rs
@@ -1,7 +1,4 @@
-use std::{
-    mem,
-    ops::{Deref, DerefMut},
-};
+use std::ops::{Deref, DerefMut};
 
 use access_control::SingleUserAccess;
 use cosmwasm_std::Storage;
@@ -30,7 +27,7 @@ use versioning::{
 use crate::{
     api::{ChannelResponse, ConfigResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg},
     error::{Error, Result},
-    ibc as ibc_msg,
+    ibc as ibc_msg, state,
     state::{Channel, Config},
 };
 
@@ -98,10 +95,7 @@ pub fn migrate(
     migrate_from
         .update_software(&CURRENT_RELEASE, &to_release)
         .map_err(Error::UpdateSoftware)
-        // Probe the stored config against the current schema: an instance whose
-        // config predates a required field must fail here, reverting the
-        // upgrade, rather than brick on the first post-upgrade load.
-        .and_then(|()| Config::load(deps.storage).map(mem::drop))
+        .and_then(|()| Config::require_current_schema(deps.storage))
         .map(|()| response::empty_response())
         .inspect_err(platform_error::log(deps.api))
 }
@@ -177,23 +171,14 @@ fn require_non_empty(field: &'static str, value: &str) -> Result<()> {
     }
 }
 
-const TRANSFER_CHANNEL_NAME_PREFIX: &str = "channel-";
-
-/// Accept only the canonical decimal rendering of a `u16` ordinal — the
-/// counterparty's responder rejects leading zeros, signs, and ordinals beyond
-/// its 16-bit entity range, so a non-canonical id would fail the handshake
-/// cross-chain instead of failing here at instantiation.
+/// Reject a non-canonical channel id here, at instantiation, instead of
+/// letting the handshake fail cross-chain at the counterparty's responder.
 fn require_canonical_transfer_channel(channel_id: &str) -> Result<()> {
-    channel_id
-        .strip_prefix(TRANSFER_CHANNEL_NAME_PREFIX)
-        .and_then(|ordinal| {
-            ordinal
-                .parse::<u16>()
-                .ok()
-                .filter(|parsed| parsed.to_string() == ordinal)
-        })
-        .map(|_ordinal| ())
-        .ok_or_else(|| Error::NonCanonicalTransferChannel(channel_id.to_string()))
+    if state::canonical_transfer_channel(channel_id) {
+        Ok(())
+    } else {
+        Err(Error::NonCanonicalTransferChannel(channel_id.to_string()))
+    }
 }
 
 fn authorize_protocol_admin_only(store: &dyn Storage, call_message: &MessageInfo) -> Result<()> {

--- a/protocol/contracts/remote_lease/src/contract/tests/execute_admin.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/execute_admin.rs
@@ -1,7 +1,9 @@
 use platform::contract::{Code, CodeId};
 use sdk::{
+    cosmos_sdk_proto::prost::Message as _,
     cosmwasm_ext::{CosmosMsg, SubMsg},
     cosmwasm_std::{AnyMsg, IbcMsg, Uint64, testing},
+    ibc_proto::ibc::core::channel::v1::MsgChannelOpenInit,
 };
 
 use crate::{
@@ -12,8 +14,9 @@ use crate::{
 };
 
 use super::{
-    ADMIN, LEASE_CODE_ID, LOCAL_CHANNEL_ID, NON_ADMIN, deps, instantiate_default, instantiate_msg,
-    query_channel, query_config, sender, store_closing_channel, store_open_channel,
+    ADMIN, LEASE_CODE_ID, LOCAL_CHANNEL_ID, NON_ADMIN, VERSION, deps, instantiate_default,
+    instantiate_msg, query_channel, query_config, sender, store_closing_channel,
+    store_open_channel,
 };
 
 #[test]
@@ -64,7 +67,12 @@ fn open_channel_admin_emits_any_msg() {
             ..
         } => {
             assert_eq!(CHANNEL_OPEN_INIT, type_url);
-            assert!(!value.is_empty());
+            let open_init =
+                MsgChannelOpenInit::decode(value.as_slice()).expect("a valid protobuf payload");
+            assert_eq!(
+                VERSION,
+                open_init.channel.expect("a channel must be set").version,
+            );
         }
         other => panic!("expected CosmosMsg::Any, got {other:?}"),
     }

--- a/protocol/contracts/remote_lease/src/contract/tests/instantiate.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/instantiate.rs
@@ -10,8 +10,8 @@ use sdk::{
 use crate::{api::InstantiateMsg, contract::instantiate, error::Error};
 
 use super::{
-    CONNECTION_ID, CREATOR, DEX_LABEL, LEASE_CODE_ID, deps, instantiate_msg, query_channel,
-    query_config, sender,
+    CONNECTION_ID, CREATOR, DEX_LABEL, LEASE_CODE_ID, TRANSFER_CHANNEL, deps, instantiate_msg,
+    query_channel, query_config, sender,
 };
 
 #[test]
@@ -29,6 +29,7 @@ fn proper_initialization() {
     let config = query_config(deps.as_ref());
     assert_eq!(CONNECTION_ID, config.connection_id);
     assert_eq!(DEX_LABEL, config.dex_label);
+    assert_eq!(TRANSFER_CHANNEL, config.transfer_channel);
     assert_eq!(
         Uint64::from(CodeId::from(Code::unchecked(LEASE_CODE_ID))),
         config.lease_code_id,
@@ -64,6 +65,36 @@ fn instantiate_rejects_empty_dex_label() {
         matches!(err, Error::EmptyInstantiateField("dex_label")),
         "got {err:?}"
     );
+}
+
+// Mirrors the Solana responder's canonical-channel-id rules: `channel-`
+// prefix, decimal ordinal with no sign or leading zeros, within `u16` range.
+#[test]
+fn instantiate_rejects_non_canonical_transfer_channel() {
+    const NON_CANONICAL: [&str; 8] = [
+        "",
+        "42",
+        "channel-",
+        "channel-abc",
+        "channel-007",
+        "channel-+5",
+        "channel-70000",
+        "transfer/channel-4",
+    ];
+
+    for transfer_channel in NON_CANONICAL {
+        let mut deps = deps();
+        let msg = InstantiateMsg {
+            transfer_channel: transfer_channel.into(),
+            ..instantiate_msg()
+        };
+        let err =
+            instantiate(deps.as_mut(), testing::mock_env(), sender(CREATOR), msg).unwrap_err();
+        assert!(
+            matches!(err, Error::NonCanonicalTransferChannel(_)),
+            "expected reject for {transfer_channel:?}, got {err:?}"
+        );
+    }
 }
 
 #[test]

--- a/protocol/contracts/remote_lease/src/contract/tests/migrate.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/migrate.rs
@@ -55,6 +55,38 @@ fn migrate_with_pre_transfer_channel_config_rejected() {
     );
 }
 
+// Overwrites the stored config with a current-shape value the current code
+// would never have accepted (non-canonical transfer channel) — the probe must
+// refuse the upgrade on the invariant, not just on deserialization.
+#[test]
+fn migrate_with_invariant_violating_config_rejected() {
+    #[derive(Serialize, Deserialize)]
+    struct RawConfig {
+        connection_id: String,
+        dex_label: String,
+        transfer_channel: String,
+        lease_code: Code,
+    }
+    const RAW_STORAGE: Item<RawConfig> = Item::new("config");
+
+    let mut deps = deps();
+    instantiate_default(deps.as_mut());
+    RAW_STORAGE
+        .save(
+            deps.as_mut().storage,
+            &RawConfig {
+                connection_id: CONNECTION_ID.into(),
+                dex_label: DEX_LABEL.into(),
+                transfer_channel: "channel-007".into(),
+                lease_code: Code::unchecked(LEASE_CODE_ID),
+            },
+        )
+        .unwrap();
+
+    let err = migrate(deps.as_mut(), testing::mock_env(), migrate_msg()).unwrap_err();
+    assert!(matches!(err, Error::MalformedStoredConfig), "got {err:?}");
+}
+
 #[test]
 fn migrate_mismatched_to_release_id_propagates_update_software_error() {
     let mut deps = deps();

--- a/protocol/contracts/remote_lease/src/contract/tests/migrate.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/migrate.rs
@@ -49,7 +49,10 @@ fn migrate_with_pre_transfer_channel_config_rejected() {
         .unwrap();
 
     let err = migrate(deps.as_mut(), testing::mock_env(), migrate_msg()).unwrap_err();
-    assert!(matches!(err, Error::Std(_)), "got {err:?}");
+    assert!(
+        matches!(err, Error::IncompatibleStoredConfig(_)),
+        "got {err:?}"
+    );
 }
 
 #[test]

--- a/protocol/contracts/remote_lease/src/contract/tests/migrate.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/migrate.rs
@@ -1,4 +1,7 @@
-use sdk::cosmwasm_std::testing;
+use serde::{Deserialize, Serialize};
+
+use platform::contract::Code;
+use sdk::{cosmwasm_std::testing, cw_storage_plus::Item};
 use versioning::{
     ProtocolMigrationMessage, ProtocolPackageRelease, ProtocolPackageReleaseId, ReleaseId,
     package_name, package_version,
@@ -6,7 +9,9 @@ use versioning::{
 
 use crate::{api::MigrateMsg, contract::migrate, error::Error};
 
-use super::{CONTRACT_STORAGE_VERSION, deps, instantiate_default};
+use super::{
+    CONNECTION_ID, CONTRACT_STORAGE_VERSION, DEX_LABEL, LEASE_CODE_ID, deps, instantiate_default,
+};
 
 #[test]
 fn migrate_same_release_succeeds() {
@@ -15,6 +20,36 @@ fn migrate_same_release_succeeds() {
 
     let res = migrate(deps.as_mut(), testing::mock_env(), migrate_msg()).unwrap();
     assert_eq!(0, res.messages.len());
+}
+
+// Overwrites the stored config with the shape that predates the required
+// `transfer_channel` field — the probe in `migrate` must refuse the upgrade
+// instead of letting the instance brick on the first post-upgrade load.
+#[test]
+fn migrate_with_pre_transfer_channel_config_rejected() {
+    #[derive(Serialize, Deserialize)]
+    struct LegacyConfig {
+        connection_id: String,
+        dex_label: String,
+        lease_code: Code,
+    }
+    const LEGACY_STORAGE: Item<LegacyConfig> = Item::new("config");
+
+    let mut deps = deps();
+    instantiate_default(deps.as_mut());
+    LEGACY_STORAGE
+        .save(
+            deps.as_mut().storage,
+            &LegacyConfig {
+                connection_id: CONNECTION_ID.into(),
+                dex_label: DEX_LABEL.into(),
+                lease_code: Code::unchecked(LEASE_CODE_ID),
+            },
+        )
+        .unwrap();
+
+    let err = migrate(deps.as_mut(), testing::mock_env(), migrate_msg()).unwrap_err();
+    assert!(matches!(err, Error::Std(_)), "got {err:?}");
 }
 
 #[test]

--- a/protocol/contracts/remote_lease/src/contract/tests/mod.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/mod.rs
@@ -42,7 +42,8 @@ const PACKET_TIMEOUT: Duration = Duration::from_secs(600);
 const LOCAL_CHANNEL_ID: &str = "channel-0";
 const COUNTERPARTY_CHANNEL_ID: &str = "channel-77";
 const COUNTERPARTY_PORT_ID: &str = "nls-remote-lease.osmosis";
-const VERSION: &str = "nls-remote-lease.v1";
+const TRANSFER_CHANNEL: &str = "channel-42";
+const VERSION: &str = "nls-remote-lease.v1+transfer=channel-42";
 const CONTRACT_STORAGE_VERSION: VersionSegment = 0;
 
 fn deps() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
@@ -137,6 +138,7 @@ fn instantiate_msg() -> InstantiateMsg {
         protocol_admin: sdk_testing::user(ADMIN).into_string(),
         connection_id: CONNECTION_ID.into(),
         dex_label: DEX_LABEL.into(),
+        transfer_channel: TRANSFER_CHANNEL.into(),
         lease_code: LEASE_CODE_ID.into(),
     }
 }

--- a/protocol/contracts/remote_lease/src/contract/tests/scenarios.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/scenarios.rs
@@ -1,6 +1,6 @@
 use remote_lease::{
     callback::RemoteLeaseCallback,
-    response::{OpenLeaseResponse, OperationResponse, RemoteLeaseId},
+    response::{OpenLeaseResponse, RemoteLeaseId, WireOperationResponse},
 };
 use sdk::{
     cosmwasm_ext::CosmosMsg,
@@ -36,7 +36,7 @@ fn scenario_open_channel_through_ack_dispatches_callback() {
 
     let packet_data = drive_open_lease(deps.as_mut());
 
-    let response = OperationResponse::OpenLease(OpenLeaseResponse {
+    let response = WireOperationResponse::OpenLease(OpenLeaseResponse {
         remote_lease_id: RemoteLeaseId::new("So1Lease7").expect("base58 lease id"),
     });
     let res = crate::ibc::ibc_packet_ack(

--- a/protocol/contracts/remote_lease/src/error.rs
+++ b/protocol/contracts/remote_lease/src/error.rs
@@ -25,6 +25,11 @@ pub enum Error {
     #[error("[RemoteLease] {0} must be non-empty")]
     EmptyInstantiateField(&'static str),
 
+    #[error(
+        "[RemoteLease] The stored config does not deserialize under the current schema, cause: {0}"
+    )]
+    IncompatibleStoredConfig(StdError),
+
     #[error("[RemoteLease] Transfer channel id '{0}' is not a canonical 'channel-<N>' identifier")]
     NonCanonicalTransferChannel(String),
 

--- a/protocol/contracts/remote_lease/src/error.rs
+++ b/protocol/contracts/remote_lease/src/error.rs
@@ -30,6 +30,9 @@ pub enum Error {
     )]
     IncompatibleStoredConfig(StdError),
 
+    #[error("[RemoteLease] The stored config violates its invariant")]
+    MalformedStoredConfig,
+
     #[error("[RemoteLease] Transfer channel id '{0}' is not a canonical 'channel-<N>' identifier")]
     NonCanonicalTransferChannel(String),
 

--- a/protocol/contracts/remote_lease/src/error.rs
+++ b/protocol/contracts/remote_lease/src/error.rs
@@ -25,6 +25,14 @@ pub enum Error {
     #[error("[RemoteLease] {0} must be non-empty")]
     EmptyInstantiateField(&'static str),
 
+    #[error("[RemoteLease] Transfer channel id '{0}' is not a canonical 'channel-<N>' identifier")]
+    NonCanonicalTransferChannel(String),
+
+    #[error(
+        "[RemoteLease] Counterparty channel version mismatch: expected '{expected}', got '{actual}'"
+    )]
+    InvalidCounterpartyVersion { expected: String, actual: String },
+
     #[error("[RemoteLease] A channel is already recorded for this controller")]
     ChannelAlreadyExists,
 

--- a/protocol/contracts/remote_lease/src/ibc.rs
+++ b/protocol/contracts/remote_lease/src/ibc.rs
@@ -1,7 +1,7 @@
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback},
     envelope::{NolusLeaseAddr, PacketEnvelope},
-    response::OperationResponse,
+    response::WireOperationResponse,
 };
 use sdk::{
     cosmos_sdk_proto::prost::Message as _,
@@ -178,9 +178,13 @@ pub fn ibc_packet_timeout(
         })
 }
 
+// The success payload is decoded as the wire shape only — currency-registry
+// validation belongs to the addressee lease, which absorbs content failures.
+// Erring here on a registry mismatch would make the relayer retry the ack
+// forever, turning counterparty content drift into a stuck packet.
 fn ack_to_callback(ack: StdAck) -> Result<RemoteLeaseCallback> {
     match ack {
-        StdAck::Success(data) => cosmwasm_std::from_json::<OperationResponse>(&data)
+        StdAck::Success(data) => cosmwasm_std::from_json::<WireOperationResponse>(&data)
             .map(RemoteLeaseCallback::OperationOk)
             .map_err(Error::from),
         StdAck::Error(message) => RemoteErrorMessage::new(message)

--- a/protocol/contracts/remote_lease/src/ibc.rs
+++ b/protocol/contracts/remote_lease/src/ibc.rs
@@ -100,6 +100,10 @@ pub fn ibc_channel_connect(
             channel,
             counterparty_version,
         } => (channel, Some(counterparty_version)),
+        // `OpenConfirm` is delivered only to the try side of a handshake and
+        // carries no counterparty version; this controller rejects `OpenTry`,
+        // so the arm is unreachable while counterparty-initiated opens stay
+        // unsupported.
         IbcChannelConnectMsg::OpenConfirm { channel } => (channel, None),
     };
 

--- a/protocol/contracts/remote_lease/src/ibc.rs
+++ b/protocol/contracts/remote_lease/src/ibc.rs
@@ -25,6 +25,22 @@ use crate::{
 };
 
 const MSG_CHANNEL_OPEN_INIT_TYPE_URL: &str = "/ibc.core.channel.v1.MsgChannelOpenInit";
+const VERSION_TRANSFER_KEY: &str = "+transfer=";
+
+/// Compose the channel handshake version: the protocol version extended with
+/// the paired Solana-side ICS-20 transfer channel (ADR-0002 §3.3).
+///
+/// Handshake grammar only — packets keep pinning the bare
+/// [`remote_lease::VERSION`]; extending the shared constant would break packet
+/// deserialization on both sides.
+fn handshake_version(config: &Config) -> String {
+    format!(
+        "{version}{key}{channel}",
+        version = remote_lease::VERSION,
+        key = VERSION_TRANSFER_KEY,
+        channel = config.transfer_channel()
+    )
+}
 
 /// Build the `CosmosMsg::Any { MsgChannelOpenInit }` that initiates the handshake.
 pub fn build_channel_open_init(env: &Env, config: &Config) -> CosmosMsg {
@@ -37,7 +53,7 @@ pub fn build_channel_open_init(env: &Env, config: &Config) -> CosmosMsg {
             channel_id: String::new(),
         }),
         connection_hops: vec![config.connection_id().to_string()],
-        version: remote_lease::VERSION.to_string(),
+        version: handshake_version(config),
         upgrade_sequence: 0,
     };
     let msg = MsgChannelOpenInit {
@@ -79,16 +95,24 @@ pub fn ibc_channel_connect(
     _env: Env,
     msg: IbcChannelConnectMsg,
 ) -> Result<IbcBasicResponse> {
-    let channel = match msg {
-        IbcChannelConnectMsg::OpenAck { channel, .. }
-        | IbcChannelConnectMsg::OpenConfirm { channel } => channel,
+    let (channel, may_counterparty_version) = match msg {
+        IbcChannelConnectMsg::OpenAck {
+            channel,
+            counterparty_version,
+        } => (channel, Some(counterparty_version)),
+        IbcChannelConnectMsg::OpenConfirm { channel } => (channel, None),
     };
 
     Channel::may_load(deps.storage)
         .and_then(|existing| match existing {
             Some(_) => Err(Error::ChannelAlreadyExists),
-            None => Config::load(deps.storage)
-                .and_then(|config| validate_handshake_channel(&channel, &config).map(|()| channel)),
+            None => Config::load(deps.storage).and_then(|config| {
+                validate_handshake_channel(&channel, &config)
+                    .and_then(|()| {
+                        validate_counterparty_version(may_counterparty_version.as_deref(), &config)
+                    })
+                    .map(|()| channel)
+            }),
         })
         .and_then(|channel| persist_open_channel(deps, channel))
         .map(|()| IbcBasicResponse::new())
@@ -195,11 +219,28 @@ fn dispatch_lease_callback(
 
 fn validate_handshake_channel(channel: &IbcChannel, config: &Config) -> Result<()> {
     require_unordered(channel.order.clone())
-        .and_then(|()| require_version(&channel.version))
+        .and_then(|()| require_version(&channel.version, &handshake_version(config)))
         .and_then(|()| require_connection_id(&channel.connection_id, config.connection_id()))
         .and_then(|()| {
             require_counterparty_port(&channel.counterparty_endpoint.port_id, config.dex_label())
         })
+}
+
+/// Validate the version the counterparty echoed in `OpenAck`. Both sides name
+/// the same Solana-side transfer channel, so the echo must equal the proposed
+/// handshake version verbatim.
+fn validate_counterparty_version(may_actual: Option<&str>, config: &Config) -> Result<()> {
+    may_actual.map_or(Ok(()), |actual| {
+        let expected = handshake_version(config);
+        if actual == expected {
+            Ok(())
+        } else {
+            Err(Error::InvalidCounterpartyVersion {
+                expected,
+                actual: actual.to_string(),
+            })
+        }
+    })
 }
 
 fn require_unordered(order: IbcOrder) -> Result<()> {
@@ -209,12 +250,12 @@ fn require_unordered(order: IbcOrder) -> Result<()> {
     }
 }
 
-fn require_version(actual: &str) -> Result<()> {
-    if actual == remote_lease::VERSION {
+fn require_version(actual: &str, expected: &str) -> Result<()> {
+    if actual == expected {
         Ok(())
     } else {
         Err(Error::InvalidChannelVersion {
-            expected: remote_lease::VERSION.to_string(),
+            expected: expected.to_string(),
             actual: actual.to_string(),
         })
     }

--- a/protocol/contracts/remote_lease/src/ibc.rs
+++ b/protocol/contracts/remote_lease/src/ibc.rs
@@ -26,6 +26,9 @@ use crate::{
 
 const MSG_CHANNEL_OPEN_INIT_TYPE_URL: &str = "/ibc.core.channel.v1.MsgChannelOpenInit";
 const VERSION_TRANSFER_KEY: &str = "+transfer=";
+// Diagnostic bound on the counterparty-authored version echoed into the
+// handshake error — a legitimate version is ~45 characters.
+const COUNTERPARTY_VERSION_ECHO_MAX_CHARS: usize = 64;
 
 /// Compose the channel handshake version: the protocol version extended with
 /// the paired Solana-side ICS-20 transfer channel (ADR-0002 §3.3).
@@ -236,7 +239,8 @@ fn validate_handshake_channel(channel: &IbcChannel, config: &Config) -> Result<(
 
 /// Validate the version the counterparty echoed in `OpenAck`. Both sides name
 /// the same Solana-side transfer channel, so the echo must equal the proposed
-/// handshake version verbatim.
+/// handshake version verbatim. The counterparty-authored string lands in the
+/// error truncated — never echoed unbounded.
 fn validate_counterparty_version(may_actual: Option<&str>, config: &Config) -> Result<()> {
     may_actual.map_or(Ok(()), |actual| {
         let expected = handshake_version(config);
@@ -245,7 +249,10 @@ fn validate_counterparty_version(may_actual: Option<&str>, config: &Config) -> R
         } else {
             Err(Error::InvalidCounterpartyVersion {
                 expected,
-                actual: actual.to_string(),
+                actual: actual
+                    .chars()
+                    .take(COUNTERPARTY_VERSION_ECHO_MAX_CHARS)
+                    .collect(),
             })
         }
     })

--- a/protocol/contracts/remote_lease/src/ibc/tests/handshake.rs
+++ b/protocol/contracts/remote_lease/src/ibc/tests/handshake.rs
@@ -9,8 +9,9 @@ use crate::{
 };
 
 use super::{
-    CONNECTION_ID, COUNTERPARTY_CHANNEL_ID, COUNTERPARTY_PORT_ID, LOCAL_CHANNEL_ID, VERSION,
-    WRONG_CONNECTION_ID, WRONG_COUNTERPARTY_PORT_ID, WRONG_VERSION, channel, deps_with_config,
+    BARE_VERSION, CONNECTION_ID, COUNTERPARTY_CHANNEL_ID, COUNTERPARTY_PORT_ID, LOCAL_CHANNEL_ID,
+    VERSION, WRONG_CONNECTION_ID, WRONG_COUNTERPARTY_PORT_ID, WRONG_TRANSFER_VERSION,
+    WRONG_VERSION, channel, deps_with_config,
 };
 
 use crate::ibc::{ibc_channel_close, ibc_channel_connect, ibc_channel_open};
@@ -63,6 +64,49 @@ fn open_init_wrong_version_rejected() {
         open_init_msg(channel(
             IbcOrder::Unordered,
             WRONG_VERSION,
+            CONNECTION_ID,
+            COUNTERPARTY_PORT_ID,
+        )),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidChannelVersion { .. }),
+        "got {err:?}"
+    );
+}
+
+// The pre-suffix grammar (bare protocol version, no `+transfer=` pairing) must
+// no longer pass the handshake — the Solana responder requires the paired
+// transfer channel since ibc-solray#322.
+#[test]
+fn open_init_bare_version_rejected() {
+    let mut deps = deps_with_config();
+    let err = ibc_channel_open(
+        deps.as_mut(),
+        testing::mock_env(),
+        open_init_msg(channel(
+            IbcOrder::Unordered,
+            BARE_VERSION,
+            CONNECTION_ID,
+            COUNTERPARTY_PORT_ID,
+        )),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidChannelVersion { .. }),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn open_init_wrong_transfer_suffix_rejected() {
+    let mut deps = deps_with_config();
+    let err = ibc_channel_open(
+        deps.as_mut(),
+        testing::mock_env(),
+        open_init_msg(channel(
+            IbcOrder::Unordered,
+            WRONG_TRANSFER_VERSION,
             CONNECTION_ID,
             COUNTERPARTY_PORT_ID,
         )),
@@ -168,6 +212,26 @@ fn connect_open_confirm_persists_channel() {
 
     let stored = Channel::may_load(&deps.storage).unwrap().unwrap();
     assert_eq!(ChannelState::Open, stored.state());
+}
+
+#[test]
+fn connect_open_ack_wrong_counterparty_version_rejected() {
+    let mut deps = deps_with_config();
+    let connect = IbcChannelConnectMsg::OpenAck {
+        channel: channel(
+            IbcOrder::Unordered,
+            VERSION,
+            CONNECTION_ID,
+            COUNTERPARTY_PORT_ID,
+        ),
+        counterparty_version: WRONG_TRANSFER_VERSION.into(),
+    };
+    let err = ibc_channel_connect(deps.as_mut(), testing::mock_env(), connect).unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidCounterpartyVersion { .. }),
+        "got {err:?}"
+    );
+    assert!(Channel::may_load(&deps.storage).unwrap().is_none());
 }
 
 #[test]

--- a/protocol/contracts/remote_lease/src/ibc/tests/handshake.rs
+++ b/protocol/contracts/remote_lease/src/ibc/tests/handshake.rs
@@ -235,6 +235,29 @@ fn connect_open_ack_wrong_counterparty_version_rejected() {
 }
 
 #[test]
+fn connect_open_ack_oversized_counterparty_version_truncated_in_error() {
+    const ECHO_CAP_CHARS: usize = 64;
+
+    let mut deps = deps_with_config();
+    let connect = IbcChannelConnectMsg::OpenAck {
+        channel: channel(
+            IbcOrder::Unordered,
+            VERSION,
+            CONNECTION_ID,
+            COUNTERPARTY_PORT_ID,
+        ),
+        counterparty_version: "x".repeat(ECHO_CAP_CHARS * 4),
+    };
+    let err = ibc_channel_connect(deps.as_mut(), testing::mock_env(), connect).unwrap_err();
+    match err {
+        Error::InvalidCounterpartyVersion { actual, .. } => {
+            assert_eq!(ECHO_CAP_CHARS, actual.chars().count());
+        }
+        other => panic!("expected InvalidCounterpartyVersion, got {other:?}"),
+    }
+}
+
+#[test]
 fn connect_rejects_when_channel_exists() {
     let mut deps = deps_with_config();
     persist_existing_open_channel(deps.as_mut());

--- a/protocol/contracts/remote_lease/src/ibc/tests/mod.rs
+++ b/protocol/contracts/remote_lease/src/ibc/tests/mod.rs
@@ -21,8 +21,11 @@ const LOCAL_CHANNEL_ID: &str = "channel-0";
 const COUNTERPARTY_CHANNEL_ID: &str = "channel-77";
 const COUNTERPARTY_PORT_ID: &str = "nls-remote-lease.osmosis";
 const WRONG_COUNTERPARTY_PORT_ID: &str = "nls-remote-lease.evil";
-const VERSION: &str = "nls-remote-lease.v1";
-const WRONG_VERSION: &str = "nls-remote-lease.v2";
+const TRANSFER_CHANNEL: &str = "channel-42";
+const VERSION: &str = "nls-remote-lease.v1+transfer=channel-42";
+const WRONG_VERSION: &str = "nls-remote-lease.v2+transfer=channel-42";
+const BARE_VERSION: &str = "nls-remote-lease.v1";
+const WRONG_TRANSFER_VERSION: &str = "nls-remote-lease.v1+transfer=channel-7";
 const LEASE_CODE_ID: u64 = 17;
 
 fn deps_with_config() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
@@ -38,6 +41,7 @@ fn deps_with_config() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
             protocol_admin: sdk_testing::user(ADMIN).into_string(),
             connection_id: CONNECTION_ID.into(),
             dex_label: DEX_LABEL.into(),
+            transfer_channel: TRANSFER_CHANNEL.into(),
             lease_code: LEASE_CODE_ID.into(),
         },
     )

--- a/protocol/contracts/remote_lease/src/ibc/tests/packets.rs
+++ b/protocol/contracts/remote_lease/src/ibc/tests/packets.rs
@@ -2,7 +2,10 @@ use remote_lease::{
     callback::{OPERATION_ERR_MAX_BYTES, RemoteErrorMessage, RemoteLeaseCallback},
     envelope::{LeaseAddrOnWire, PacketEnvelope},
     msg::{CloseLeaseParams, Operation},
-    response::{CloseLeaseResponse, OpenLeaseResponse, OperationResponse, RemoteLeaseId},
+    response::{
+        CloseLeaseResponse, OpenLeaseResponse, RemoteLeaseId, Ticker, WireCoin,
+        WireOperationResponse, WireSwapResponse,
+    },
     version::ProtocolVersion,
 };
 use sdk::{
@@ -56,7 +59,7 @@ fn packet_ack_success_dispatches_operation_ok() {
     let mut deps = deps_with_config();
     let lease = sdk_testing::user("lease-1");
     let envelope_bytes = encode_envelope(&envelope_with_close_lease(&lease));
-    let response = OperationResponse::CloseLease(CloseLeaseResponse {});
+    let response = WireOperationResponse::CloseLease(CloseLeaseResponse {});
     let ack_bytes = StdAck::Success(cosmwasm_std::to_json_binary(&response).unwrap()).to_binary();
 
     let res = ibc_packet_ack(
@@ -162,6 +165,33 @@ fn packet_ack_malformed_acknowledgement_errors() {
     assert!(matches!(err, Error::Std(_)), "got {err:?}");
 }
 
+// Content validation belongs to the addressee lease — a ticker outside the
+// Nolus currency registry must pass through this controller untouched, or the
+// relayer would retry the ack forever (issue #637).
+#[test]
+fn packet_ack_out_of_registry_ticker_dispatches_ok() {
+    let mut deps = deps_with_config();
+    let lease = sdk_testing::user("lease-alien-ticker");
+    let envelope_bytes = encode_envelope(&envelope_with_close_lease(&lease));
+    let response = WireOperationResponse::Swap(WireSwapResponse {
+        amount_out: WireCoin::new(42, Ticker::new("NOT_IN_REGISTRY")),
+    });
+    let ack_bytes = StdAck::Success(cosmwasm_std::to_json_binary(&response).unwrap()).to_binary();
+
+    let res = ibc_packet_ack(
+        deps.as_mut(),
+        testing::mock_env(),
+        ack_msg(envelope_bytes, ack_bytes),
+    )
+    .unwrap();
+
+    assert_dispatched_callback(
+        &lease,
+        RemoteLeaseCallback::OperationOk(response),
+        &res.messages,
+    );
+}
+
 #[test]
 fn packet_ack_success_with_malformed_response_errors() {
     let mut deps = deps_with_config();
@@ -215,7 +245,7 @@ fn packet_ack_malformed_lease_addr_in_envelope_errors() {
         version: ProtocolVersion,
     };
     let envelope_bytes = cosmwasm_std::to_json_binary(&envelope).expect("envelope serialises");
-    let response = OperationResponse::CloseLease(CloseLeaseResponse {});
+    let response = WireOperationResponse::CloseLease(CloseLeaseResponse {});
     let ack_bytes = StdAck::Success(cosmwasm_std::to_json_binary(&response).unwrap()).to_binary();
 
     let err = ibc_packet_ack(
@@ -258,7 +288,7 @@ fn fixture_stdack_success_open_lease_decodes_to_callback() {
     const FIXTURE_REMOTE_LEASE_ID: &str = "So1RayF1xtureLease1";
     const ACK_BYTES: &[u8] =
         include_bytes!("../../../tests/fixtures/stdack_success_open_lease.bin");
-    let response = OperationResponse::OpenLease(OpenLeaseResponse {
+    let response = WireOperationResponse::OpenLease(OpenLeaseResponse {
         remote_lease_id: RemoteLeaseId::new(FIXTURE_REMOTE_LEASE_ID).expect("base58 fixture id"),
     });
 

--- a/protocol/contracts/remote_lease/src/state/config.rs
+++ b/protocol/contracts/remote_lease/src/state/config.rs
@@ -14,16 +14,23 @@ use crate::error::{Error, Result};
 pub struct Config {
     connection_id: String,
     dex_label: String,
+    transfer_channel: String,
     lease_code: Code,
 }
 
 impl Config {
     const STORAGE: Item<Self> = Item::new("config");
 
-    pub fn new(connection_id: String, dex_label: String, lease_code: Code) -> Self {
+    pub fn new(
+        connection_id: String,
+        dex_label: String,
+        transfer_channel: String,
+        lease_code: Code,
+    ) -> Self {
         Self {
             connection_id,
             dex_label,
+            transfer_channel,
             lease_code,
         }
     }
@@ -36,12 +43,21 @@ impl Config {
         &self.dex_label
     }
 
+    pub fn transfer_channel(&self) -> &str {
+        &self.transfer_channel
+    }
+
     pub const fn lease_code(&self) -> Code {
         self.lease_code
     }
 
-    pub(super) fn into_parts(self) -> (String, String, Code) {
-        (self.connection_id, self.dex_label, self.lease_code)
+    pub(super) fn into_parts(self) -> (String, String, String, Code) {
+        (
+            self.connection_id,
+            self.dex_label,
+            self.transfer_channel,
+            self.lease_code,
+        )
     }
 
     pub fn store(&self, storage: &mut dyn Storage) -> Result<()> {
@@ -94,6 +110,7 @@ mod test {
 
     const CONNECTION_ID: &str = "connection-0";
     const DEX_LABEL: &str = "osmosis";
+    const TRANSFER_CHANNEL: &str = "channel-4";
     const LEASE_USER: &str = "lease";
 
     #[test]
@@ -104,6 +121,7 @@ mod test {
         let loaded = Config::load(&store).unwrap();
         assert_eq!(CONNECTION_ID, loaded.connection_id());
         assert_eq!(DEX_LABEL, loaded.dex_label());
+        assert_eq!(TRANSFER_CHANNEL, loaded.transfer_channel());
         assert_lease_code(lease_code, &store);
     }
 
@@ -118,6 +136,7 @@ mod test {
         let loaded = Config::load(&store).unwrap();
         assert_eq!(CONNECTION_ID, loaded.connection_id());
         assert_eq!(DEX_LABEL, loaded.dex_label());
+        assert_eq!(TRANSFER_CHANNEL, loaded.transfer_channel());
     }
 
     #[test]
@@ -162,7 +181,12 @@ mod test {
     }
 
     fn config(lease_code: Code) -> Config {
-        Config::new(CONNECTION_ID.into(), DEX_LABEL.into(), lease_code)
+        Config::new(
+            CONNECTION_ID.into(),
+            DEX_LABEL.into(),
+            TRANSFER_CHANNEL.into(),
+            lease_code,
+        )
     }
 
     fn assert_lease_code(expected: Code, store: &dyn Storage) {

--- a/protocol/contracts/remote_lease/src/state/config.rs
+++ b/protocol/contracts/remote_lease/src/state/config.rs
@@ -10,6 +10,8 @@ use sdk::{
 
 use crate::error::{Error, Result};
 
+const TRANSFER_CHANNEL_NAME_PREFIX: &str = "channel-";
+
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct Config {
     connection_id: String,
@@ -27,12 +29,20 @@ impl Config {
         transfer_channel: String,
         lease_code: Code,
     ) -> Self {
-        Self {
+        let obj = Self {
             connection_id,
             dex_label,
             transfer_channel,
             lease_code,
-        }
+        };
+        debug_assert!(obj.invariant_held());
+        obj
+    }
+
+    pub fn invariant_held(&self) -> bool {
+        !self.connection_id.is_empty()
+            && !self.dex_label.is_empty()
+            && canonical_transfer_channel(&self.transfer_channel)
     }
 
     pub fn connection_id(&self) -> &str {
@@ -71,12 +81,26 @@ impl Config {
     pub fn update_lease_code(storage: &mut dyn Storage, lease_code: Code) -> Result<()> {
         Self::STORAGE
             .update(storage, |config: Self| {
-                Ok(Self {
+                let updated = Self {
                     lease_code,
                     ..config
-                })
+                };
+                debug_assert!(updated.invariant_held());
+                Ok(updated)
             })
             .map(mem::drop)
+    }
+
+    /// Prove the stored config deserializes under the current schema.
+    ///
+    /// Run by `migrate` so an instance whose stored config predates a required
+    /// field refuses the upgrade instead of bricking on the first
+    /// post-upgrade load.
+    pub fn require_current_schema(storage: &dyn Storage) -> Result<()> {
+        Self::STORAGE
+            .load(storage)
+            .map(mem::drop)
+            .map_err(Error::IncompatibleStoredConfig)
     }
 
     /// Verify the caller is a contract instance of `Config.lease_code`.
@@ -90,6 +114,21 @@ impl Config {
             .check_contract_code(caller, &self.lease_code)
             .map_err(|_| Error::UnauthorisedCaller)
     }
+}
+
+/// `true` only for the canonical decimal rendering of a `u16` ordinal behind
+/// the `channel-` prefix — the counterparty's responder rejects leading zeros,
+/// signs, and ordinals beyond its 16-bit entity range.
+pub(crate) fn canonical_transfer_channel(channel_id: &str) -> bool {
+    channel_id
+        .strip_prefix(TRANSFER_CHANNEL_NAME_PREFIX)
+        .and_then(|ordinal| {
+            ordinal
+                .parse::<u16>()
+                .ok()
+                .filter(|parsed| parsed.to_string() == ordinal)
+        })
+        .is_some()
 }
 
 #[cfg(test)]
@@ -178,6 +217,27 @@ mod test {
             .auth_caller(QuerierWrapper::new(&querier), sdk_testing::user(LEASE_USER))
             .unwrap_err();
         assert!(matches!(err, Error::UnauthorisedCaller), "got {err:?}");
+    }
+
+    #[test]
+    fn invariant_violations_detected() {
+        assert!(config(Code::unchecked(1)).invariant_held());
+
+        let non_canonical_channel = Config {
+            connection_id: CONNECTION_ID.into(),
+            dex_label: DEX_LABEL.into(),
+            transfer_channel: "channel-007".into(),
+            lease_code: Code::unchecked(1),
+        };
+        assert!(!non_canonical_channel.invariant_held());
+
+        let empty_connection = Config {
+            connection_id: String::new(),
+            dex_label: DEX_LABEL.into(),
+            transfer_channel: TRANSFER_CHANNEL.into(),
+            lease_code: Code::unchecked(1),
+        };
+        assert!(!empty_connection.invariant_held());
     }
 
     fn config(lease_code: Code) -> Config {

--- a/protocol/contracts/remote_lease/src/state/config.rs
+++ b/protocol/contracts/remote_lease/src/state/config.rs
@@ -91,16 +91,23 @@ impl Config {
             .map(mem::drop)
     }
 
-    /// Prove the stored config deserializes under the current schema.
+    /// Prove the stored config deserializes under the current schema and
+    /// upholds its invariant.
     ///
     /// Run by `migrate` so an instance whose stored config predates a required
-    /// field refuses the upgrade instead of bricking on the first
-    /// post-upgrade load.
+    /// field, or carries values the current code would never have accepted,
+    /// refuses the upgrade instead of bricking on the first post-upgrade load.
     pub fn require_current_schema(storage: &dyn Storage) -> Result<()> {
         Self::STORAGE
             .load(storage)
-            .map(mem::drop)
             .map_err(Error::IncompatibleStoredConfig)
+            .and_then(|config| {
+                if config.invariant_held() {
+                    Ok(())
+                } else {
+                    Err(Error::MalformedStoredConfig)
+                }
+            })
     }
 
     /// Verify the caller is a contract instance of `Config.lease_code`.

--- a/protocol/contracts/remote_lease/src/state/mod.rs
+++ b/protocol/contracts/remote_lease/src/state/mod.rs
@@ -1,5 +1,6 @@
 use crate::api::{ChannelInfo, ChannelResponse, ChannelStateResponse, ConfigResponse};
 
+pub(crate) use self::config::canonical_transfer_channel;
 pub use self::{
     channel::{Channel, ChannelState},
     config::Config,

--- a/protocol/contracts/remote_lease/src/state/mod.rs
+++ b/protocol/contracts/remote_lease/src/state/mod.rs
@@ -10,8 +10,8 @@ mod config;
 
 impl From<Config> for ConfigResponse {
     fn from(cfg: Config) -> Self {
-        let (connection_id, dex_label, lease_code) = cfg.into_parts();
-        Self::new(connection_id, dex_label, lease_code)
+        let (connection_id, dex_label, transfer_channel, lease_code) = cfg.into_parts();
+        Self::new(connection_id, dex_label, transfer_channel, lease_code)
     }
 }
 

--- a/protocol/docs/remote-lease-callback-flow.md
+++ b/protocol/docs/remote-lease-callback-flow.md
@@ -1,29 +1,32 @@
 # Remote-Lease Callback — Execution Flow inside a Lease Instance
 
-Trace of a swap callback delivered to the Lease contract via
-`ExecuteMsg::RemoteLeaseCallback`. The focus is the **safe-delivery
-segment** (`ResponseDelivery` + `reply_on_error` + `TimeAlarms` retry
-loop) — boxes **A**–**D** below. Preserved verbatim from today's
-SudoMsg path per ADR `0001-remote-lease-protocol.md` §3.7.1 / §9.5; only
-the outer transport and the auth gate change with #141.
+Trace of a callback delivered to the Lease contract via
+`ExecuteMsg::RemoteLeaseCallback`. Two distinct segments:
 
-## Whole flow
+1. **Controller → lease dispatch** — auth at the lease, then direct
+   routing into the state's `on_remote_*` entry points. The remote-swap
+   leg processes the acknowledgment **directly** — there is no
+   `ResponseDelivery` hop on this path; content problems are absorbed
+   with events so the controller's ack always commits.
+2. **Safe-delivery segment** (`ResponseDelivery` + `reply_on_error` +
+   `TimeAlarms` retry loop, boxes **A**–**D**) — applies to the
+   **still-ICA legs** driven by `SudoMsg` (transfer-out, transfer-in,
+   the repay/liquidation swaps). Controller callbacks never route
+   through it.
+
+## Controller → lease dispatch
 
 ```mermaid
 flowchart TD
     classDef ctrl   fill:#fefaf0,stroke:#b6883a,color:#000;
     classDef lease  fill:#f0f4ff,stroke:#3a5dbe,color:#000;
-    classDef safeA  fill:#e8f5e9,stroke:#3a7d3a,color:#000;
-    classDef safeB  fill:#e8f5e9,stroke:#3a7d3a,color:#000;
-    classDef safeC  fill:#fff3e0,stroke:#b6883a,color:#000;
-    classDef safeD  fill:#fff3e0,stroke:#b6883a,color:#000;
     classDef ok     fill:#dcedc8,stroke:#33691e,color:#000;
     classDef err    fill:#ffcdd2,stroke:#b71c1c,color:#000;
 
     subgraph Controller[remote_lease controller]
         direction TB
         Ack["ibc_packet_ack — packet received from Solana"]:::ctrl
-        Decode["from_json(envelope) → RemoteLeaseCallback::OperationOk(SwapResponse)"]:::ctrl
+        Decode["from_json(StdAck) → wire-shape OperationResponse → RemoteLeaseCallback::OperationOk<br/><i>wire decode only — currency-registry validation belongs to the lease (#637)</i>"]:::ctrl
         WasmExec["add_message: WasmMsg::Execute(lease, ExecuteMsg::RemoteLeaseCallback(cb))<br/><i>plain add_message — not reply_on_*</i>"]:::ctrl
         Ack --> Decode --> WasmExec
     end
@@ -31,12 +34,38 @@ flowchart TD
     subgraph LeaseEntry[Lease — entry & dispatch]
         direction TB
         ExecEntry["contract::endpoins::execute → state.on_remote_lease_callback"]:::lease
-        Auth["DexState&lt;H&gt;::authz_remote_lease_callback<br/>check_remote_lease_callback(h.remote_lease, info)<br/>← SingleUserPermission ↔ info.sender"]:::lease
-        Classify["classify_callback(cb) → CallbackDispatch::Response(to_json_binary(swap_resp))"]:::lease
-        DispatchResp["on_dex_response(data) → H::on_response → SwapExactIn::on_response"]:::lease
-        ExecEntry --> Auth -->|matches| Classify --> DispatchResp
-        Auth -. mismatch / no controller .-> AuthErr["DexError::Unauthorized / UnsupportedOperation<br/>← Err propagates to controller, relayer retries"]:::err
+        Auth["Handler::authz_remote_callback<br/>LeasesRef::remote_lease_callback_permission<br/>← leaser query CheckRemoteLeaseCallbackPermission"]:::lease
+        Classify["deliver_remote_callback:<br/>OperationOk → on_remote_response(bytes) · OperationErr → on_remote_error · OperationTimeout → on_remote_timeout"]:::lease
+        RemoteLeg["RemoteSwap leg (overrides on_remote_*):<br/>decode_response — typed, registry-validating — credits the in-flight leg<br/>absorbed with event on undecodable-response / unexpected-response-variant /<br/>out-currency-mismatch / output-overflow; under-min-out re-emits the leg"]:::ok
+        IcaLeg["ICA legs (default on_remote_*):<br/>absorb with `remote-callback` event — never advance the ICA ack countdown"]:::ok
+        ExecEntry --> Auth -->|granted| Classify
+        Classify --> RemoteLeg
+        Classify --> IcaLeg
+        Auth -. denied .-> AuthErr["DexError::Unauthorized<br/>← Err propagates to controller, its ibc_packet_ack reverts, relayer retries"]:::err
     end
+
+    WasmExec --> ExecEntry
+```
+
+A synchronous `Err` escapes the lease only for faults whose retry
+belongs to the relayer: the auth mismatch above, serialization, and
+storage failures. Everything content-shaped — a payload that does not
+decode, names a currency outside the registry, carries the wrong
+operation variant, or overflows — is absorbed with a distinct event
+reason so the controller's `ibc_packet_ack` commits.
+
+## Safe-delivery segment — still-ICA legs (`SudoMsg` path)
+
+```mermaid
+flowchart TD
+    classDef safeA  fill:#e8f5e9,stroke:#3a7d3a,color:#000;
+    classDef safeB  fill:#e8f5e9,stroke:#3a7d3a,color:#000;
+    classDef safeC  fill:#fff3e0,stroke:#b6883a,color:#000;
+    classDef safeD  fill:#fff3e0,stroke:#b6883a,color:#000;
+    classDef ok     fill:#dcedc8,stroke:#33691e,color:#000;
+    classDef lease  fill:#f0f4ff,stroke:#3a5dbe,color:#000;
+
+    DispatchResp["SudoMsg::Response → on_dex_response(data) → H::on_response"]:::lease
 
     subgraph SafeDelivery[Safe-delivery segment]
         direction TB
@@ -53,7 +82,6 @@ flowchart TD
         D -->|do_deliver| B
     end
 
-    WasmExec --> ExecEntry
     DispatchResp --> A
 ```
 
@@ -122,14 +150,14 @@ on a permanently-unrecoverable state.
    concern of the lease + `TimeAlarms` contract. The controller is
    never invoked again for the same packet.
 
-## What changed in #141 (vs. today's SudoMsg path)
+## Transport comparison (ICA legs vs. remote legs)
 
-| Stage | Today (SudoMsg) | After #141 (ExecuteMsg::RemoteLeaseCallback) |
-|-------|-----------------|----------------------------------------------|
-| Outer transport | `SudoMsg::Response` (chain-delivered) | `ExecuteMsg::RemoteLeaseCallback` (controller-delivered via `WasmMsg::Execute`) |
-| Auth gate | Implicit (Sudo privilege) | `info.sender == remote_lease` at `DexState::on_remote_lease_callback` |
-| Classify | `data` enters directly into `on_dex_response` | `classify_callback` projects variant → `CallbackDispatch::Response/Error/Timeout` |
-| A–D safe-delivery boxes | unchanged | unchanged |
+| Stage | ICA legs (SudoMsg) | Remote legs (ExecuteMsg::RemoteLeaseCallback) |
+|-------|--------------------|-----------------------------------------------|
+| Outer transport | `SudoMsg::Response` (chain-delivered) | `WasmMsg::Execute` from the controller's `ibc_packet_ack` / `ibc_packet_timeout` |
+| Auth gate | Implicit (Sudo privilege) | Leaser query (`CheckRemoteLeaseCallbackPermission` vs `Config.remote_lease_controller`) |
+| Dispatch | `data` enters `on_dex_response` → safe-delivery boxes A–D | `deliver_remote_callback` → `on_remote_response/error/timeout`; `RemoteSwap` processes directly, ICA legs absorb |
+| Content failure | retried locally via the A–D loop | absorbed with a distinct event reason; ack commits |
 
 ## Outbound open-side lifecycle (issue #142)
 
@@ -154,27 +182,29 @@ RequestLoan ──open loan──▶ OpenLease
                      │             │
                      ▼             ▼
         super::buy_asset::start    OpenFailed  (terminal)
-        (legacy ICA-open cascade)  authenticated late-ack absorber:
-                                   emits `wasm-ls-remote-lease-late-ack`
+        (ICA open + transfer-out,  authenticated late-ack absorber:
+        swap legs via RemoteSwap)  emits `wasm-ls-remote-lease-late-ack`
 ```
 
 `OpenLease::on_remote_lease_callback` authenticates `info.sender` via `LeasesRef::remote_lease_callback_permission` before dispatching, identical to the in-flight DexState gate documented above. `OpenFailed` runs the same check — every callback handler that returns `Ok` is authz-gated, regardless of idempotence.
 
-The legacy ICA-open + DEX swap cascade entered via `super::buy_asset::start` is retained additively; later phases (swap replacement, TransferOut, CloseLease) migrate the remaining lifecycle stages off it.
+`super::buy_asset::start` still opens the ICA account and transfers the funds out over ICA, but the swap legs run through the remote-lease controller (`RemoteSwap` — sequential single-coin legs, `acks_left` countdown, pinned per-leg `min_out`). The remaining lifecycle stages (drain-home TransferOut, CloseLease, the repay/liquidation swaps) still ride ICA and migrate in later phases.
 
 An `OperationOk` ack carrying any operation other than `OpenLease` (a `CloseLease` / `Swap` / `TransferOut` response against an in-flight open) can only originate from a buggy or hostile counterparty. The lease treats it exactly like `OperationErr`: it refunds the customer, finalises, and moves to `OpenFailed` with a synthesised `unexpected operation response: …` reason. It does **not** return `Err` — an error would revert the controller's `ibc_packet_ack`, stranding the relayer and freezing the lease in `OpenLease`. Operators see the same `wasm-ls-remote-lease-open-failed` event and audit the counterparty per the runbook.
 
-## Storage: v9 → v10 (refuse-migrate)
+## Storage: v9 → v10 → v11 (refuse-migrate)
 
-v10 makes `LeaseDTO.remote_lease_id` a non-optional Solana PDA, which is binary-incompatible with the v9 layout. The `migrate` entry point therefore **rejects unconditionally** (`ContractError::UnsupportedMigration`):
+v10 makes `LeaseDTO.remote_lease_id` a non-optional Solana PDA, which is binary-incompatible with the v9 layout. v11 reshapes the opening-swap state: the `BuyAsset` spec gains the controller address and slippage bound, and the swap leg moves from the ICA `SwapExactIn` to the `RemoteSwap` transport. The `migrate` entry point **rejects unconditionally** (`ContractError::UnsupportedMigration`):
 
-- **Mainnet** carries zero v9 leases (plan §10.A.1), so refusing is strictly safer than risking a silent deserialise failure on the first post-upgrade load.
-- A v9 lease has no meaningful `remote_lease_id` to synthesise — its `dex_account` is an ICA host on the DEX chain, not a Solana PDA — so a "real" migration would only invent a permanent sentinel.
+- **Mainnet** carries zero pre-v11 remote-lease positions, so refusing is strictly safer than risking a silent deserialise failure on the first post-upgrade load.
+- A v9 lease has no meaningful `remote_lease_id` to synthesise — its `dex_account` is an ICA host on the DEX chain, not a Solana PDA — and a pre-v11 opening state has no transport to resume on, so a "real" migration would only invent permanent sentinels.
 
-**Operational procedure for non-mainnet (devnet/testnet/local):** drain every v9 lease to a terminal state *before* upgrading the lease code to v10. There is no `ExecuteMsg` escape hatch for a stranded v9 lease, so the drain is a prerequisite, not a recovery step.
+**Operational procedure for non-mainnet (devnet/testnet/local):** drain every pre-v11 lease to a terminal state *before* upgrading the lease code. There is no `ExecuteMsg` escape hatch for a stranded pre-v11 lease, so the drain is a prerequisite, not a recovery step.
 
-## Closed: in-lease decoder shape
+## In-lease decoder shape
 
-The `OperationOk(SwapResponse)` decoder still feeds the safe-delivery
-boxes A–D above; the protobuf-vs-JSON shape switch tracked here previously
-moves with the Phase-4 swap replacement work.
+The remote-swap acknowledgment is JSON: the controller forwards the
+wire-shaped `OperationResponse` (#637), and the `RemoteSwap` leg's
+`decode_response` parses the typed, registry-validating twin from those
+bytes — a registry miss is absorbed as `undecodable-response` rather
+than erred.

--- a/protocol/packages/remote_lease/src/callback.rs
+++ b/protocol/packages/remote_lease/src/callback.rs
@@ -2,21 +2,25 @@ use serde::{Deserialize, Serialize};
 
 pub use remote_lease_wire::callback::{OPERATION_ERR_MAX_BYTES, RemoteErrorMessage};
 
-use crate::response::OperationResponse;
+use crate::response::WireOperationResponse;
 
 /// Outcome of a remote operation as reported back to the Nolus controller.
 ///
-/// `OperationOk` carries the typed response when Solana confirmed the
-/// requested action. `OperationErr` carries a short error message authored
-/// by the Solana program itself, e.g. a DEX-layer failure or an invariant
-/// rejection in the vault. `OperationTimeout` is emitted by the IBC layer
-/// when the packet was never acknowledged — it is structurally distinct
-/// from `OperationErr` because the recovery path differs (funds may still
-/// be in flight on the Solana side until the channel times out).
+/// `OperationOk` carries the wire-shaped response verbatim when Solana
+/// confirmed the requested action: the controller validates only that the
+/// payload is a well-formed response, while content validation (the currency
+/// registry) belongs to the addressee lease, whose callback handlers absorb
+/// failures instead of erring (ADR 0001 §3.7.2). `OperationErr` carries a
+/// short error message authored by the Solana program itself, e.g. a
+/// DEX-layer failure or an invariant rejection in the vault.
+/// `OperationTimeout` is emitted by the IBC layer when the packet was never
+/// acknowledged — it is structurally distinct from `OperationErr` because
+/// the recovery path differs (funds may still be in flight on the Solana
+/// side until the channel times out).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum RemoteLeaseCallback {
-    OperationOk(OperationResponse),
+    OperationOk(WireOperationResponse),
     OperationErr(RemoteErrorMessage),
     OperationTimeout,
 }

--- a/protocol/packages/remote_lease/src/response.rs
+++ b/protocol/packages/remote_lease/src/response.rs
@@ -3,15 +3,14 @@ use serde::{Deserialize, Serialize};
 use currencies::PaymentGroup;
 use finance::coin::CoinDTO;
 
-use remote_lease_wire::{
-    coin::WireCoin,
-    response::{OperationResponse as WireOperationResponse, SwapResponse as WireSwapResponse},
-    ticker::Ticker,
-};
-
 pub use remote_lease_wire::{
+    coin::WireCoin,
     lease_id::RemoteLeaseId,
-    response::{CloseLeaseResponse, OpenLeaseResponse, TransferOutResponse},
+    response::{
+        CloseLeaseResponse, OpenLeaseResponse, OperationResponse as WireOperationResponse,
+        SwapResponse as WireSwapResponse, TransferOutResponse,
+    },
+    ticker::Ticker,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/protocol/packages/remote_lease/src/tests.rs
+++ b/protocol/packages/remote_lease/src/tests.rs
@@ -26,7 +26,7 @@ use crate::{
     port_id_for,
     response::{
         CloseLeaseResponse, OpenLeaseResponse, OperationResponse, RemoteLeaseId, SwapResponse,
-        TransferOutResponse,
+        TransferOutResponse, WireOperationResponse,
     },
     version::ProtocolVersion,
 };
@@ -113,7 +113,7 @@ fn transfer_out_response_serde() {
 #[test]
 fn callback_operation_ok_serde() {
     let value =
-        RemoteLeaseCallback::OperationOk(OperationResponse::CloseLease(CloseLeaseResponse {}));
+        RemoteLeaseCallback::OperationOk(WireOperationResponse::CloseLease(CloseLeaseResponse {}));
     assert_round_trip_eq(r#"{"operation_ok":{"close_lease":{}}}"#, &value);
 }
 

--- a/protocol/packages/remote_lease/tests/cross_surface.rs
+++ b/protocol/packages/remote_lease/tests/cross_surface.rs
@@ -86,8 +86,7 @@ fn response_transfer_out_byte_identical() {
 
 #[test]
 fn callback_operation_ok_byte_identical() {
-    let typed =
-        RemoteLeaseCallback::OperationOk(OperationResponse::CloseLease(CloseLeaseResponse {}));
+    let typed = RemoteLeaseCallback::OperationOk(WireResponse::CloseLease(CloseLeaseResponse {}));
     assert_cross_surface_eq::<RemoteLeaseCallback, WireCallback>(&typed);
 }
 

--- a/tests/src/common/remote_lease_controller_stub.rs
+++ b/tests/src/common/remote_lease_controller_stub.rs
@@ -181,6 +181,7 @@ const RECORDED_SWAPS: Map<&Addr, Vec<SwapParams>> = Map::new("stub_recorded_swap
 struct StubConfig {
     connection_id: String,
     dex_label: String,
+    transfer_channel: String,
     lease_code: Code,
 }
 
@@ -212,6 +213,7 @@ pub fn instantiate(
     let config = StubConfig {
         connection_id: msg.connection_id,
         dex_label: msg.dex_label,
+        transfer_channel: msg.transfer_channel,
         lease_code,
     };
     CONFIG.save(deps.storage, &config)?;
@@ -279,6 +281,7 @@ pub fn query(deps: Deps<'_>, _env: Env, msg: StubQueryMsg) -> StdResult<Binary> 
             to_json_binary(&ConfigResponse {
                 connection_id: config.connection_id,
                 dex_label: config.dex_label,
+                transfer_channel: config.transfer_channel,
                 lease_code_id: CodeId::from(config.lease_code).into(),
             })
         }
@@ -449,6 +452,7 @@ impl Instantiator {
             protocol_admin: sdk::testing::user(ADMIN).into_string(),
             connection_id: super::test_case::TestCase::DEX_CONNECTION_ID.into(),
             dex_label: "test-dex".into(),
+            transfer_channel: "channel-0".into(),
             lease_code: Uint64::from(CodeId::from(lease_code)),
         };
 

--- a/tests/src/common/remote_lease_controller_stub.rs
+++ b/tests/src/common/remote_lease_controller_stub.rs
@@ -320,10 +320,10 @@ where
         .unwrap_or(ResponseMode::Ok);
 
     let callback = match mode {
-        ResponseMode::Ok => RemoteLeaseCallback::OperationOk(build_ok(deps.storage)?),
+        ResponseMode::Ok => RemoteLeaseCallback::OperationOk(build_ok(deps.storage)?.into()),
         ResponseMode::Err(reason) => RemoteLeaseCallback::OperationErr(reason),
         ResponseMode::Delayed => {
-            let payload = RemoteLeaseCallback::OperationOk(build_ok(deps.storage)?);
+            let payload = RemoteLeaseCallback::OperationOk(build_ok(deps.storage)?.into());
             PENDING.save(
                 deps.storage,
                 op,
@@ -336,7 +336,7 @@ where
         }
         ResponseMode::UnderpayingOnce => {
             MODES.save(deps.storage, op, &ResponseMode::Ok)?;
-            RemoteLeaseCallback::OperationOk(underpay(build_ok(deps.storage)?))
+            RemoteLeaseCallback::OperationOk(underpay(build_ok(deps.storage)?).into())
         }
     };
 

--- a/tests/src/lease/remote_lease_callback.rs
+++ b/tests/src/lease/remote_lease_callback.rs
@@ -23,7 +23,7 @@ use lease::{
 };
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback},
-    response::{CloseLeaseResponse, OperationResponse},
+    response::{CloseLeaseResponse, WireOperationResponse},
 };
 use sdk::{
     cosmwasm_std::{Addr, Event, StdError},
@@ -108,7 +108,7 @@ fn operation_err_retries_the_in_flight_leg() {
 fn non_swap_operation_ok_is_absorbed() {
     let (mut test_case, lease) = drive_to_swap_pending();
     let controller = controller_addr(&test_case);
-    let payload = OperationResponse::CloseLease(CloseLeaseResponse {});
+    let payload = WireOperationResponse::CloseLease(CloseLeaseResponse {});
 
     let response = test_case
         .app

--- a/tests/src/lease/remote_lease_open.rs
+++ b/tests/src/lease/remote_lease_open.rs
@@ -12,7 +12,7 @@ use lease::api::{
 };
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback},
-    response::{CloseLeaseResponse, OpenLeaseResponse, OperationResponse, RemoteLeaseId},
+    response::{CloseLeaseResponse, OpenLeaseResponse, RemoteLeaseId, WireOperationResponse},
 };
 use sdk::{cosmwasm_std::Addr, testing};
 
@@ -147,7 +147,7 @@ fn open_failed_on_unexpected_operation_refunds_and_finalises() {
     // open failure — refund and move to terminal — rather than returning
     // `Err`, which would revert the controller's ack and strand the relayer.
     let unexpected =
-        RemoteLeaseCallback::OperationOk(OperationResponse::CloseLease(CloseLeaseResponse {}));
+        RemoteLeaseCallback::OperationOk(WireOperationResponse::CloseLease(CloseLeaseResponse {}));
     let failed = test_case
         .app
         .execute(
@@ -224,7 +224,7 @@ fn late_open_lease_ack_after_open_failed_is_absorbed() {
     // Synthesise the late OK ack that ibc-go would deliver against the
     // already-terminal lease on an UNORDERED channel.
     let late_callback =
-        RemoteLeaseCallback::OperationOk(OperationResponse::OpenLease(OpenLeaseResponse {
+        RemoteLeaseCallback::OperationOk(WireOperationResponse::OpenLease(OpenLeaseResponse {
             remote_lease_id: RemoteLeaseId::new(
                 "StubPdaLate111111111111111111111111111".to_owned(),
             )

--- a/tests/src/lease/remote_lease_swap.rs
+++ b/tests/src/lease/remote_lease_swap.rs
@@ -33,6 +33,9 @@
 //!   but non-swap success payload is absorbed
 //!   (`unexpected-response-variant`); `ExecuteMsg::Heal` re-emits the
 //!   in-flight leg and the opening completes.
+//! - `out_of_registry_ticker_absorbed_at_lease` — a success ack naming a
+//!   ticker outside the currency registry passes the controller
+//!   wire-shaped and is absorbed at the lease (`undecodable-response`).
 
 use currencies::PaymentGroup;
 use currency::{CurrencyDef, MemberOf};
@@ -46,7 +49,10 @@ use lease::api::{
 };
 use remote_lease::{
     callback::RemoteLeaseCallback,
-    response::{OperationResponse, SwapResponse, TransferOutResponse},
+    response::{
+        OperationResponse, SwapResponse, Ticker, TransferOutResponse, WireCoin,
+        WireOperationResponse, WireSwapResponse,
+    },
 };
 use sdk::{
     cosmwasm_std::{Addr, Event},
@@ -236,9 +242,12 @@ fn swap_ack_in_transfer_leg_absorbed() {
     // a swap acknowledgment arrives while both transfer acknowledgments
     // are still outstanding - it must neither error nor advance the
     // transfer countdown
-    let unexpected = RemoteLeaseCallback::OperationOk(OperationResponse::Swap(SwapResponse {
-        amount_out: Coin::<LeaseCurrency>::new(1).into(),
-    }));
+    let unexpected = RemoteLeaseCallback::OperationOk(
+        OperationResponse::Swap(SwapResponse {
+            amount_out: Coin::<LeaseCurrency>::new(1).into(),
+        })
+        .into(),
+    );
     let injected = stub::inject_callback(&mut test_case.app, &controller, &lease, unexpected);
     expect_attribute(&injected.events, ABSORB_EVENT, "absorbed", "response");
     assert_transfers_pending(&test_case, lease.clone());
@@ -278,8 +287,9 @@ fn wrong_variant_callback_absorbed_then_heal_recovers() {
     let _response = transfer_funds(&mut test_case, &lease, DOWNPAYMENT);
     assert_eq!(2, opening_acks_left(&test_case, lease.clone()));
 
-    let wrong_variant =
-        RemoteLeaseCallback::OperationOk(OperationResponse::TransferOut(TransferOutResponse {}));
+    let wrong_variant = RemoteLeaseCallback::OperationOk(WireOperationResponse::TransferOut(
+        TransferOutResponse {},
+    ));
     let injected = stub::inject_callback(&mut test_case.app, &controller, &lease, wrong_variant);
     expect_attribute(
         &injected.events,
@@ -308,6 +318,36 @@ fn wrong_variant_callback_absorbed_then_heal_recovers() {
     expect_attribute(&healed.events, OPENING_SWAP_EVENT, "heal", "re-emit");
 
     let _amount = opened_amount(&test_case, lease);
+}
+
+// The controller forwards success acks wire-shaped (issue #637): a ticker
+// outside the currency registry reaches the lease, whose typed decode fails
+// and absorbs the callback - the controller's ack tx commits.
+#[test]
+fn out_of_registry_ticker_absorbed_at_lease() {
+    let (mut test_case, lease, controller) = start_open(DOWNPAYMENT);
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+
+    let _response = transfer_funds(&mut test_case, &lease, DOWNPAYMENT);
+    assert_eq!(2, opening_acks_left(&test_case, lease.clone()));
+
+    let alien_ticker =
+        RemoteLeaseCallback::OperationOk(WireOperationResponse::Swap(WireSwapResponse {
+            amount_out: WireCoin::new(42, Ticker::new("NOT_IN_REGISTRY")),
+        }));
+    let injected = stub::inject_callback(&mut test_case.app, &controller, &lease, alien_ticker);
+    expect_attribute(
+        &injected.events,
+        OPENING_SWAP_EVENT,
+        "absorbed",
+        "undecodable-response",
+    );
+    assert_eq!(2, opening_acks_left(&test_case, lease.clone()));
 }
 
 fn start_open<DownpaymentC>(downpayment: Coin<DownpaymentC>) -> (LeaseTestCase, Addr, Addr)


### PR DESCRIPTION
## What

Two controller fixes that gate end-to-end deployment of the remote-lease channel, plus a docs sync.

**Handshake version pairing (closes nolus-protocol/ibc-solray#388).** The Solana responder validates and persists the lease↔transfer channel binding from the channel version (ibc-solray#322), so the bare `nls-remote-lease.v1` no longer completes the handshake. The controller now:

- learns the Solana-side ICS-20 transfer channel at instantiation (`InstantiateMsg.transfer_channel`, stored in `Config`, surfaced in `ConfigResponse`),
- rejects non-canonical ids at instantiation (`channel-` prefix, decimal ordinal, no sign or leading zeros, `u16` range — exactly what the responder enforces, failing locally instead of cross-chain),
- proposes `nls-remote-lease.v1+transfer=channel-<N>` in `MsgChannelOpenInit` and requires the same grammar on every handshake callback,
- verifies the counterparty's echoed version on `OpenAck` (`InvalidCounterpartyVersion`).

The suffix exists at the handshake layer only. `remote_lease::VERSION` and the per-packet `ProtocolVersion` pin stay bare — extending the shared constant would break packet deserialization on both sides (the double-duty hazard ADR-0002 §3.3 warns about).

**Wire-shape ack decoding (closes #637).** `ibc_packet_ack` used to decode the acknowledged payload into the typed `OperationResponse`, whose coin parsing validates tickers against the currency registry — a response naming an out-of-registry ticker failed *at the controller*, and a failing ack handler makes the relayer retry forever. The controller now decodes the wire shape only and `RemoteLeaseCallback::OperationOk` carries it verbatim; the lease's typed, registry-validating decode runs at the remote-swap leg, where a miss is absorbed (`undecodable-response`) so the ack commits. Wire-shape hardening (length caps, canonical amounts, `deny_unknown_fields`) still applies at the controller — wire garbage remains the one case it may surface as an ack-handling error.

**Docs.** `protocol/docs/remote-lease-callback-flow.md` now matches the shipped callback routing (direct remote-swap processing, leaser-query auth gate, safe-delivery segment scoped to the still-ICA legs, storage v11); `RUNBOOK.md` gains the local-vs-CI clippy divergence entry and the `PROTOCOL_*` env trio.

## Testing

- New handshake tests: bare version rejected, wrong transfer suffix rejected, counterparty echo mismatch rejected on `OpenAck`; instantiation rejects eight non-canonical channel-id shapes.
- New ack-path tests at both levels: the controller forwards an out-of-registry ticker without erring (`packet_ack_out_of_registry_ticker_dispatches_ok`); the lease absorbs it (`out_of_registry_ticker_absorbed_at_lease`).
- Pinned `.bin` StdAck fixture tests unchanged and green; the dispatched-callback wire-shape pin unchanged.
- Full gate green on the CI-pinned toolchain (1.94): build, fmt, clippy with and without test targets, full test run across the protocol and tests workspaces.
- Each commit builds standalone (verified in a separate worktree for the first).

## Reviews

Two independent reviews ran over `4a863c1f0..HEAD` before push; the scope of the diff was separately checked against the plan (no out-of-plan changes, no manifest/CI edits).

**Correctness checklist (12 generic items + the project rules from the contribution checklist): all PASS.** Three follow-ups surfaced and were resolved:

1. *Stored-`Config` schema change with a pass-through `migrate`* — an already-instantiated controller migrated onto this code would pass `update_software` and then fail every `Config::load`. Resolved in the last commit: `migrate` now probes `Config::load`, refusing the upgrade (old code keeps running) instead of bricking after it. No deployed controller instance exists on any network (verified against the archive node — only the five legacy OSMOSIS protocols are registered), so no migration path is owed.
2. *Proposed handshake version asserted only transitively* — the admin test now decodes the emitted `MsgChannelOpenInit` and pins `channel.version` to the suffixed grammar.
3. *Wire-contract spec edit initially left out of the docs commit* — `docs/remote-lease-wire-contract.md` now records the suffixed handshake grammar and the wire-shape ack decoding alongside the unchanged packet-level pin.

**Security-focused review: CLEAR (nothing above MEDIUM).** The MEDIUM was the same migration finding (resolved above). One LOW: `OpenConfirm` carries no counterparty version to verify — unreachable while `OpenTry` stays rejected; the invariant is now documented at the match. Verified non-findings worth recording: (a) moving registry validation out of the ack handler is a net availability improvement — at the merge-base an out-of-registry ticker permanently stranded the ack (unordered channel, no timeout proof possible once the ack is written); all wire-layer hardening (`deny_unknown_fields`, canonical amounts, length caps, version pin) is unchanged, and the fund-routing floor still comes from the leg's own persisted `min_out`, never from the counterparty. (b) No version-grammar injection surface: the suffix is composed from a compile-time constant plus a digits-only validated channel id, config is immutable post-instantiation, and all comparisons are whole-string equality. Coverage note: semgrep is not installed on this machine, so mechanical scanning of the parsing changes did not run; review of that category was manual plus the wire crate's canonicalization tests.
