### PR TITLE
feat: restore the remote-lease slippage terminal for opened swap legs

### DIFF
--- a/protocol/contracts/lease/src/contract/finalize.rs
+++ b/protocol/contracts/lease/src/contract/finalize.rs
@@ -53,6 +53,15 @@ impl LeasesRef {
             .map_err(ContractError::PositionLimitsQuery)
     }
 
+    pub(super) fn anomaly_resolution_permission<'self_, 'querier>(
+        &'self_ self,
+        querier: QuerierWrapper<'querier>,
+    ) -> impl AccessPermission + use<'self_, 'querier> {
+        RemotelyGrantedPermission::new(&self.addr, querier, |caller| {
+            AccessCheck::AnomalyResolution { by: caller }
+        })
+    }
+
     pub(super) fn close_position_permission<'self_, 'querier>(
         &'self_ self,
         querier: QuerierWrapper<'querier>,

--- a/protocol/contracts/lease/src/contract/state/dex.rs
+++ b/protocol/contracts/lease/src/contract/state/dex.rs
@@ -3,7 +3,10 @@ use serde::{Deserialize, Serialize};
 use dex::{Contract as DexContract, Handler as DexHandler};
 use finance::duration::Duration;
 use finance::instant::Instant;
-use platform::{ica::ErrorResponse as ICAErrorResponse, state_machine};
+use platform::{
+    batch::Batch, ica::ErrorResponse as ICAErrorResponse, message::Response as MessageResponse,
+    state_machine,
+};
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback},
     response::WireOperationResponse,
@@ -141,13 +144,24 @@ where
         self.handler.on_time_alarm(querier, env, info).into()
     }
 
+    /// A live dex leg drops a price alarm silently - the swap is mid-flight
+    /// and a re-quote would corrupt its pinned floor. A leg parked at the
+    /// slippage-anomaly terminal is frozen until an operator heal, so it
+    /// still drops the alarm but emits a dropped-alarm event: monitoring must
+    /// see that a frozen lease ignored a price move it would normally act on.
     fn on_price_alarm(
         self,
         _querier: QuerierWrapper<'_>,
         _env: Env,
         _info: MessageInfo,
     ) -> ContractResult<Response> {
-        super::ignore_msg(self)
+        match self.handler.price_alarm_dropped() {
+            None => super::ignore_msg(self),
+            Some(emitter) => Ok(Response::from(
+                MessageResponse::messages_with_event(Batch::default(), emitter),
+                self,
+            )),
+        }
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/dex.rs
+++ b/protocol/contracts/lease/src/contract/state/dex.rs
@@ -114,9 +114,9 @@ where
         self,
         querier: QuerierWrapper<'_>,
         env: Env,
-        _info: MessageInfo,
+        info: MessageInfo,
     ) -> ContractResult<Response> {
-        self.handler.heal(querier, env).into()
+        self.handler.heal(querier, env, &info).into()
     }
 
     fn state(

--- a/protocol/contracts/lease/src/contract/state/opened/close/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/mod.rs
@@ -1,4 +1,4 @@
-use dex::SlippageCalculator;
+use dex::{CoinsNb, SlippageCalculator};
 
 use crate::{
     api::{
@@ -18,6 +18,7 @@ pub(crate) trait Closable {
     fn amount<'a>(&'a self, lease: &'a Lease) -> &'a LeaseCoin;
     fn transaction(&self, lease: &Lease, in_progress: PositionCloseTrx) -> OngoingTrx;
     fn event_type(&self) -> Type;
+    fn timeout_retry_budget(&self) -> CoinsNb;
 }
 
 /// Aim to simplify trait boundaries within this module and underneat

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/full.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/full.rs
@@ -1,3 +1,4 @@
+use dex::CoinsNb;
 use profit::stub::ProfitStub;
 use sdk::cosmwasm_std::Env;
 
@@ -27,6 +28,8 @@ type Spec = FullClose;
 pub(in super::super) type RepayableImpl = Close<Spec>;
 pub(crate) type DexState = close::sell_asset::DexState<RepayableImpl, Calculator>;
 
+const TIMEOUT_RETRY_BUDGET: CoinsNb = 2;
+
 impl IntoRepayable for Spec {
     type Repayable = RepayableImpl;
 
@@ -49,6 +52,10 @@ impl Closable for Spec {
 
     fn event_type(&self) -> Type {
         Type::ClosePosition
+    }
+
+    fn timeout_retry_budget(&self) -> CoinsNb {
+        TIMEOUT_RETRY_BUDGET
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/partial.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/partial.rs
@@ -1,3 +1,4 @@
+use dex::CoinsNb;
 use sdk::cosmwasm_std::Env;
 
 use crate::{
@@ -26,6 +27,8 @@ type Spec = PartialClose;
 pub(in super::super) type RepayableImpl = Repay<Spec>;
 pub(crate) type DexState = close::sell_asset::DexState<RepayableImpl, Calculator>;
 
+const TIMEOUT_RETRY_BUDGET: CoinsNb = 2;
+
 impl IntoRepayable for Spec {
     type Repayable = RepayableImpl;
 
@@ -48,6 +51,10 @@ impl Closable for Spec {
 
     fn event_type(&self) -> Type {
         Type::ClosePosition
+    }
+
+    fn timeout_retry_budget(&self) -> CoinsNb {
+        TIMEOUT_RETRY_BUDGET
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/full.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/full.rs
@@ -1,3 +1,4 @@
+use dex::CoinsNb;
 use profit::stub::ProfitStub;
 use sdk::cosmwasm_std::Env;
 
@@ -27,6 +28,8 @@ type Spec = FullLiquidationDTO;
 pub(in super::super) type RepayableImpl = Close<Spec>;
 pub(crate) type DexState = close::sell_asset::DexState<RepayableImpl, Calculator>;
 
+const TIMEOUT_RETRY_BUDGET: CoinsNb = 5;
+
 impl IntoRepayable for Spec {
     type Repayable = RepayableImpl;
 
@@ -50,6 +53,10 @@ impl Closable for Spec {
 
     fn event_type(&self) -> Type {
         Type::LiquidationSwap
+    }
+
+    fn timeout_retry_budget(&self) -> CoinsNb {
+        TIMEOUT_RETRY_BUDGET
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/partial.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/partial.rs
@@ -1,3 +1,4 @@
+use dex::CoinsNb;
 use sdk::cosmwasm_std::Env;
 
 use crate::{
@@ -25,6 +26,8 @@ type Spec = PartialLiquidationDTO;
 pub(in super::super) type RepayableImpl = Repay<Spec>;
 pub(crate) type DexState = close::sell_asset::DexState<RepayableImpl, Calculator>;
 
+const TIMEOUT_RETRY_BUDGET: CoinsNb = 5;
+
 impl IntoRepayable for Spec {
     type Repayable = RepayableImpl;
 
@@ -48,6 +51,10 @@ impl Closable for Spec {
 
     fn event_type(&self) -> Type {
         Type::LiquidationSwap
+    }
+
+    fn timeout_retry_budget(&self) -> CoinsNb {
+        TIMEOUT_RETRY_BUDGET
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 
 use dex::{
     Account, CoinsNb, ContractInRemoteSwap, Enterable, Error as DexError, RemoteSwapClient,
-    SlippageCalculator, SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
+    SlippageCalculator, SlippageEscalation, SwapOutputTask, SwapTask, WithCalculator,
+    WithOutputTask,
 };
 use finance::instant::Instant;
 use finance::{
@@ -153,6 +154,10 @@ where
         self.repayable.timeout_retry_budget()
     }
 
+    fn slippage_escalation(&self) -> SlippageEscalation {
+        SlippageEscalation::Park
+    }
+
     fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>> {
         iter::once(*self.repayable.amount(&self.lease))
     }
@@ -276,6 +281,22 @@ where
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
         self.query(PositionCloseTrx::Swap, now, due_projection, querier)
+    }
+
+    fn anomaly_state(
+        self,
+        _acks_left: CoinsNb,
+        now: Instant,
+        due_projection: Duration,
+        querier: QuerierWrapper<'_>,
+    ) -> Self::StateResponse {
+        opened::lease_state(
+            self.lease,
+            Status::SlippageProtectionActivated,
+            now,
+            due_projection,
+            querier,
+        )
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
@@ -149,6 +149,10 @@ where
         .map_err(DexError::Unauthorized)
     }
 
+    fn timeout_retry_budget(&self) -> CoinsNb {
+        self.repayable.timeout_retry_budget()
+    }
+
     fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>> {
         iter::once(*self.repayable.amount(&self.lease))
     }

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
@@ -150,6 +150,18 @@ where
         .map_err(DexError::Unauthorized)
     }
 
+    fn authz_anomaly_resolution(
+        &self,
+        querier: QuerierWrapper<'_>,
+        info: &MessageInfo,
+    ) -> dex::DexResult<()> {
+        access_control::check(
+            &self.lease.leases.anomaly_resolution_permission(querier),
+            info,
+        )
+        .map_err(DexError::Unauthorized)
+    }
+
     fn timeout_retry_budget(&self) -> CoinsNb {
         self.repayable.timeout_retry_budget()
     }

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
@@ -295,7 +295,7 @@ where
         self.query(PositionCloseTrx::Swap, now, due_projection, querier)
     }
 
-    fn anomaly_state(
+    fn anomaly_response(
         self,
         _acks_left: CoinsNb,
         now: Instant,

--- a/protocol/contracts/lease/src/contract/state/opened/payment/close.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/payment/close.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use dex::CoinsNb;
 use platform::bank::FixedAddressSender;
 use sdk::cosmwasm_std::{Env, QuerierWrapper};
 
@@ -70,6 +71,10 @@ where
 
     fn event_type(&self) -> Type {
         self.0.event_type()
+    }
+
+    fn timeout_retry_budget(&self) -> CoinsNb {
+        self.0.timeout_retry_budget()
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opened/payment/repay.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/payment/repay.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use dex::CoinsNb;
 use sdk::cosmwasm_std::{Env, QuerierWrapper};
 
 use crate::{
@@ -64,6 +65,10 @@ where
 
     fn event_type(&self) -> Type {
         self.0.event_type()
+    }
+
+    fn timeout_retry_budget(&self) -> CoinsNb {
+        self.0.timeout_retry_budget()
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
@@ -57,6 +57,8 @@ const NON_SWAP_RESPONSE: &str = "non-swap operation response";
 /// response cannot have originated from the scheduled repay swap.
 const OUT_NOT_LPN: &str = "swapped-out currency is not the lease LPN";
 
+const TIMEOUT_RETRY_BUDGET: CoinsNb = 3;
+
 pub(crate) type DexState = dex::StateOutSwap<BuyLpn, SwapClient, ForwardToDexEntry>;
 pub(crate) type DrainState = dex::StateDrain<RepayDrain<RepayFinish>>;
 
@@ -140,6 +142,10 @@ impl SwapTask for BuyLpn {
             info,
         )
         .map_err(DexError::Unauthorized)
+    }
+
+    fn timeout_retry_budget(&self) -> CoinsNb {
+        TIMEOUT_RETRY_BUDGET
     }
 
     fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>> {

--- a/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
@@ -292,7 +292,7 @@ impl ContractInRemoteSwap for BuyLpn {
         self.query(RepayTrx::Swap, now, due_projection, querier)
     }
 
-    fn anomaly_state(
+    fn anomaly_response(
         self,
         _acks_left: CoinsNb,
         now: Instant,

--- a/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 
 use dex::{
     AcceptAnyNonZeroSwap, Account, AnomalyTreatment, CoinsNb, ContractInRemoteSwap, ContractInSwap,
-    Enterable, Error as DexError, RemoteSwapClient, Stage, SwapOutputTask, SwapTask,
-    WithCalculator, WithOutputTask,
+    Enterable, Error as DexError, RemoteSwapClient, SlippageEscalation, Stage, SwapOutputTask,
+    SwapTask, WithCalculator, WithOutputTask,
 };
 use finance::instant::Instant;
 use finance::{
@@ -148,6 +148,10 @@ impl SwapTask for BuyLpn {
         TIMEOUT_RETRY_BUDGET
     }
 
+    fn slippage_escalation(&self) -> SlippageEscalation {
+        SlippageEscalation::Park
+    }
+
     fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>> {
         iter::once(self.payment)
     }
@@ -274,6 +278,22 @@ impl ContractInRemoteSwap for BuyLpn {
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
         self.query(RepayTrx::Swap, now, due_projection, querier)
+    }
+
+    fn anomaly_state(
+        self,
+        _acks_left: CoinsNb,
+        now: Instant,
+        due_projection: Duration,
+        querier: QuerierWrapper<'_>,
+    ) -> Self::StateResponse {
+        opened::lease_state(
+            self.lease,
+            Status::SlippageProtectionActivated,
+            now,
+            due_projection,
+            querier,
+        )
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
@@ -144,6 +144,18 @@ impl SwapTask for BuyLpn {
         .map_err(DexError::Unauthorized)
     }
 
+    fn authz_anomaly_resolution(
+        &self,
+        querier: QuerierWrapper<'_>,
+        info: &MessageInfo,
+    ) -> dex::DexResult<()> {
+        access_control::check(
+            &self.lease.leases.anomaly_resolution_permission(querier),
+            info,
+        )
+        .map_err(DexError::Unauthorized)
+    }
+
     fn timeout_retry_budget(&self) -> CoinsNb {
         TIMEOUT_RETRY_BUDGET
     }

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -187,6 +187,14 @@ impl SwapTask for BuyAsset {
             .map_err(DexError::Unauthorized)
     }
 
+    fn authz_anomaly_resolution(
+        &self,
+        _querier: QuerierWrapper<'_>,
+        _info: &MessageInfo,
+    ) -> dex::DexResult<()> {
+        unreachable!("the opening swap re-emits on a slippage anomaly and never parks")
+    }
+
     fn timeout_retry_budget(&self) -> CoinsNb {
         TIMEOUT_RETRY_BUDGET
     }

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -56,6 +56,8 @@ const NON_SWAP_RESPONSE: &str = "non-swap operation response";
 /// group, so the response cannot have originated from the scheduled swap.
 const OUT_NOT_AN_ASSET: &str = "swapped-out currency is not a lease asset";
 
+const TIMEOUT_RETRY_BUDGET: CoinsNb = 3;
+
 type AssetGroup = LeaseAssetCurrencies;
 pub(super) type StartState = StartLocalRemoteState<OpenIcaAccount, BuyAsset>;
 pub(in super::super) type DexState = dex::StateRemoteOut<
@@ -182,6 +184,10 @@ impl SwapTask for BuyAsset {
     ) -> dex::DexResult<()> {
         access_control::check(&self.deps.3.remote_lease_callback_permission(querier), info)
             .map_err(DexError::Unauthorized)
+    }
+
+    fn timeout_retry_budget(&self) -> CoinsNb {
+        TIMEOUT_RETRY_BUDGET
     }
 
     fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>> {

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 use dex::MaxSlippage;
 use dex::{
     Account, CoinsNb, ContractInRemoteSwap, ContractInSwap, Error as DexError, RemoteSwapClient,
-    Stage, StartLocalRemoteState, SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
+    SlippageEscalation, Stage, StartLocalRemoteState, SwapOutputTask, SwapTask, WithCalculator,
+    WithOutputTask,
 };
 use finance::coin::{Amount, Coin};
 use finance::instant::Instant;
@@ -190,6 +191,12 @@ impl SwapTask for BuyAsset {
         TIMEOUT_RETRY_BUDGET
     }
 
+    /// The opening swap re-emits on a slippage anomaly and never parks - a
+    /// follow-up issue owns the opening-leg terminal (see issue #655).
+    fn slippage_escalation(&self) -> SlippageEscalation {
+        SlippageEscalation::ReEmit
+    }
+
     fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>> {
         [self.downpayment, self.loan.principal.into_super_group()].into_iter()
     }
@@ -293,6 +300,16 @@ impl ContractInRemoteSwap for BuyAsset {
         _querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
         self.state(|_ica_account| OngoingTrx::BuyAsset { acks_left })
+    }
+
+    fn anomaly_state(
+        self,
+        _acks_left: CoinsNb,
+        _now: Instant,
+        _due_projection: Duration,
+        _querier: QuerierWrapper<'_>,
+    ) -> Self::StateResponse {
+        unreachable!("the opening swap re-emits on a slippage anomaly and never parks")
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -38,7 +38,7 @@ use crate::{
             resp_delivery::{ForwardToDexEntry, ForwardToDexEntryContinue},
         },
     },
-    error::ContractResult,
+    error::{ContractError, ContractResult},
     event::Type,
     finance::{LppRef, OracleRef},
 };
@@ -58,6 +58,11 @@ const NON_SWAP_RESPONSE: &str = "non-swap operation response";
 const OUT_NOT_AN_ASSET: &str = "swapped-out currency is not a lease asset";
 
 const TIMEOUT_RETRY_BUDGET: CoinsNb = 3;
+
+/// The operation names the never-parking opening swap reports for the two
+/// slippage-anomaly trait methods it can never legitimately reach.
+const ANOMALY_RESOLUTION_OP: &str = "slippage-anomaly resolution";
+const ANOMALY_RESPONSE_OP: &str = "slippage-anomaly state query";
 
 type AssetGroup = LeaseAssetCurrencies;
 pub(super) type StartState = StartLocalRemoteState<OpenIcaAccount, BuyAsset>;
@@ -187,12 +192,19 @@ impl SwapTask for BuyAsset {
             .map_err(DexError::Unauthorized)
     }
 
+    /// The opening swap re-emits on a slippage anomaly and never parks, so the
+    /// heal that this authorisation guards is never reached. A deserialized
+    /// `SlippageAnomaly` arm is not type-excluded, so the unreachable path
+    /// returns a typed error rather than panicking.
     fn authz_anomaly_resolution(
         &self,
         _querier: QuerierWrapper<'_>,
         _info: &MessageInfo,
     ) -> dex::DexResult<()> {
-        unreachable!("the opening swap re-emits on a slippage anomaly and never parks")
+        Err(DexError::UnsupportedOperation(
+            ANOMALY_RESOLUTION_OP.into(),
+            String::from(self.label()),
+        ))
     }
 
     fn timeout_retry_budget(&self) -> CoinsNb {
@@ -310,14 +322,18 @@ impl ContractInRemoteSwap for BuyAsset {
         self.state(|_ica_account| OngoingTrx::BuyAsset { acks_left })
     }
 
-    fn anomaly_state(
+    /// The opening swap re-emits on a slippage anomaly and never parks, so a
+    /// persisted `SlippageAnomaly` arm for it can only be a corrupt or
+    /// out-of-protocol state. A deserialized state is not type-excluded, so
+    /// the unreachable path returns a typed error rather than panicking.
+    fn anomaly_response(
         self,
         _acks_left: CoinsNb,
         _now: Instant,
         _due_projection: Duration,
         _querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
-        unreachable!("the opening swap re-emits on a slippage anomaly and never parks")
+        Err(ContractError::unsupported_operation(ANOMALY_RESPONSE_OP))
     }
 }
 

--- a/protocol/contracts/profit/src/contract.rs
+++ b/protocol/contracts/profit/src/contract.rs
@@ -145,7 +145,10 @@ pub fn execute(
                 .map(response::response_only_messages)
         }
         ExecuteMsg::Heal() => {
-            try_handle_execute_message(deps, env, State::heal).map(response::response_only_messages)
+            try_handle_execute_message(deps, env, |state, querier, env| {
+                State::heal(state, querier, env, &info)
+            })
+            .map(response::response_only_messages)
         }
     }
 }

--- a/protocol/contracts/profit/src/contract.rs
+++ b/protocol/contracts/profit/src/contract.rs
@@ -144,12 +144,10 @@ pub fn execute(
             try_handle_execute_message(deps, env, State::on_inner_continue)
                 .map(response::response_only_messages)
         }
-        ExecuteMsg::Heal() => {
-            try_handle_execute_message(deps, env, |state, querier, env| {
-                State::heal(state, querier, env, &info)
-            })
-            .map(response::response_only_messages)
-        }
+        ExecuteMsg::Heal() => try_handle_execute_message(deps, env, |machine, querier, env| {
+            State::heal(machine, querier, env, &info)
+        })
+        .map(response::response_only_messages),
     }
 }
 

--- a/protocol/contracts/profit/src/state/buy_back.rs
+++ b/protocol/contracts/profit/src/state/buy_back.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use currencies::{Native, Nls, PaymentGroup};
 use dex::{
     AcceptAnyNonZeroSwap, Account, AnomalyTreatment, CoinsNb, ContractInSwap, DexResult,
-    Error as DexError, Response as DexResponse, Stage, StateLocalOut, SwapOutputTask, SwapTask,
-    WithCalculator, WithOutputTask,
+    Error as DexError, Response as DexResponse, SlippageEscalation, Stage, StateLocalOut,
+    SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
 };
 use finance::instant::Instant;
 use finance::{
@@ -99,6 +99,13 @@ impl SwapTask for BuyBack {
 
     fn timeout_retry_budget(&self) -> CoinsNb {
         TIMEOUT_RETRY_BUDGET
+    }
+
+    /// Profit's buy-back runs over the ICA transport, never the remote-lease
+    /// swap, so its anomaly escalation is never consulted; re-emitting keeps
+    /// it aligned with the unbounded local-swap retry.
+    fn slippage_escalation(&self) -> SlippageEscalation {
+        SlippageEscalation::ReEmit
     }
 
     fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>> {

--- a/protocol/contracts/profit/src/state/buy_back.rs
+++ b/protocol/contracts/profit/src/state/buy_back.rs
@@ -3,9 +3,9 @@ use serde::{Deserialize, Serialize};
 
 use currencies::{Native, Nls, PaymentGroup};
 use dex::{
-    AcceptAnyNonZeroSwap, Account, AnomalyTreatment, ContractInSwap, DexResult, Error as DexError,
-    Response as DexResponse, Stage, StateLocalOut, SwapOutputTask, SwapTask, WithCalculator,
-    WithOutputTask,
+    AcceptAnyNonZeroSwap, Account, AnomalyTreatment, CoinsNb, ContractInSwap, DexResult,
+    Error as DexError, Response as DexResponse, Stage, StateLocalOut, SwapOutputTask, SwapTask,
+    WithCalculator, WithOutputTask,
 };
 use finance::instant::Instant;
 use finance::{
@@ -23,6 +23,8 @@ use super::{
     Config, ConfigManagement, State, StateEnum, SwapClient, idle::Idle,
     resp_delivery::ForwardToDexEntry,
 };
+
+const TIMEOUT_RETRY_BUDGET: CoinsNb = 3;
 
 #[derive(Serialize, Deserialize)]
 pub(super) struct BuyBack {
@@ -93,6 +95,10 @@ impl SwapTask for BuyBack {
         Err(DexError::Unauthorized(
             access_control::error::Error::Unauthorized {},
         ))
+    }
+
+    fn timeout_retry_budget(&self) -> CoinsNb {
+        TIMEOUT_RETRY_BUDGET
     }
 
     fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>> {

--- a/protocol/contracts/profit/src/state/buy_back.rs
+++ b/protocol/contracts/profit/src/state/buy_back.rs
@@ -97,6 +97,17 @@ impl SwapTask for BuyBack {
         ))
     }
 
+    fn authz_anomaly_resolution(
+        &self,
+        _querier: QuerierWrapper<'_>,
+        _info: &MessageInfo,
+    ) -> DexResult<()> {
+        // Profit's buy-back never parks at the remote-swap terminal.
+        Err(DexError::Unauthorized(
+            access_control::error::Error::Unauthorized {},
+        ))
+    }
+
     fn timeout_retry_budget(&self) -> CoinsNb {
         TIMEOUT_RETRY_BUDGET
     }

--- a/protocol/contracts/profit/src/state/mod.rs
+++ b/protocol/contracts/profit/src/state/mod.rs
@@ -221,11 +221,11 @@ impl Handler for State {
         }
     }
 
-    fn heal(self, querier: QuerierWrapper<'_>, env: Env) -> SwapDecision<Self> {
+    fn heal(self, querier: QuerierWrapper<'_>, env: Env, info: &MessageInfo) -> SwapDecision<Self> {
         match self.0 {
-            StateEnum::OpenIca(ica) => ica.heal(querier, env).map_into(),
-            StateEnum::Idle(idle) => idle.heal(querier, env).map_into(),
-            StateEnum::BuyBack(buy_back) => buy_back.heal(querier, env).map_into(),
+            StateEnum::OpenIca(ica) => ica.heal(querier, env, info).map_into(),
+            StateEnum::Idle(idle) => idle.heal(querier, env, info).map_into(),
+            StateEnum::BuyBack(buy_back) => buy_back.heal(querier, env, info).map_into(),
         }
     }
 

--- a/protocol/packages/dex/src/error.rs
+++ b/protocol/packages/dex/src/error.rs
@@ -36,6 +36,11 @@ pub enum Error {
     #[error("[Dex] [RemoteSwap] No in-flight swap leg matches the current task state")]
     MissingSwapLeg,
 
+    #[error(
+        "[Dex] [SlippageAnomaly] A restored parked terminal violates its in-flight-leg invariant"
+    )]
+    SlippageAnomalyInvariantViolated,
+
     #[error("[Dex] [RemoteSwap] The number of swap legs exceeds the supported maximum of {0}")]
     SwapLegsNbOverflow(CoinsNb),
 

--- a/protocol/packages/dex/src/impl_/drain.rs
+++ b/protocol/packages/dex/src/impl_/drain.rs
@@ -166,12 +166,7 @@ mod impl_handler {
             }
         }
 
-        fn heal(
-            self,
-            querier: QuerierWrapper<'_>,
-            env: Env,
-            info: &MessageInfo,
-        ) -> Result<Self> {
+        fn heal(self, querier: QuerierWrapper<'_>, env: Env, info: &MessageInfo) -> Result<Self> {
             match self {
                 State::TransferOut(inner) => Handler::heal(inner, querier, env, info).map_into(),
                 State::FundsArrival(inner) => Handler::heal(inner, querier, env, info).map_into(),

--- a/protocol/packages/dex/src/impl_/drain.rs
+++ b/protocol/packages/dex/src/impl_/drain.rs
@@ -166,10 +166,15 @@ mod impl_handler {
             }
         }
 
-        fn heal(self, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
+        fn heal(
+            self,
+            querier: QuerierWrapper<'_>,
+            env: Env,
+            info: &MessageInfo,
+        ) -> Result<Self> {
             match self {
-                State::TransferOut(inner) => Handler::heal(inner, querier, env).map_into(),
-                State::FundsArrival(inner) => Handler::heal(inner, querier, env).map_into(),
+                State::TransferOut(inner) => Handler::heal(inner, querier, env, info).map_into(),
+                State::FundsArrival(inner) => Handler::heal(inner, querier, env, info).map_into(),
             }
         }
 

--- a/protocol/packages/dex/src/impl_/funds_arrival.rs
+++ b/protocol/packages/dex/src/impl_/funds_arrival.rs
@@ -114,7 +114,12 @@ where
         self.spec.authz_remote_callback(querier, info)
     }
 
-    fn heal(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
+    fn heal(
+        self,
+        querier: QuerierWrapper<'_>,
+        env: Env,
+        _info: &MessageInfo,
+    ) -> HandlerResult<Self> {
         self.try_complete(querier, env)
     }
 
@@ -248,7 +253,7 @@ mod tests {
 
         assert_eq!(
             mock::FINISH_RESULT,
-            finished(arrival(true).heal(querier, testing::mock_env()))
+            finished(arrival(true).heal(querier, testing::mock_env(), &alarms_delivery()))
         );
     }
 

--- a/protocol/packages/dex/src/impl_/mod.rs
+++ b/protocol/packages/dex/src/impl_/mod.rs
@@ -17,6 +17,7 @@ pub use self::{
     remote_transfer_out::{DrainStage, RemoteTransferOut, RemoteTransferOutTask},
     resp_delivery::{ICAOpenResponseDelivery, ResponseDelivery},
     slippage::{AcceptAnyNonZeroSwap, Calculator as AcceptUpToMaxSlippage, MaxSlippage},
+    slippage_anomaly::SlippageAnomaly,
     swap_exact_in::SwapExactIn,
     transfer_in_finish::TransferInFinish,
     transfer_in_init::TransferInInit,
@@ -37,6 +38,7 @@ mod remote_swap_only;
 mod remote_transfer_out;
 mod resp_delivery;
 mod slippage;
+mod slippage_anomaly;
 mod swap_exact_in;
 mod timeout;
 mod transfer_in;

--- a/protocol/packages/dex/src/impl_/out_local.rs
+++ b/protocol/packages/dex/src/impl_/out_local.rs
@@ -334,21 +334,28 @@ mod impl_handler {
             }
         }
 
-        fn heal(self, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
+        fn heal(
+            self,
+            querier: QuerierWrapper<'_>,
+            env: Env,
+            info: &MessageInfo,
+        ) -> Result<Self> {
             match self {
-                State::TransferOut(inner) => Handler::heal(inner, querier, env).map_into(),
+                State::TransferOut(inner) => Handler::heal(inner, querier, env, info).map_into(),
                 State::TransferOutRespDelivery(inner) => {
-                    Handler::heal(inner, querier, env).map_into()
+                    Handler::heal(inner, querier, env, info).map_into()
                 }
-                State::SwapExactIn(inner) => Handler::heal(inner, querier, env).map_into(),
+                State::SwapExactIn(inner) => Handler::heal(inner, querier, env, info).map_into(),
                 State::SwapExactInRespDelivery(inner) => {
-                    Handler::heal(inner, querier, env).map_into()
+                    Handler::heal(inner, querier, env, info).map_into()
                 }
-                State::TransferInInit(inner) => Handler::heal(inner, querier, env).map_into(),
+                State::TransferInInit(inner) => Handler::heal(inner, querier, env, info).map_into(),
                 State::TransferInInitRespDelivery(inner) => {
-                    Handler::heal(inner, querier, env).map_into()
+                    Handler::heal(inner, querier, env, info).map_into()
                 }
-                State::TransferInFinish(inner) => Handler::heal(inner, querier, env).map_into(),
+                State::TransferInFinish(inner) => {
+                    Handler::heal(inner, querier, env, info).map_into()
+                }
             }
         }
 

--- a/protocol/packages/dex/src/impl_/out_local.rs
+++ b/protocol/packages/dex/src/impl_/out_local.rs
@@ -334,12 +334,7 @@ mod impl_handler {
             }
         }
 
-        fn heal(
-            self,
-            querier: QuerierWrapper<'_>,
-            env: Env,
-            info: &MessageInfo,
-        ) -> Result<Self> {
+        fn heal(self, querier: QuerierWrapper<'_>, env: Env, info: &MessageInfo) -> Result<Self> {
             match self {
                 State::TransferOut(inner) => Handler::heal(inner, querier, env, info).map_into(),
                 State::TransferOutRespDelivery(inner) => {

--- a/protocol/packages/dex/src/impl_/out_remote.rs
+++ b/protocol/packages/dex/src/impl_/out_remote.rs
@@ -318,12 +318,7 @@ mod impl_handler {
             }
         }
 
-        fn heal(
-            self,
-            querier: QuerierWrapper<'_>,
-            env: Env,
-            info: &MessageInfo,
-        ) -> Result<Self> {
+        fn heal(self, querier: QuerierWrapper<'_>, env: Env, info: &MessageInfo) -> Result<Self> {
             match self {
                 State::OpenIca(inner) => Handler::heal(inner, querier, env, info).map_into(),
                 State::OpenIcaRespDelivery(inner) => {

--- a/protocol/packages/dex/src/impl_/out_remote.rs
+++ b/protocol/packages/dex/src/impl_/out_remote.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     Connectable, IcaConnectee, SwapTask as SwapTaskT,
     impl_::{
-        IcaConnector, RemoteSwap, TransferOut, TransferOutRespDelivery,
+        IcaConnector, RemoteSwap, SlippageAnomaly, TransferOut, TransferOutRespDelivery,
         resp_delivery::ICAOpenResponseDelivery,
     },
 };
@@ -38,6 +38,10 @@ where
         >,
     ),
     RemoteSwap(RemoteSwap<SwapTask, Self>),
+    /// Present only to satisfy the `RemoteSwap` transport's terminal bound -
+    /// the opening swap re-emits on a slippage anomaly and never parks, so a
+    /// follow-up issue owns the opening-leg terminal (see issue #655).
+    SlippageAnomaly(SlippageAnomaly<SwapTask, Self>),
 }
 
 pub type StartLocalRemoteState<OpenIca, SwapTask> =
@@ -54,7 +58,7 @@ where
 mod impl_into {
     use crate::{
         SwapTask as SwapTaskT,
-        impl_::{IcaConnector, RemoteSwap, TransferOut, TransferOutRespDelivery},
+        impl_::{IcaConnector, RemoteSwap, SlippageAnomaly, TransferOut, TransferOutRespDelivery},
     };
 
     use super::{OpenIcaRespDelivery, State};
@@ -132,6 +136,17 @@ mod impl_into {
             Self::RemoteSwap(value)
         }
     }
+
+    impl<OpenIca, SwapTask, SwapClient, ForwardToInnerMsg, ForwardToInnerContinueMsg>
+        From<SlippageAnomaly<SwapTask, Self>>
+        for State<OpenIca, SwapTask, SwapClient, ForwardToInnerMsg, ForwardToInnerContinueMsg>
+    where
+        SwapTask: SwapTaskT,
+    {
+        fn from(value: SlippageAnomaly<SwapTask, Self>) -> Self {
+            Self::SlippageAnomaly(value)
+        }
+    }
 }
 
 mod impl_handler {
@@ -172,6 +187,7 @@ mod impl_handler {
                 State::TransferOut(inner) => inner.authz_remote_callback(querier, info),
                 State::TransferOutRespDelivery(inner) => inner.authz_remote_callback(querier, info),
                 State::RemoteSwap(inner) => inner.authz_remote_callback(querier, info),
+                State::SlippageAnomaly(inner) => inner.authz_remote_callback(querier, info),
             }
         }
 
@@ -199,6 +215,9 @@ mod impl_handler {
                 State::RemoteSwap(inner) => {
                     Handler::on_open_ica(inner, counterparty_version, querier, env)
                 }
+                State::SlippageAnomaly(inner) => {
+                    Handler::on_open_ica(inner, counterparty_version, querier, env)
+                }
             }
         }
 
@@ -222,6 +241,9 @@ mod impl_handler {
                     Handler::on_response(inner, response, querier, env).map_into()
                 }
                 State::RemoteSwap(inner) => {
+                    Handler::on_response(inner, response, querier, env).map_into()
+                }
+                State::SlippageAnomaly(inner) => {
                     Handler::on_response(inner, response, querier, env).map_into()
                 }
             }
@@ -249,6 +271,9 @@ mod impl_handler {
                 State::RemoteSwap(inner) => {
                     Handler::on_error(inner, response, querier, env).map_into()
                 }
+                State::SlippageAnomaly(inner) => {
+                    Handler::on_error(inner, response, querier, env).map_into()
+                }
             }
         }
 
@@ -259,6 +284,7 @@ mod impl_handler {
                 State::TransferOut(inner) => Handler::on_timeout(inner, querier, env),
                 State::TransferOutRespDelivery(inner) => Handler::on_timeout(inner, querier, env),
                 State::RemoteSwap(inner) => Handler::on_timeout(inner, querier, env),
+                State::SlippageAnomaly(inner) => Handler::on_timeout(inner, querier, env),
             }
         }
 
@@ -273,6 +299,7 @@ mod impl_handler {
                     Handler::on_inner(inner, querier, env).map_into()
                 }
                 State::RemoteSwap(inner) => Handler::on_inner(inner, querier, env).map_into(),
+                State::SlippageAnomaly(inner) => Handler::on_inner(inner, querier, env).map_into(),
             }
         }
 
@@ -287,6 +314,7 @@ mod impl_handler {
                     Handler::on_inner_continue(inner, querier, env)
                 }
                 State::RemoteSwap(inner) => Handler::on_inner_continue(inner, querier, env),
+                State::SlippageAnomaly(inner) => Handler::on_inner_continue(inner, querier, env),
             }
         }
 
@@ -299,6 +327,7 @@ mod impl_handler {
                     Handler::heal(inner, querier, env).map_into()
                 }
                 State::RemoteSwap(inner) => Handler::heal(inner, querier, env).map_into(),
+                State::SlippageAnomaly(inner) => Handler::heal(inner, querier, env).map_into(),
             }
         }
 
@@ -309,6 +338,7 @@ mod impl_handler {
                 State::TransferOut(inner) => Handler::reply(inner, querier, env, msg),
                 State::TransferOutRespDelivery(inner) => Handler::reply(inner, querier, env, msg),
                 State::RemoteSwap(inner) => Handler::reply(inner, querier, env, msg),
+                State::SlippageAnomaly(inner) => Handler::reply(inner, querier, env, msg),
             }
         }
 
@@ -332,6 +362,9 @@ mod impl_handler {
                     Handler::on_time_alarm(inner, querier, env, info).map_into()
                 }
                 State::RemoteSwap(inner) => {
+                    Handler::on_time_alarm(inner, querier, env, info).map_into()
+                }
+                State::SlippageAnomaly(inner) => {
                     Handler::on_time_alarm(inner, querier, env, info).map_into()
                 }
             }
@@ -365,6 +398,9 @@ mod impl_handler {
                 State::RemoteSwap(inner) => {
                     Handler::on_remote_response(inner, data, querier, env).map_into()
                 }
+                State::SlippageAnomaly(inner) => {
+                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                }
             }
         }
 
@@ -390,6 +426,9 @@ mod impl_handler {
                 State::RemoteSwap(inner) => {
                     Handler::on_remote_error(inner, response, querier, env).map_into()
                 }
+                State::SlippageAnomaly(inner) => {
+                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                }
             }
         }
 
@@ -406,6 +445,9 @@ mod impl_handler {
                     Handler::on_remote_timeout(inner, querier, env).map_into()
                 }
                 State::RemoteSwap(inner) => {
+                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                }
+                State::SlippageAnomaly(inner) => {
                     Handler::on_remote_timeout(inner, querier, env).map_into()
                 }
             }
@@ -448,6 +490,9 @@ mod impl_contract {
                     Contract::state(inner, now, due_projection, querier)
                 }
                 State::RemoteSwap(inner) => Contract::state(inner, now, due_projection, querier),
+                State::SlippageAnomaly(inner) => {
+                    Contract::state(inner, now, due_projection, querier)
+                }
             }
         }
     }
@@ -473,6 +518,7 @@ mod impl_display {
                 State::TransferOut(inner) => Display::fmt(inner, f),
                 State::TransferOutRespDelivery(inner) => Display::fmt(inner, f),
                 State::RemoteSwap(inner) => inner.fmt(f),
+                State::SlippageAnomaly(inner) => inner.fmt(f),
             }
         }
     }
@@ -540,6 +586,7 @@ mod impl_migration {
                 State::TransferOut(inner) => inner.migrate_spec(migrate_spec).into(),
                 State::TransferOutRespDelivery(inner) => inner.migrate_spec(migrate_spec).into(),
                 State::RemoteSwap(inner) => inner.migrate_spec(migrate_spec).into(),
+                State::SlippageAnomaly(inner) => inner.migrate_spec(migrate_spec).into(),
             }
         }
     }

--- a/protocol/packages/dex/src/impl_/out_remote.rs
+++ b/protocol/packages/dex/src/impl_/out_remote.rs
@@ -318,16 +318,25 @@ mod impl_handler {
             }
         }
 
-        fn heal(self, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
+        fn heal(
+            self,
+            querier: QuerierWrapper<'_>,
+            env: Env,
+            info: &MessageInfo,
+        ) -> Result<Self> {
             match self {
-                State::OpenIca(inner) => Handler::heal(inner, querier, env).map_into(),
-                State::OpenIcaRespDelivery(inner) => Handler::heal(inner, querier, env).map_into(),
-                State::TransferOut(inner) => Handler::heal(inner, querier, env).map_into(),
-                State::TransferOutRespDelivery(inner) => {
-                    Handler::heal(inner, querier, env).map_into()
+                State::OpenIca(inner) => Handler::heal(inner, querier, env, info).map_into(),
+                State::OpenIcaRespDelivery(inner) => {
+                    Handler::heal(inner, querier, env, info).map_into()
                 }
-                State::RemoteSwap(inner) => Handler::heal(inner, querier, env).map_into(),
-                State::SlippageAnomaly(inner) => Handler::heal(inner, querier, env).map_into(),
+                State::TransferOut(inner) => Handler::heal(inner, querier, env, info).map_into(),
+                State::TransferOutRespDelivery(inner) => {
+                    Handler::heal(inner, querier, env, info).map_into()
+                }
+                State::RemoteSwap(inner) => Handler::heal(inner, querier, env, info).map_into(),
+                State::SlippageAnomaly(inner) => {
+                    Handler::heal(inner, querier, env, info).map_into()
+                }
             }
         }
 

--- a/protocol/packages/dex/src/impl_/out_remote.rs
+++ b/protocol/packages/dex/src/impl_/out_remote.rs
@@ -152,7 +152,7 @@ mod impl_into {
 mod impl_handler {
     use std::fmt::Display;
 
-    use platform::ica::ErrorResponse as ICAErrorResponse;
+    use platform::{batch::Emitter, ica::ErrorResponse as ICAErrorResponse};
     use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply};
 
     use crate::{
@@ -450,6 +450,17 @@ mod impl_handler {
                 State::SlippageAnomaly(inner) => {
                     Handler::on_remote_timeout(inner, querier, env).map_into()
                 }
+            }
+        }
+
+        fn price_alarm_dropped(&self) -> Option<Emitter> {
+            match self {
+                State::OpenIca(inner) => inner.price_alarm_dropped(),
+                State::OpenIcaRespDelivery(inner) => inner.price_alarm_dropped(),
+                State::TransferOut(inner) => inner.price_alarm_dropped(),
+                State::TransferOutRespDelivery(inner) => inner.price_alarm_dropped(),
+                State::RemoteSwap(inner) => inner.price_alarm_dropped(),
+                State::SlippageAnomaly(inner) => inner.price_alarm_dropped(),
             }
         }
     }

--- a/protocol/packages/dex/src/impl_/out_swap.rs
+++ b/protocol/packages/dex/src/impl_/out_swap.rs
@@ -8,7 +8,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::{RemoteSwap, TransferOut, TransferOutRespDelivery};
+use super::{RemoteSwap, SlippageAnomaly, TransferOut, TransferOutRespDelivery};
 use crate::{ForwardToInner, SwapTask as SwapTaskT};
 
 #[derive(Serialize, Deserialize)]
@@ -31,6 +31,7 @@ where
         >,
     ),
     RemoteSwap(RemoteSwap<SwapTask, Self>),
+    SlippageAnomaly(SlippageAnomaly<SwapTask, Self>),
 }
 
 pub type StartOutSwapState<SwapTask, SwapClient, ForwardToInnerMsg> = TransferOut<
@@ -54,7 +55,9 @@ where
 mod impl_into {
     use crate::{
         SwapTask as SwapTaskT,
-        impl_::{ForwardToInner, RemoteSwap, TransferOut, TransferOutRespDelivery},
+        impl_::{
+            ForwardToInner, RemoteSwap, SlippageAnomaly, TransferOut, TransferOutRespDelivery,
+        },
     };
 
     use super::State;
@@ -108,6 +111,16 @@ mod impl_into {
             Self::RemoteSwap(value)
         }
     }
+
+    impl<SwapTask, SwapClient, ForwardToInnerMsg> From<SlippageAnomaly<SwapTask, Self>>
+        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    where
+        SwapTask: SwapTaskT,
+    {
+        fn from(value: SlippageAnomaly<SwapTask, Self>) -> Self {
+            Self::SlippageAnomaly(value)
+        }
+    }
 }
 
 mod impl_handler {
@@ -142,6 +155,7 @@ mod impl_handler {
                 State::TransferOut(inner) => inner.authz_remote_callback(querier, info),
                 State::TransferOutRespDelivery(inner) => inner.authz_remote_callback(querier, info),
                 State::RemoteSwap(inner) => inner.authz_remote_callback(querier, info),
+                State::SlippageAnomaly(inner) => inner.authz_remote_callback(querier, info),
             }
         }
 
@@ -159,6 +173,9 @@ mod impl_handler {
                     Handler::on_open_ica(inner, counterparty_version, querier, env)
                 }
                 State::RemoteSwap(inner) => {
+                    Handler::on_open_ica(inner, counterparty_version, querier, env)
+                }
+                State::SlippageAnomaly(inner) => {
                     Handler::on_open_ica(inner, counterparty_version, querier, env)
                 }
             }
@@ -180,6 +197,9 @@ mod impl_handler {
                 State::RemoteSwap(inner) => {
                     Handler::on_response(inner, response, querier, env).map_into()
                 }
+                State::SlippageAnomaly(inner) => {
+                    Handler::on_response(inner, response, querier, env).map_into()
+                }
             }
         }
 
@@ -199,6 +219,9 @@ mod impl_handler {
                 State::RemoteSwap(inner) => {
                     Handler::on_error(inner, response, querier, env).map_into()
                 }
+                State::SlippageAnomaly(inner) => {
+                    Handler::on_error(inner, response, querier, env).map_into()
+                }
             }
         }
 
@@ -207,6 +230,7 @@ mod impl_handler {
                 State::TransferOut(inner) => Handler::on_timeout(inner, querier, env),
                 State::TransferOutRespDelivery(inner) => Handler::on_timeout(inner, querier, env),
                 State::RemoteSwap(inner) => Handler::on_timeout(inner, querier, env),
+                State::SlippageAnomaly(inner) => Handler::on_timeout(inner, querier, env),
             }
         }
 
@@ -217,6 +241,7 @@ mod impl_handler {
                     Handler::on_inner(inner, querier, env).map_into()
                 }
                 State::RemoteSwap(inner) => Handler::on_inner(inner, querier, env).map_into(),
+                State::SlippageAnomaly(inner) => Handler::on_inner(inner, querier, env).map_into(),
             }
         }
 
@@ -227,6 +252,7 @@ mod impl_handler {
                     Handler::on_inner_continue(inner, querier, env)
                 }
                 State::RemoteSwap(inner) => Handler::on_inner_continue(inner, querier, env),
+                State::SlippageAnomaly(inner) => Handler::on_inner_continue(inner, querier, env),
             }
         }
 
@@ -237,6 +263,7 @@ mod impl_handler {
                     Handler::heal(inner, querier, env).map_into()
                 }
                 State::RemoteSwap(inner) => Handler::heal(inner, querier, env).map_into(),
+                State::SlippageAnomaly(inner) => Handler::heal(inner, querier, env).map_into(),
             }
         }
 
@@ -245,6 +272,7 @@ mod impl_handler {
                 State::TransferOut(inner) => Handler::reply(inner, querier, env, msg),
                 State::TransferOutRespDelivery(inner) => Handler::reply(inner, querier, env, msg),
                 State::RemoteSwap(inner) => Handler::reply(inner, querier, env, msg),
+                State::SlippageAnomaly(inner) => Handler::reply(inner, querier, env, msg),
             }
         }
 
@@ -262,6 +290,9 @@ mod impl_handler {
                     Handler::on_time_alarm(inner, querier, env, info).map_into()
                 }
                 State::RemoteSwap(inner) => {
+                    Handler::on_time_alarm(inner, querier, env, info).map_into()
+                }
+                State::SlippageAnomaly(inner) => {
                     Handler::on_time_alarm(inner, querier, env, info).map_into()
                 }
             }
@@ -283,6 +314,9 @@ mod impl_handler {
                 State::RemoteSwap(inner) => {
                     Handler::on_remote_response(inner, data, querier, env).map_into()
                 }
+                State::SlippageAnomaly(inner) => {
+                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                }
             }
         }
 
@@ -302,6 +336,9 @@ mod impl_handler {
                 State::RemoteSwap(inner) => {
                     Handler::on_remote_error(inner, response, querier, env).map_into()
                 }
+                State::SlippageAnomaly(inner) => {
+                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                }
             }
         }
 
@@ -314,6 +351,9 @@ mod impl_handler {
                     Handler::on_remote_timeout(inner, querier, env).map_into()
                 }
                 State::RemoteSwap(inner) => {
+                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                }
+                State::SlippageAnomaly(inner) => {
                     Handler::on_remote_timeout(inner, querier, env).map_into()
                 }
             }
@@ -353,6 +393,9 @@ mod impl_contract {
                     Contract::state(inner, now, due_projection, querier)
                 }
                 State::RemoteSwap(inner) => Contract::state(inner, now, due_projection, querier),
+                State::SlippageAnomaly(inner) => {
+                    Contract::state(inner, now, due_projection, querier)
+                }
             }
         }
     }
@@ -375,6 +418,7 @@ mod impl_display {
                 State::TransferOut(inner) => Display::fmt(inner, f),
                 State::TransferOutRespDelivery(inner) => Display::fmt(inner, f),
                 State::RemoteSwap(inner) => inner.fmt(f),
+                State::SlippageAnomaly(inner) => inner.fmt(f),
             }
         }
     }
@@ -406,6 +450,7 @@ mod impl_migration {
                 State::TransferOut(inner) => inner.migrate_spec(migrate_fn).into(),
                 State::TransferOutRespDelivery(inner) => inner.migrate_spec(migrate_fn).into(),
                 State::RemoteSwap(inner) => inner.migrate_spec(migrate_fn).into(),
+                State::SlippageAnomaly(inner) => inner.migrate_spec(migrate_fn).into(),
             }
         }
     }
@@ -424,6 +469,7 @@ mod impl_migration {
                 State::TransferOut(inner) => inner.inspect_spec(inspect_fn),
                 State::TransferOutRespDelivery(inner) => inner.inspect_spec(inspect_fn),
                 State::RemoteSwap(inner) => inner.inspect_spec(inspect_fn),
+                State::SlippageAnomaly(inner) => inner.inspect_spec(inspect_fn),
             }
         }
     }

--- a/protocol/packages/dex/src/impl_/out_swap.rs
+++ b/protocol/packages/dex/src/impl_/out_swap.rs
@@ -124,7 +124,7 @@ mod impl_into {
 }
 
 mod impl_handler {
-    use platform::ica::ErrorResponse as ICAErrorResponse;
+    use platform::{batch::Emitter, ica::ErrorResponse as ICAErrorResponse};
     use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply};
 
     use crate::{
@@ -356,6 +356,15 @@ mod impl_handler {
                 State::SlippageAnomaly(inner) => {
                     Handler::on_remote_timeout(inner, querier, env).map_into()
                 }
+            }
+        }
+
+        fn price_alarm_dropped(&self) -> Option<Emitter> {
+            match self {
+                State::TransferOut(inner) => inner.price_alarm_dropped(),
+                State::TransferOutRespDelivery(inner) => inner.price_alarm_dropped(),
+                State::RemoteSwap(inner) => inner.price_alarm_dropped(),
+                State::SlippageAnomaly(inner) => inner.price_alarm_dropped(),
             }
         }
     }

--- a/protocol/packages/dex/src/impl_/out_swap.rs
+++ b/protocol/packages/dex/src/impl_/out_swap.rs
@@ -256,14 +256,21 @@ mod impl_handler {
             }
         }
 
-        fn heal(self, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
+        fn heal(
+            self,
+            querier: QuerierWrapper<'_>,
+            env: Env,
+            info: &MessageInfo,
+        ) -> Result<Self> {
             match self {
-                State::TransferOut(inner) => Handler::heal(inner, querier, env).map_into(),
+                State::TransferOut(inner) => Handler::heal(inner, querier, env, info).map_into(),
                 State::TransferOutRespDelivery(inner) => {
-                    Handler::heal(inner, querier, env).map_into()
+                    Handler::heal(inner, querier, env, info).map_into()
                 }
-                State::RemoteSwap(inner) => Handler::heal(inner, querier, env).map_into(),
-                State::SlippageAnomaly(inner) => Handler::heal(inner, querier, env).map_into(),
+                State::RemoteSwap(inner) => Handler::heal(inner, querier, env, info).map_into(),
+                State::SlippageAnomaly(inner) => {
+                    Handler::heal(inner, querier, env, info).map_into()
+                }
             }
         }
 

--- a/protocol/packages/dex/src/impl_/out_swap.rs
+++ b/protocol/packages/dex/src/impl_/out_swap.rs
@@ -256,12 +256,7 @@ mod impl_handler {
             }
         }
 
-        fn heal(
-            self,
-            querier: QuerierWrapper<'_>,
-            env: Env,
-            info: &MessageInfo,
-        ) -> Result<Self> {
+        fn heal(self, querier: QuerierWrapper<'_>, env: Env, info: &MessageInfo) -> Result<Self> {
             match self {
                 State::TransferOut(inner) => Handler::heal(inner, querier, env, info).map_into(),
                 State::TransferOutRespDelivery(inner) => {

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -50,13 +50,14 @@ use platform::{
 use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper};
 
 use crate::{
-    CoinsNb, Contract, ContractInRemoteSwap, Enterable, SlippageCalculator, SwapOutputTask,
-    SwapTask as SwapTaskT, TimeAlarm, WithCalculator, WithOutputTask,
+    CoinsNb, Contract, ContractInRemoteSwap, Enterable, SlippageCalculator, SlippageEscalation,
+    SwapOutputTask, SwapTask as SwapTaskT, TimeAlarm, WithCalculator, WithOutputTask,
     error::{Error, Result},
     impl_::{
+        SlippageAnomaly,
         next_leg::NextLeg,
         response::{self, ContinueResult, Handler, Result as HandlerResult},
-        timeout,
+        slippage_anomaly, timeout,
     },
 };
 
@@ -266,6 +267,25 @@ where
         })
     }
 
+    /// Re-emit the in-flight leg verbatim after a transient failure, keeping
+    /// the pinned floor and the accumulated progress intact.
+    fn reemit_in_flight(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
+        let state_label = self.spec.label();
+        timeout::on_timeout_retry(self, state_label, querier, env).into()
+    }
+
+    /// Re-emit the in-flight leg after a heal, signalling the recovery with
+    /// the heal event. The node carries the floor freshly pinned by
+    /// [`RemoteSwap::open_leg`] and the retry counters it reset to zero.
+    pub(super) fn reemit_healed(self) -> ContinueResult<Self> {
+        self.schedule().and_then(|batch| {
+            response::res_continue::<_, _, Self>(
+                MessageResponse::messages_with_event(batch, self.emit_heal()),
+                self,
+            )
+        })
+    }
+
     fn emit_total_out(&self) -> Emitter {
         Emitter::of_type(self.spec.label()).emit_coin_dto(EVENT_KEY_TOTAL_OUT, &self.total_out)
     }
@@ -306,8 +326,9 @@ where
     ///
     /// The single place the oracle is consulted - the resulting floor is
     /// what the leg's emission and every re-emission promise, and what its
-    /// acknowledgment is validated against.
-    fn open_leg(
+    /// acknowledgment is validated against. Re-opening the SAME leg, as a
+    /// heal does, re-quotes the floor and resets the retry counters to zero.
+    pub(super) fn open_leg(
         spec: SwapTask,
         acks_left: CoinsNb,
         total_out: CoinDTO<SwapTask::OutG>,
@@ -316,6 +337,20 @@ where
         in_flight_leg(&spec, total_out.currency(), acks_left)
             .and_then(|coin_in| leg_min_out(&spec, coin_in, total_out.currency(), querier))
             .map(|min_out| Self::internal_new(spec, acks_left, total_out, min_out, 0, 0))
+    }
+
+    fn with_incremented_errors(self) -> Self {
+        Self {
+            errors: self.errors.saturating_add(1),
+            ..self
+        }
+    }
+
+    fn with_incremented_timeouts(self) -> Self {
+        Self {
+            timeouts: self.timeouts.saturating_add(1),
+            ..self
+        }
     }
 
     fn internal_new(
@@ -379,10 +414,43 @@ where
     }
 }
 
+impl<SwapTask, SEnum> RemoteSwap<SwapTask, SEnum>
+where
+    SwapTask: SwapTaskT + RemoteSwapClient,
+    Self: Into<SEnum>,
+    SlippageAnomaly<SwapTask, SEnum>: Into<SEnum>,
+{
+    /// Escalate a spent in-flight leg per the spec's policy: park the opened
+    /// legs at the slippage-anomaly terminal, or re-emit the opening swap
+    /// verbatim.
+    fn escalate(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
+        match self.spec.slippage_escalation() {
+            SlippageEscalation::ReEmit => self.reemit_in_flight(querier, env),
+            SlippageEscalation::Park => self.park(),
+        }
+    }
+
+    fn park(self) -> HandlerResult<Self> {
+        let terminal = SlippageAnomaly::new(
+            self.spec,
+            self.acks_left,
+            self.total_out,
+            self.in_flight_min_out,
+        );
+        let emitter = slippage_anomaly::emit_parked_on_entry(&terminal);
+        response::res_continue::<_, _, Self>(
+            MessageResponse::messages_with_event(Batch::default(), emitter),
+            terminal,
+        )
+        .into()
+    }
+}
+
 impl<SwapTask, SEnum> Handler for RemoteSwap<SwapTask, SEnum>
 where
     SwapTask: SwapTaskT + RemoteSwapClient,
     Self: Into<SEnum>,
+    SlippageAnomaly<SwapTask, SEnum>: Into<SEnum>,
 {
     type Response = SEnum;
     type SwapResult = SwapTask::Result;
@@ -414,22 +482,34 @@ where
         }
     }
 
-    /// Anomalies are deliberately not routed through the spec's
-    /// `on_anomaly` - its `Retry` treatment rebuilds the node from the spec
-    /// and would re-issue the already-acknowledged legs. Only the in-flight
-    /// leg is re-emitted, preserving the accumulated progress.
+    /// An error on the in-flight leg escalates immediately - there is no
+    /// retry budget for an explicit under-floor rejection. Opened legs park
+    /// at the slippage-anomaly terminal; the opening swap re-emits verbatim,
+    /// the legacy error-equals-timeout behaviour, and never parks.
+    ///
+    /// Anomalies are deliberately not routed through the spec's `on_anomaly`,
+    /// whose `Retry` treatment rebuilds the node from the spec and would
+    /// re-issue the already-acknowledged legs. Only the in-flight leg is
+    /// re-emitted, preserving the accumulated progress.
     fn on_remote_error(
         self,
         _response: ICAErrorResponse,
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> HandlerResult<Self> {
-        self.on_remote_timeout(querier, env)
+        self.with_incremented_errors().escalate(querier, env)
     }
 
+    /// A timeout re-emits the in-flight leg up to the spec's per-op retry
+    /// budget and escalates past it - the opened legs park while the opening
+    /// swap keeps re-emitting unbounded.
     fn on_remote_timeout(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
-        let state_label = self.spec.label();
-        timeout::on_timeout_retry(self, state_label, querier, env).into()
+        let bumped = self.with_incremented_timeouts();
+        if bumped.timeouts <= bumped.spec.timeout_retry_budget() {
+            bumped.reemit_in_flight(querier, env)
+        } else {
+            bumped.escalate(querier, env)
+        }
     }
 
     /// The only operator recovery on this transport - there is neither a
@@ -726,7 +806,7 @@ pub(super) mod mock {
 
     use crate::{
         Account, AnomalyTreatment, CoinsNb, ContractInRemoteSwap, SlippageCalculator,
-        SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
+        SlippageEscalation, SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
         error::{Error, Result},
     };
 
@@ -735,9 +815,18 @@ pub(super) mod mock {
     pub const LABEL: &str = "RemoteSwapMock";
     pub const CONTROLLER: &str = "controller";
     pub const WRONG_VARIANT_PAYLOAD: &[u8] = b"wrong-variant";
+    pub const PARKED_STATE: CoinsNb = CoinsNb::MAX;
 
     const DEFAULT_FLOOR: Amount = 1;
     const DEFAULT_BUDGET: CoinsNb = 3;
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    enum Escalation {
+        #[default]
+        Park,
+        ReEmit,
+    }
 
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
     #[serde(deny_unknown_fields, rename_all = "snake_case")]
@@ -745,6 +834,8 @@ pub(super) mod mock {
         coins: Vec<CoinDTO<SuperGroup>>,
         floor: Amount,
         budget: CoinsNb,
+        #[serde(default)]
+        escalation: Escalation,
     }
 
     #[derive(Serialize)]
@@ -765,6 +856,7 @@ pub(super) mod mock {
                 coins,
                 floor: DEFAULT_FLOOR,
                 budget: DEFAULT_BUDGET,
+                escalation: Escalation::Park,
             }
         }
 
@@ -774,6 +866,10 @@ pub(super) mod mock {
 
         pub fn set_budget(&mut self, budget: CoinsNb) {
             self.budget = budget;
+        }
+
+        pub fn set_reemit(&mut self) {
+            self.escalation = Escalation::ReEmit;
         }
     }
 
@@ -810,6 +906,13 @@ pub(super) mod mock {
 
         fn timeout_retry_budget(&self) -> CoinsNb {
             self.budget
+        }
+
+        fn slippage_escalation(&self) -> SlippageEscalation {
+            match self.escalation {
+                Escalation::Park => SlippageEscalation::Park,
+                Escalation::ReEmit => SlippageEscalation::ReEmit,
+            }
         }
 
         fn coins(&self) -> impl IntoIterator<Item = CoinDTO<SuperGroup>> {
@@ -867,6 +970,16 @@ pub(super) mod mock {
             _querier: QuerierWrapper<'_>,
         ) -> Self::StateResponse {
             acks_left
+        }
+
+        fn anomaly_state(
+            self,
+            _acks_left: CoinsNb,
+            _now: finance::instant::Instant,
+            _due_projection: finance::duration::Duration,
+            _querier: QuerierWrapper<'_>,
+        ) -> Self::StateResponse {
+            PARKED_STATE
         }
     }
 
@@ -962,14 +1075,22 @@ mod tests {
 
     type OutG = <MockSpec as crate::SwapTask>::OutG;
     type Node = super::RemoteSwap<MockSpec, TestWorkflow>;
+    type Terminal = crate::impl_::SlippageAnomaly<MockSpec, TestWorkflow>;
 
     enum TestWorkflow {
         RemoteSwap(Node),
+        SlippageAnomaly(Terminal),
     }
 
     impl From<Node> for TestWorkflow {
         fn from(node: Node) -> Self {
             Self::RemoteSwap(node)
+        }
+    }
+
+    impl From<Terminal> for TestWorkflow {
+        fn from(terminal: Terminal) -> Self {
+            Self::SlippageAnomaly(terminal)
         }
     }
 
@@ -1075,6 +1196,7 @@ mod tests {
             continued(after_first_ack(querier).on_remote_timeout(querier, env.clone()));
         assert_eq!(timeout_response(&coin_in(70), &env), response);
         assert_node(1, &coin_out(80), &min_out(), &node);
+        assert_eq!(1, node.timeouts);
     }
 
     /// The re-emission repeats the floor pinned at the leg's emission even
@@ -1107,19 +1229,21 @@ mod tests {
         assert_node(2, &coin_out(50), &coin_out(PINNED_FLOOR), &node);
     }
 
+    /// An error parks immediately - no retry - freezing the in-flight leg's
+    /// progress at the terminal and emitting the on-entry anomaly event.
     #[test]
-    fn error_reemits_preserving_progress() {
+    fn error_parks_preserving_progress() {
         let mock_querier = MockQuerier::default();
         let querier = QuerierWrapper::new(&mock_querier);
         let env = testing::mock_env();
 
-        let (response, node) = continued(after_first_ack(querier).on_remote_error(
+        let (response, terminal) = parked(after_first_ack(querier).on_remote_error(
             ICAErrorResponse::from(String::from("swap failed")),
             querier,
-            env.clone(),
+            env,
         ));
-        assert_eq!(timeout_response(&coin_in(70), &env), response);
-        assert_node(1, &coin_out(80), &min_out(), &node);
+        assert_eq!(parked_response(), response);
+        assert_terminal(1, &coin_out(80), &min_out(), &terminal);
     }
 
     #[test]
@@ -1199,6 +1323,135 @@ mod tests {
             response
         );
         assert_node(1, &coin_out(80), &min_out(), &node);
+    }
+
+    /// A leg parks once its timeout budget is spent: the budget-th timeout
+    /// still re-emits, the next one parks at the terminal.
+    #[test]
+    fn timeout_budget_spent_parks_at_terminal() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let terminal = parked_terminal(querier);
+        assert_terminal(1, &coin_out(80), &min_out(), &terminal);
+    }
+
+    /// The opening swap escalation re-emits past the budget instead of
+    /// parking - opening keeps the legacy unbounded behaviour.
+    #[test]
+    fn reemit_escalation_never_parks() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let mut spec = spec3();
+        spec.set_reemit();
+        let (_response, node) = continued(Node::start(spec, &testing::mock_env(), querier));
+        let (_response, mut node) = continued(node.on_remote_response(
+            payload(&coin_out(30)),
+            querier,
+            testing::mock_env(),
+        ));
+
+        let rounds = u16::from(mock_budget()) + 3;
+        for _ in 0..rounds {
+            let (_response, next) = continued(node.on_remote_timeout(querier, testing::mock_env()));
+            node = next;
+        }
+        assert_node(1, &coin_out(80), &min_out(), &node);
+    }
+
+    /// A late acknowledgment of the original packet reaching the parked
+    /// terminal is absorbed without leaving the terminal.
+    #[test]
+    fn terminal_absorbs_late_ok_ack() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let terminal = parked_terminal(querier);
+        let (response, terminal) = terminal_continued(terminal.on_remote_response(
+            payload(&coin_out(40)),
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(parked_absorb_response("parked-response"), response);
+        assert_terminal(1, &coin_out(80), &min_out(), &terminal);
+    }
+
+    /// A late error and a late timeout reaching the parked terminal are both
+    /// absorbed without advancing or leaving it.
+    #[test]
+    fn terminal_absorbs_late_err_and_timeout() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let terminal = parked_terminal(querier);
+        let (response, terminal) = terminal_continued(terminal.on_remote_error(
+            ICAErrorResponse::from(String::from("late error")),
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(parked_absorb_response("parked-error"), response);
+
+        let (response, terminal) =
+            terminal_continued(terminal.on_remote_timeout(querier, testing::mock_env()));
+        assert_eq!(parked_absorb_response("parked-timeout"), response);
+        assert_terminal(1, &coin_out(80), &min_out(), &terminal);
+    }
+
+    /// A late callback must not mutate the parked progress: the frozen leg,
+    /// total, and floor are byte-identical before and after.
+    #[test]
+    fn terminal_late_callback_does_not_mutate_counters() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let terminal = parked_terminal(querier);
+        let before = sdk::cosmwasm_std::to_json_vec(&terminal).expect("a serializable terminal");
+
+        let (_response, terminal) =
+            terminal_continued(terminal.on_remote_timeout(querier, testing::mock_env()));
+        let after = sdk::cosmwasm_std::to_json_vec(&terminal).expect("a serializable terminal");
+        assert_eq!(before, after);
+    }
+
+    /// A heal re-quotes the SAME in-flight leg with a fresh floor, resets the
+    /// retry counters, re-emits, and leaves the terminal back into the live
+    /// swap node.
+    #[test]
+    fn terminal_heal_requotes_and_resets() {
+        const RAISED_FLOOR: Amount = 100;
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let mut terminal = parked_terminal(querier);
+        terminal.spec_mut().set_floor(RAISED_FLOOR);
+
+        let (response, node) = terminal_healed(terminal.heal(querier, testing::mock_env()));
+        assert_eq!(
+            MessageResponse::messages_with_event(
+                mock::swap_request(&coin_in(70), &coin_out(RAISED_FLOOR))
+                    .expect("a valid swap request"),
+                Emitter::of_type(mock::LABEL).emit("heal", "re-emit"),
+            ),
+            response
+        );
+        assert_node(1, &coin_out(80), &coin_out(RAISED_FLOOR), &node);
+        assert_eq!(0, node.timeouts);
+        assert_eq!(0, node.errors);
+    }
+
+    /// The parked terminal survives a serde round-trip and keeps absorbing
+    /// late callbacks afterwards.
+    #[test]
+    fn terminal_serde_round_trips() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let terminal = parked_terminal(querier);
+        let restored: Terminal = sdk::cosmwasm_std::to_json_vec(&terminal)
+            .and_then(sdk::cosmwasm_std::from_json)
+            .expect("the terminal should round-trip");
+        assert_terminal(1, &coin_out(80), &min_out(), &restored);
     }
 
     #[test]
@@ -1304,14 +1557,80 @@ mod tests {
         assert_eq!(*expected_pinned, node.in_flight_min_out);
     }
 
+    fn assert_terminal(
+        expected_acks: CoinsNb,
+        expected_total: &CoinDTO<OutG>,
+        expected_pinned: &CoinDTO<OutG>,
+        terminal: &Terminal,
+    ) {
+        assert_eq!(expected_acks, terminal.acks_left());
+        assert_eq!(*expected_total, *terminal.total_out());
+        assert_eq!(*expected_pinned, *terminal.in_flight_min_out());
+    }
+
+    fn parked_response() -> MessageResponse {
+        MessageResponse::messages_with_event(
+            Batch::default(),
+            Emitter::of_type(mock::LABEL).emit("anomaly", "slippage-anomaly-parked"),
+        )
+    }
+
+    fn parked_absorb_response(reason: &str) -> MessageResponse {
+        MessageResponse::messages_with_event(
+            Batch::default(),
+            Emitter::of_type(mock::LABEL).emit("absorbed", reason),
+        )
+    }
+
     fn continued(res: HandlerResult<Node>) -> (MessageResponse, Node) {
         match res {
-            HandlerResult::Continue(Ok(resp)) => {
-                let TestWorkflow::RemoteSwap(node) = resp.next_state;
-                (resp.response, node)
-            }
+            HandlerResult::Continue(Ok(resp)) => match resp.next_state {
+                TestWorkflow::RemoteSwap(node) => (resp.response, node),
+                TestWorkflow::SlippageAnomaly(_terminal) => {
+                    panic!("expected the live swap node, got the parked terminal")
+                }
+            },
             HandlerResult::Continue(Err(err)) => panic!("expected a continuation, got {err}"),
             HandlerResult::Finished(_total) => panic!("expected a continuation, got a finish"),
+        }
+    }
+
+    fn parked(res: HandlerResult<Node>) -> (MessageResponse, Terminal) {
+        match res {
+            HandlerResult::Continue(Ok(resp)) => match resp.next_state {
+                TestWorkflow::SlippageAnomaly(terminal) => (resp.response, terminal),
+                TestWorkflow::RemoteSwap(_node) => {
+                    panic!("expected the parked terminal, got the live swap node")
+                }
+            },
+            HandlerResult::Continue(Err(err)) => panic!("expected the terminal, got {err}"),
+            HandlerResult::Finished(_total) => panic!("expected the terminal, got a finish"),
+        }
+    }
+
+    fn terminal_continued(res: HandlerResult<Terminal>) -> (MessageResponse, Terminal) {
+        match res {
+            HandlerResult::Continue(Ok(resp)) => match resp.next_state {
+                TestWorkflow::SlippageAnomaly(terminal) => (resp.response, terminal),
+                TestWorkflow::RemoteSwap(_node) => {
+                    panic!("expected the terminal to stay parked, got the live swap node")
+                }
+            },
+            HandlerResult::Continue(Err(err)) => panic!("expected the terminal, got {err}"),
+            HandlerResult::Finished(_total) => panic!("expected the terminal, got a finish"),
+        }
+    }
+
+    fn terminal_healed(res: HandlerResult<Terminal>) -> (MessageResponse, Node) {
+        match res {
+            HandlerResult::Continue(Ok(resp)) => match resp.next_state {
+                TestWorkflow::RemoteSwap(node) => (resp.response, node),
+                TestWorkflow::SlippageAnomaly(_terminal) => {
+                    panic!("expected the healed swap node, got the parked terminal")
+                }
+            },
+            HandlerResult::Continue(Err(err)) => panic!("expected the healed node, got {err}"),
+            HandlerResult::Finished(_total) => panic!("expected the healed node, got a finish"),
         }
     }
 
@@ -1330,6 +1649,23 @@ mod tests {
             testing::mock_env(),
         ));
         node
+    }
+
+    /// Drive the in-flight leg into the parked terminal by exhausting the
+    /// timeout budget: `budget` re-emits keep retrying, the next one parks.
+    fn parked_terminal(querier: QuerierWrapper<'_>) -> Terminal {
+        let node = after_first_ack(querier);
+        let budget = mock_budget();
+        let node = (0..budget).fold(node, |node, _round| {
+            continued(node.on_remote_timeout(querier, testing::mock_env())).1
+        });
+        parked(node.on_remote_timeout(querier, testing::mock_env())).1
+    }
+
+    fn mock_budget() -> CoinsNb {
+        use crate::SwapTask;
+
+        spec3().timeout_retry_budget()
     }
 
     fn spec3() -> MockSpec {

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -841,6 +841,8 @@ pub(super) mod mock {
         budget: CoinsNb,
         #[serde(default)]
         escalation: Escalation,
+        #[serde(default)]
+        anomaly_resolution_authorised: bool,
     }
 
     #[derive(Serialize)]
@@ -862,6 +864,7 @@ pub(super) mod mock {
                 floor: DEFAULT_FLOOR,
                 budget: DEFAULT_BUDGET,
                 escalation: Escalation::Park,
+                anomaly_resolution_authorised: true,
             }
         }
 
@@ -875,6 +878,10 @@ pub(super) mod mock {
 
         pub fn set_reemit(&mut self) {
             self.escalation = Escalation::ReEmit;
+        }
+
+        pub fn deny_anomaly_resolution(&mut self) {
+            self.anomaly_resolution_authorised = false;
         }
     }
 
@@ -907,6 +914,20 @@ pub(super) mod mock {
             _info: &MessageInfo,
         ) -> Result<()> {
             Ok(())
+        }
+
+        fn authz_anomaly_resolution(
+            &self,
+            _querier: QuerierWrapper<'_>,
+            _info: &MessageInfo,
+        ) -> Result<()> {
+            if self.anomaly_resolution_authorised {
+                Ok(())
+            } else {
+                Err(Error::Unauthorized(
+                    access_control::error::Error::Unauthorized {},
+                ))
+            }
         }
 
         fn timeout_retry_budget(&self) -> CoinsNb {
@@ -1073,6 +1094,7 @@ mod tests {
 
     use crate::{
         CoinsNb, Contract,
+        error::Error,
         impl_::response::{Handler, Result as HandlerResult},
     };
 
@@ -1444,6 +1466,53 @@ mod tests {
         assert_node(1, &coin_out(80), &coin_out(RAISED_FLOOR), &node);
         assert_eq!(0, node.timeouts);
         assert_eq!(0, node.errors);
+    }
+
+    /// The original packet reaching the parked terminal is absorbed, so the
+    /// operator heal re-emits a single in-flight leg whose acknowledgment
+    /// credits the total exactly once - the at-most-once, single-leg property
+    /// that keeps a stale packet plus the heal re-emission from double-crediting.
+    #[test]
+    fn double_heal_absorbs_second_packet() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        // the original packet lands while parked and is absorbed - no credit
+        let terminal = parked_terminal(querier);
+        let (_response, terminal) = terminal_continued(terminal.on_remote_response(
+            payload(&coin_out(40)),
+            querier,
+            testing::mock_env(),
+        ));
+        assert_terminal(1, &coin_out(80), &min_out(), &terminal);
+
+        // the heal re-emits the SAME in-flight leg without advancing it
+        let (_response, node) =
+            terminal_healed(terminal.heal(querier, testing::mock_env(), &healer()));
+        assert_node(1, &coin_out(80), &min_out(), &node);
+
+        // exactly one acknowledgment of the re-emitted leg finishes the
+        // workflow - the absorbed first packet did not also credit
+        assert_eq!(
+            coin_out(120),
+            finished(node.on_remote_response(payload(&coin_out(40)), querier, testing::mock_env()))
+        );
+    }
+
+    /// An unauthorised operator `heal` of a parked leg is rejected before any
+    /// re-quote - the leg stays frozen at the terminal.
+    #[test]
+    fn heal_rejects_unauthorised_operator() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let mut terminal = parked_terminal(querier);
+        terminal.spec_mut().deny_anomaly_resolution();
+
+        assert!(matches!(
+            terminal.heal(querier, testing::mock_env(), &healer()),
+            HandlerResult::Continue(Err(Error::Unauthorized(_)))
+        ));
     }
 
     /// A live swap leg drops a price alarm silently, while the parked

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -1440,6 +1440,23 @@ mod tests {
         assert_eq!(0, node.errors);
     }
 
+    /// A live swap leg drops a price alarm silently, while the parked
+    /// terminal reports a dropped-alarm event for monitoring.
+    #[test]
+    fn price_alarm_dropped_only_when_parked() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let live = after_first_ack(querier);
+        assert!(live.price_alarm_dropped().is_none());
+
+        let terminal = parked_terminal(querier);
+        assert_eq!(
+            Some(Emitter::of_type(mock::LABEL).emit("anomaly", "price-alarm-dropped")),
+            terminal.price_alarm_dropped(),
+        );
+    }
+
     /// The parked terminal survives a serde round-trip and keeps absorbing
     /// late callbacks afterwards.
     #[test]

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -57,7 +57,7 @@ use crate::{
         SlippageAnomaly,
         next_leg::NextLeg,
         response::{self, ContinueResult, Handler, Result as HandlerResult},
-        slippage_anomaly, timeout,
+        timeout,
     },
 };
 
@@ -270,8 +270,8 @@ where
     /// Re-emit the in-flight leg verbatim after a transient failure, keeping
     /// the pinned floor and the accumulated progress intact.
     fn reemit_in_flight(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
-        let state_label = self.spec.label();
-        timeout::on_timeout_retry(self, state_label, querier, env).into()
+        let leg_label = self.spec.label();
+        timeout::on_timeout_retry(self, leg_label, querier, env).into()
     }
 
     /// Re-emit the in-flight leg after a heal, signalling the recovery with
@@ -437,7 +437,7 @@ where
             self.total_out,
             self.in_flight_min_out,
         );
-        let emitter = slippage_anomaly::emit_parked_on_entry(&terminal);
+        let emitter = terminal.emit_parked();
         response::res_continue::<_, _, Self>(
             MessageResponse::messages_with_event(Batch::default(), emitter),
             terminal,
@@ -693,7 +693,7 @@ where
     }
 }
 
-fn swappable_coins<SwapTask>(
+pub(super) fn swappable_coins<SwapTask>(
     spec: &SwapTask,
     out_currency: CurrencyDTO<SwapTask::OutG>,
 ) -> impl Iterator<Item = CoinDTO<SwapTask::InG>>
@@ -820,7 +820,7 @@ pub(super) mod mock {
     pub const LABEL: &str = "RemoteSwapMock";
     pub const CONTROLLER: &str = "controller";
     pub const WRONG_VARIANT_PAYLOAD: &[u8] = b"wrong-variant";
-    pub const PARKED_STATE: CoinsNb = CoinsNb::MAX;
+    pub const SLIPPAGE_PROTECTION_SENTINEL: CoinsNb = CoinsNb::MAX;
 
     const DEFAULT_FLOOR: Amount = 1;
     const DEFAULT_BUDGET: CoinsNb = 3;
@@ -998,14 +998,14 @@ pub(super) mod mock {
             acks_left
         }
 
-        fn anomaly_state(
+        fn anomaly_response(
             self,
             _acks_left: CoinsNb,
             _now: finance::instant::Instant,
             _due_projection: finance::duration::Duration,
             _querier: QuerierWrapper<'_>,
         ) -> Self::StateResponse {
-            PARKED_STATE
+            SLIPPAGE_PROTECTION_SENTINEL
         }
     }
 
@@ -1572,10 +1572,10 @@ mod tests {
     /// `#[serde(default)]` must let it load with both counters cleared so
     /// the new code-id never bricks an in-flight lease.
     #[test]
-    fn old_state_without_counters_deserializes_to_zero() {
-        let old_state = br#"{"spec":{"coins":[{"amount":"100","ticker":"ticker#2"},{"amount":"50","ticker":"ticker#1"},{"amount":"70","ticker":"ticker#2"}],"floor":1,"budget":3},"acks_left":1,"total_out":{"amount":"80","ticker":"ticker#1"},"in_flight_min_out":{"amount":"1","ticker":"ticker#1"}}"#;
+    fn legacy_remote_swap_without_counters_deserializes_to_zero() {
+        let legacy_remote_swap = br#"{"spec":{"coins":[{"amount":"100","ticker":"ticker#2"},{"amount":"50","ticker":"ticker#1"},{"amount":"70","ticker":"ticker#2"}],"floor":1,"budget":3},"acks_left":1,"total_out":{"amount":"80","ticker":"ticker#1"},"in_flight_min_out":{"amount":"1","ticker":"ticker#1"}}"#;
 
-        let restored: Node = sdk::cosmwasm_std::from_json(old_state.as_slice())
+        let restored: Node = sdk::cosmwasm_std::from_json(legacy_remote_swap.as_slice())
             .expect("the pre-#655 state should deserialize");
         assert_eq!(0, restored.timeouts);
         assert_eq!(0, restored.errors);

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -126,6 +126,10 @@ where
     acks_left: CoinsNb,
     total_out: CoinDTO<SwapTask::OutG>,
     in_flight_min_out: CoinDTO<SwapTask::OutG>,
+    #[serde(default)]
+    timeouts: CoinsNb,
+    #[serde(default)]
+    errors: CoinsNb,
     #[serde(skip)]
     _state_enum: PhantomData<SEnum>,
 }
@@ -311,7 +315,7 @@ where
     ) -> Result<Self> {
         in_flight_leg(&spec, total_out.currency(), acks_left)
             .and_then(|coin_in| leg_min_out(&spec, coin_in, total_out.currency(), querier))
-            .map(|min_out| Self::internal_new(spec, acks_left, total_out, min_out))
+            .map(|min_out| Self::internal_new(spec, acks_left, total_out, min_out, 0, 0))
     }
 
     fn internal_new(
@@ -319,12 +323,16 @@ where
         acks_left: CoinsNb,
         total_out: CoinDTO<SwapTask::OutG>,
         in_flight_min_out: CoinDTO<SwapTask::OutG>,
+        timeouts: CoinsNb,
+        errors: CoinsNb,
     ) -> Self {
         let ret = Self {
             spec,
             acks_left,
             total_out,
             in_flight_min_out,
+            timeouts,
+            errors,
             _state_enum: PhantomData,
         };
         debug_assert!(ret.invariant_held());
@@ -506,6 +514,8 @@ where
             self.acks_left,
             self.total_out,
             self.in_flight_min_out,
+            self.timeouts,
+            self.errors,
         )
     }
 }
@@ -1185,7 +1195,9 @@ mod tests {
         let mock_querier = MockQuerier::default();
         let querier = QuerierWrapper::new(&mock_querier);
 
-        let node = after_first_ack(querier);
+        let mut node = after_first_ack(querier);
+        node.timeouts = 4;
+        node.errors = 2;
         let restored: Node = sdk::cosmwasm_std::to_json_vec(&node)
             .and_then(sdk::cosmwasm_std::from_json)
             .expect("the state should round-trip");
@@ -1196,6 +1208,52 @@ mod tests {
             &node.in_flight_min_out,
             &restored,
         );
+        assert_eq!(node.timeouts, restored.timeouts);
+        assert_eq!(node.errors, restored.errors);
+    }
+
+    /// A lease persisted before #655 carries no `timeouts`/`errors` keys;
+    /// `#[serde(default)]` must let it load with both counters cleared so
+    /// the new code-id never bricks an in-flight lease.
+    #[test]
+    fn old_state_without_counters_deserializes_to_zero() {
+        let old_state = br#"{"spec":{"coins":[{"amount":"100","ticker":"ticker#2"},{"amount":"50","ticker":"ticker#1"},{"amount":"70","ticker":"ticker#2"}],"floor":1},"acks_left":1,"total_out":{"amount":"80","ticker":"ticker#1"},"in_flight_min_out":{"amount":"1","ticker":"ticker#1"}}"#;
+
+        let restored: Node = sdk::cosmwasm_std::from_json(old_state.as_slice())
+            .expect("the pre-#655 state should deserialize");
+        assert_eq!(0, restored.timeouts);
+        assert_eq!(0, restored.errors);
+    }
+
+    #[test]
+    fn counters_round_trip() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let mut node = after_first_ack(querier);
+        node.timeouts = 3;
+        node.errors = 1;
+        let restored: Node = sdk::cosmwasm_std::to_json_vec(&node)
+            .and_then(sdk::cosmwasm_std::from_json)
+            .expect("the counters should round-trip");
+        assert_eq!(3, restored.timeouts);
+        assert_eq!(1, restored.errors);
+    }
+
+    #[cfg(feature = "migration")]
+    #[test]
+    fn migrate_preserves_counters() {
+        use crate::impl_::migration::MigrateSpec;
+
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let mut node = after_first_ack(querier);
+        node.timeouts = 4;
+        node.errors = 2;
+        let migrated: Node = node.migrate_spec(|spec| spec);
+        assert_eq!(4, migrated.timeouts);
+        assert_eq!(2, migrated.errors);
     }
 
     #[test]

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -518,7 +518,12 @@ where
     /// `in_flight_min_out`, the exact promise of the original emission.
     /// See the module doc for the duplicate-acknowledgment risk a heal
     /// issued while the original operation is still resolvable creates.
-    fn heal(self, _querier: QuerierWrapper<'_>, _env: Env) -> HandlerResult<Self> {
+    fn heal(
+        self,
+        _querier: QuerierWrapper<'_>,
+        _env: Env,
+        _info: &MessageInfo,
+    ) -> HandlerResult<Self> {
         self.schedule()
             .and_then(|batch| {
                 response::res_continue::<_, _, Self>(
@@ -1062,7 +1067,7 @@ mod tests {
         message::Response as MessageResponse,
     };
     use sdk::cosmwasm_std::{
-        Binary, Env, QuerierWrapper,
+        Addr, Binary, Env, MessageInfo, QuerierWrapper,
         testing::{self, MockQuerier},
     };
 
@@ -1314,7 +1319,7 @@ mod tests {
         let mut node = after_first_ack(querier);
         node.spec.set_floor(RAISED_FLOOR);
 
-        let (response, node) = continued(node.heal(querier, testing::mock_env()));
+        let (response, node) = continued(node.heal(querier, testing::mock_env(), &healer()));
         assert_eq!(
             MessageResponse::messages_with_event(
                 mock::swap_request(&coin_in(70), &min_out()).expect("a valid swap request"),
@@ -1426,7 +1431,8 @@ mod tests {
         let mut terminal = parked_terminal(querier);
         terminal.spec_mut().set_floor(RAISED_FLOOR);
 
-        let (response, node) = terminal_healed(terminal.heal(querier, testing::mock_env()));
+        let (response, node) =
+            terminal_healed(terminal.heal(querier, testing::mock_env(), &healer()));
         assert_eq!(
             MessageResponse::messages_with_event(
                 mock::swap_request(&coin_in(70), &coin_out(RAISED_FLOOR))
@@ -1687,6 +1693,13 @@ mod tests {
 
     fn spec3() -> MockSpec {
         MockSpec::new(vec![coin_in(100), coin_out(50), coin_in(70)])
+    }
+
+    fn healer() -> MessageInfo {
+        MessageInfo {
+            sender: Addr::unchecked(mock::CONTROLLER),
+            funds: vec![],
+        }
     }
 
     fn leg_response(

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -737,12 +737,14 @@ pub(super) mod mock {
     pub const WRONG_VARIANT_PAYLOAD: &[u8] = b"wrong-variant";
 
     const DEFAULT_FLOOR: Amount = 1;
+    const DEFAULT_BUDGET: CoinsNb = 3;
 
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
     #[serde(deny_unknown_fields, rename_all = "snake_case")]
     pub struct MockSpec {
         coins: Vec<CoinDTO<SuperGroup>>,
         floor: Amount,
+        budget: CoinsNb,
     }
 
     #[derive(Serialize)]
@@ -762,11 +764,16 @@ pub(super) mod mock {
             Self {
                 coins,
                 floor: DEFAULT_FLOOR,
+                budget: DEFAULT_BUDGET,
             }
         }
 
         pub fn set_floor(&mut self, floor: Amount) {
             self.floor = floor;
+        }
+
+        pub fn set_budget(&mut self, budget: CoinsNb) {
+            self.budget = budget;
         }
     }
 
@@ -799,6 +806,10 @@ pub(super) mod mock {
             _info: &MessageInfo,
         ) -> Result<()> {
             Ok(())
+        }
+
+        fn timeout_retry_budget(&self) -> CoinsNb {
+            self.budget
         }
 
         fn coins(&self) -> impl IntoIterator<Item = CoinDTO<SuperGroup>> {
@@ -1217,7 +1228,7 @@ mod tests {
     /// the new code-id never bricks an in-flight lease.
     #[test]
     fn old_state_without_counters_deserializes_to_zero() {
-        let old_state = br#"{"spec":{"coins":[{"amount":"100","ticker":"ticker#2"},{"amount":"50","ticker":"ticker#1"},{"amount":"70","ticker":"ticker#2"}],"floor":1},"acks_left":1,"total_out":{"amount":"80","ticker":"ticker#1"},"in_flight_min_out":{"amount":"1","ticker":"ticker#1"}}"#;
+        let old_state = br#"{"spec":{"coins":[{"amount":"100","ticker":"ticker#2"},{"amount":"50","ticker":"ticker#1"},{"amount":"70","ticker":"ticker#2"}],"floor":1,"budget":3},"acks_left":1,"total_out":{"amount":"80","ticker":"ticker#1"},"in_flight_min_out":{"amount":"1","ticker":"ticker#1"}}"#;
 
         let restored: Node = sdk::cosmwasm_std::from_json(old_state.as_slice())
             .expect("the pre-#655 state should deserialize");
@@ -1238,6 +1249,15 @@ mod tests {
             .expect("the counters should round-trip");
         assert_eq!(3, restored.timeouts);
         assert_eq!(1, restored.errors);
+    }
+
+    #[test]
+    fn spec_reports_its_timeout_retry_budget() {
+        use crate::SwapTask;
+
+        let mut spec = spec3();
+        spec.set_budget(7);
+        assert_eq!(7, spec.timeout_retry_budget());
     }
 
     #[cfg(feature = "migration")]

--- a/protocol/packages/dex/src/impl_/remote_swap_only.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap_only.rs
@@ -320,12 +320,31 @@ mod test {
         testing::{self, MockQuerier},
     };
 
+    use serde::Serialize;
+
     use crate::{
-        impl_::remote_swap::mock::{self, MockSpec},
+        CoinsNb,
+        impl_::{
+            SlippageAnomaly,
+            remote_swap::mock::{self, MockSpec},
+        },
         response::{Handler, Result as HandlerResult},
     };
 
     use super::{State, start};
+
+    type Anomaly = SlippageAnomaly<MockSpec, State<MockSpec>>;
+
+    /// A serializable mirror of the parked terminal's wire shape, letting a
+    /// test pin field values the constructor would reject so the restore path
+    /// can be exercised against a corrupted store.
+    #[derive(Serialize)]
+    struct AnomalyWire {
+        spec: MockSpec,
+        acks_left: CoinsNb,
+        total_out: CoinDTO<OutG>,
+        in_flight_min_out: CoinDTO<OutG>,
+    }
 
     type OutG = <MockSpec as crate::SwapTask>::OutG;
 
@@ -495,6 +514,41 @@ mod test {
             testing::mock_env(),
         ));
         assert!(matches!(still_parked, State::SlippageAnomaly(_)));
+    }
+
+    /// A corrupted stored terminal - a zero `acks_left` countdown, or an
+    /// `in_flight_min_out` floor denominated in a currency other than the
+    /// accumulated `total_out` - is rejected on restore instead of reaching
+    /// the public state/heal path unchecked. The constructor's `debug_assert!`
+    /// is compiled out in release and never guards the deserialize path, so the
+    /// invariant has to be re-run through `try_from`.
+    #[test]
+    fn malformed_slippage_terminal_is_rejected_on_restore() {
+        let zero_acks = AnomalyWire {
+            spec: spec3(),
+            acks_left: 0,
+            total_out: coin_out(120),
+            in_flight_min_out: coin_out(40),
+        };
+        let serialized =
+            sdk::cosmwasm_std::to_json_vec(&zero_acks).expect("a serializable wire terminal");
+        assert!(
+            sdk::cosmwasm_std::from_json::<Anomaly>(&serialized).is_err(),
+            "a zero-acks-left terminal must be rejected on restore"
+        );
+
+        let currency_mismatch = AnomalyWire {
+            spec: spec3(),
+            acks_left: 1,
+            total_out: coin_out(120),
+            in_flight_min_out: coin_in(40),
+        };
+        let serialized = sdk::cosmwasm_std::to_json_vec(&currency_mismatch)
+            .expect("a serializable wire terminal");
+        assert!(
+            sdk::cosmwasm_std::from_json::<Anomaly>(&serialized).is_err(),
+            "a currency-mismatched floor must be rejected on restore"
+        );
     }
 
     fn continued(res: HandlerResult<State<MockSpec>>) -> (MessageResponse, State<MockSpec>) {

--- a/protocol/packages/dex/src/impl_/remote_swap_only.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap_only.rs
@@ -172,12 +172,7 @@ mod impl_handler {
             }
         }
 
-        fn heal(
-            self,
-            querier: QuerierWrapper<'_>,
-            env: Env,
-            info: &MessageInfo,
-        ) -> Result<Self> {
+        fn heal(self, querier: QuerierWrapper<'_>, env: Env, info: &MessageInfo) -> Result<Self> {
             match self {
                 State::RemoteSwap(inner) => Handler::heal(inner, querier, env, info).map_into(),
                 State::SlippageAnomaly(inner) => {

--- a/protocol/packages/dex/src/impl_/remote_swap_only.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap_only.rs
@@ -11,7 +11,7 @@ use sdk::cosmwasm_std::{Env, QuerierWrapper};
 
 use crate::{
     SwapTask as SwapTaskT,
-    impl_::{RemoteSwap, RemoteSwapClient},
+    impl_::{RemoteSwap, RemoteSwapClient, SlippageAnomaly},
     response::Result as HandlerResult,
 };
 
@@ -25,6 +25,7 @@ where
     SwapTask: SwapTaskT,
 {
     RemoteSwap(RemoteSwap<SwapTask, Self>),
+    SlippageAnomaly(SlippageAnomaly<SwapTask, Self>),
 }
 
 pub type StartSwapState<SwapTask> = RemoteSwap<SwapTask, State<SwapTask>>;
@@ -45,7 +46,10 @@ where
 }
 
 mod impl_into {
-    use crate::{SwapTask as SwapTaskT, impl_::RemoteSwap};
+    use crate::{
+        SwapTask as SwapTaskT,
+        impl_::{RemoteSwap, SlippageAnomaly},
+    };
 
     use super::State;
 
@@ -55,6 +59,15 @@ mod impl_into {
     {
         fn from(value: RemoteSwap<SwapTask, Self>) -> Self {
             Self::RemoteSwap(value)
+        }
+    }
+
+    impl<SwapTask> From<SlippageAnomaly<SwapTask, Self>> for State<SwapTask>
+    where
+        SwapTask: SwapTaskT,
+    {
+        fn from(value: SlippageAnomaly<SwapTask, Self>) -> Self {
+            Self::SlippageAnomaly(value)
         }
     }
 }
@@ -86,6 +99,7 @@ mod impl_handler {
         ) -> DexResult<()> {
             match self {
                 State::RemoteSwap(inner) => inner.authz_remote_callback(querier, info),
+                State::SlippageAnomaly(inner) => inner.authz_remote_callback(querier, info),
             }
         }
 
@@ -97,6 +111,9 @@ mod impl_handler {
         ) -> ContinueResult<Self> {
             match self {
                 State::RemoteSwap(inner) => {
+                    Handler::on_open_ica(inner, counterparty_version, querier, env)
+                }
+                State::SlippageAnomaly(inner) => {
                     Handler::on_open_ica(inner, counterparty_version, querier, env)
                 }
             }
@@ -112,6 +129,9 @@ mod impl_handler {
                 State::RemoteSwap(inner) => {
                     Handler::on_response(inner, response, querier, env).map_into()
                 }
+                State::SlippageAnomaly(inner) => {
+                    Handler::on_response(inner, response, querier, env).map_into()
+                }
             }
         }
 
@@ -125,36 +145,44 @@ mod impl_handler {
                 State::RemoteSwap(inner) => {
                     Handler::on_error(inner, response, querier, env).map_into()
                 }
+                State::SlippageAnomaly(inner) => {
+                    Handler::on_error(inner, response, querier, env).map_into()
+                }
             }
         }
 
         fn on_timeout(self, querier: QuerierWrapper<'_>, env: Env) -> ContinueResult<Self> {
             match self {
                 State::RemoteSwap(inner) => Handler::on_timeout(inner, querier, env),
+                State::SlippageAnomaly(inner) => Handler::on_timeout(inner, querier, env),
             }
         }
 
         fn on_inner(self, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
             match self {
                 State::RemoteSwap(inner) => Handler::on_inner(inner, querier, env).map_into(),
+                State::SlippageAnomaly(inner) => Handler::on_inner(inner, querier, env).map_into(),
             }
         }
 
         fn on_inner_continue(self, querier: QuerierWrapper<'_>, env: Env) -> ContinueResult<Self> {
             match self {
                 State::RemoteSwap(inner) => Handler::on_inner_continue(inner, querier, env),
+                State::SlippageAnomaly(inner) => Handler::on_inner_continue(inner, querier, env),
             }
         }
 
         fn heal(self, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
             match self {
                 State::RemoteSwap(inner) => Handler::heal(inner, querier, env).map_into(),
+                State::SlippageAnomaly(inner) => Handler::heal(inner, querier, env).map_into(),
             }
         }
 
         fn reply(self, querier: QuerierWrapper<'_>, env: Env, msg: Reply) -> ContinueResult<Self> {
             match self {
                 State::RemoteSwap(inner) => Handler::reply(inner, querier, env, msg),
+                State::SlippageAnomaly(inner) => Handler::reply(inner, querier, env, msg),
             }
         }
 
@@ -166,6 +194,9 @@ mod impl_handler {
         ) -> Result<Self> {
             match self {
                 State::RemoteSwap(inner) => {
+                    Handler::on_time_alarm(inner, querier, env, info).map_into()
+                }
+                State::SlippageAnomaly(inner) => {
                     Handler::on_time_alarm(inner, querier, env, info).map_into()
                 }
             }
@@ -181,6 +212,9 @@ mod impl_handler {
                 State::RemoteSwap(inner) => {
                     Handler::on_remote_response(inner, data, querier, env).map_into()
                 }
+                State::SlippageAnomaly(inner) => {
+                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                }
             }
         }
 
@@ -194,12 +228,18 @@ mod impl_handler {
                 State::RemoteSwap(inner) => {
                     Handler::on_remote_error(inner, response, querier, env).map_into()
                 }
+                State::SlippageAnomaly(inner) => {
+                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                }
             }
         }
 
         fn on_remote_timeout(self, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
             match self {
                 State::RemoteSwap(inner) => {
+                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                }
+                State::SlippageAnomaly(inner) => {
                     Handler::on_remote_timeout(inner, querier, env).map_into()
                 }
             }
@@ -230,6 +270,9 @@ mod impl_contract {
         ) -> Self::StateResponse {
             match self {
                 State::RemoteSwap(inner) => Contract::state(inner, now, due_projection, querier),
+                State::SlippageAnomaly(inner) => {
+                    Contract::state(inner, now, due_projection, querier)
+                }
             }
         }
     }
@@ -249,6 +292,7 @@ mod impl_display {
         fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
             match self {
                 State::RemoteSwap(inner) => inner.fmt(f),
+                State::SlippageAnomaly(inner) => inner.fmt(f),
             }
         }
     }
@@ -381,6 +425,63 @@ mod test {
             ),
             response
         );
+    }
+
+    /// An `OperationErr` parks the composite at the `SlippageAnomaly` arm
+    /// without retrying, emitting the on-entry anomaly event.
+    #[test]
+    fn error_parks_at_slippage_anomaly_arm() {
+        use platform::ica::ErrorResponse as ICAErrorResponse;
+
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let (response, state) = continued(after_first_ack(querier).on_remote_error(
+            ICAErrorResponse::from(String::from("swap reverted")),
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(
+            MessageResponse::messages_with_event(
+                Default::default(),
+                Emitter::of_type(mock::LABEL).emit("anomaly", "slippage-anomaly-parked"),
+            ),
+            response
+        );
+        assert!(matches!(state, State::SlippageAnomaly(_)));
+    }
+
+    /// The parked `SlippageAnomaly` arm survives a serde round-trip and keeps
+    /// absorbing late callbacks afterwards.
+    #[test]
+    fn anomaly_arm_serde_round_trips() {
+        use platform::ica::ErrorResponse as ICAErrorResponse;
+
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let (_response, parked) = continued(after_first_ack(querier).on_remote_error(
+            ICAErrorResponse::from(String::from("swap reverted")),
+            querier,
+            testing::mock_env(),
+        ));
+        assert!(matches!(parked, State::SlippageAnomaly(_)));
+
+        let serialized = sdk::cosmwasm_std::to_json_vec(&parked).expect("a serializable arm");
+        let restored: State<MockSpec> =
+            sdk::cosmwasm_std::from_json(&serialized).expect("the anomaly arm should round-trip");
+        assert_eq!(
+            serialized,
+            sdk::cosmwasm_std::to_json_vec(&restored).expect("a serializable arm"),
+        );
+        assert!(matches!(restored, State::SlippageAnomaly(_)));
+
+        let (_response, still_parked) = continued(restored.on_remote_response(
+            payload(&coin_out(40)),
+            querier,
+            testing::mock_env(),
+        ));
+        assert!(matches!(still_parked, State::SlippageAnomaly(_)));
     }
 
     fn continued(res: HandlerResult<State<MockSpec>>) -> (MessageResponse, State<MockSpec>) {

--- a/protocol/packages/dex/src/impl_/remote_swap_only.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap_only.rs
@@ -73,7 +73,7 @@ mod impl_into {
 }
 
 mod impl_handler {
-    use platform::ica::ErrorResponse as ICAErrorResponse;
+    use platform::{batch::Emitter, ica::ErrorResponse as ICAErrorResponse};
     use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply};
 
     use crate::{
@@ -242,6 +242,13 @@ mod impl_handler {
                 State::SlippageAnomaly(inner) => {
                     Handler::on_remote_timeout(inner, querier, env).map_into()
                 }
+            }
+        }
+
+        fn price_alarm_dropped(&self) -> Option<Emitter> {
+            match self {
+                State::RemoteSwap(inner) => inner.price_alarm_dropped(),
+                State::SlippageAnomaly(inner) => inner.price_alarm_dropped(),
             }
         }
     }

--- a/protocol/packages/dex/src/impl_/remote_swap_only.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap_only.rs
@@ -172,10 +172,17 @@ mod impl_handler {
             }
         }
 
-        fn heal(self, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
+        fn heal(
+            self,
+            querier: QuerierWrapper<'_>,
+            env: Env,
+            info: &MessageInfo,
+        ) -> Result<Self> {
             match self {
-                State::RemoteSwap(inner) => Handler::heal(inner, querier, env).map_into(),
-                State::SlippageAnomaly(inner) => Handler::heal(inner, querier, env).map_into(),
+                State::RemoteSwap(inner) => Handler::heal(inner, querier, env, info).map_into(),
+                State::SlippageAnomaly(inner) => {
+                    Handler::heal(inner, querier, env, info).map_into()
+                }
             }
         }
 
@@ -314,7 +321,7 @@ mod test {
         message::Response as MessageResponse,
     };
     use sdk::cosmwasm_std::{
-        Binary, QuerierWrapper,
+        Addr, Binary, MessageInfo, QuerierWrapper,
         testing::{self, MockQuerier},
     };
 
@@ -370,8 +377,12 @@ mod test {
         let mock_querier = MockQuerier::default();
         let querier = QuerierWrapper::new(&mock_querier);
 
+        let info = MessageInfo {
+            sender: Addr::unchecked(mock::CONTROLLER),
+            funds: vec![],
+        };
         let (response, _state) =
-            continued(after_first_ack(querier).heal(querier, testing::mock_env()));
+            continued(after_first_ack(querier).heal(querier, testing::mock_env(), &info));
         assert_eq!(
             MessageResponse::messages_with_event(
                 mock::swap_request(&coin_in(70), &min_out()).expect("a valid swap request"),

--- a/protocol/packages/dex/src/impl_/remote_transfer_out.rs
+++ b/protocol/packages/dex/src/impl_/remote_transfer_out.rs
@@ -327,7 +327,12 @@ where
     /// duplicate-acknowledgment risk a heal issued while the original
     /// operation is still resolvable creates - with no payload to
     /// cross-check, this transport is credulous to it by construction.
-    fn heal(self, _querier: QuerierWrapper<'_>, _env: Env) -> HandlerResult<Self> {
+    fn heal(
+        self,
+        _querier: QuerierWrapper<'_>,
+        _env: Env,
+        _info: &MessageInfo,
+    ) -> HandlerResult<Self> {
         self.schedule()
             .and_then(|batch| {
                 response::res_continue::<_, _, Self>(
@@ -524,7 +529,7 @@ mod tests {
         message::Response as MessageResponse,
     };
     use sdk::cosmwasm_std::{
-        Binary, Env, QuerierWrapper,
+        Addr, Binary, Env, MessageInfo, QuerierWrapper,
         testing::{self, MockQuerier},
     };
 
@@ -666,7 +671,11 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
 
         let node = after_first_ack(querier);
-        let (response, node) = continued(node.heal(querier, testing::mock_env()));
+        let info = MessageInfo {
+            sender: Addr::unchecked(mock::CONTROLLER),
+            funds: vec![],
+        };
+        let (response, node) = continued(node.heal(querier, testing::mock_env(), &info));
         assert_eq!(
             MessageResponse::messages_with_event(
                 mock::transfer_request(&coin2(70)).expect("a valid transfer request"),

--- a/protocol/packages/dex/src/impl_/slippage_anomaly.rs
+++ b/protocol/packages/dex/src/impl_/slippage_anomaly.rs
@@ -33,7 +33,7 @@ use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper};
 
 use crate::{
     CoinsNb, Contract, ContractInRemoteSwap, SwapTask as SwapTaskT, TimeAlarm,
-    error::Result,
+    error::{Error, Result},
     impl_::{
         RemoteSwap, RemoteSwapClient,
         response::{self, Handler, Result as HandlerResult},
@@ -52,14 +52,19 @@ const ABSORB_PARKED_ERROR: &str = "parked-error";
 const ABSORB_PARKED_TIMEOUT: &str = "parked-timeout";
 
 /// A remote swap leg parked on a slippage anomaly
+///
+/// The restore path runs through [`SlippageAnomalyRaw`] so a corrupted or
+/// malformed stored terminal is rejected before it reaches the public
+/// state/heal path: the constructor's `debug_assert!` is compiled out in
+/// release and would not guard a `Deserialize`-restored instance anyway.
 #[derive(Serialize, Deserialize)]
 #[serde(
     bound(
         serialize = "SwapTask: Serialize",
         deserialize = "SwapTask: Deserialize<'de> + SwapTaskT"
     ),
-    deny_unknown_fields,
-    rename_all = "snake_case"
+    rename_all = "snake_case",
+    try_from = "SlippageAnomalyRaw<SwapTask, SEnum>"
 )]
 pub struct SlippageAnomaly<SwapTask, SEnum>
 where
@@ -71,6 +76,51 @@ where
     in_flight_min_out: CoinDTO<SwapTask::OutG>,
     #[serde(skip)]
     _variant_set: PhantomData<SEnum>,
+}
+
+/// The wire mirror restored terminals deserialize through. [`TryFrom`]
+/// re-runs the constructor's invariant before handing back a typed terminal,
+/// so a corrupted store yields a typed [`Error`] rather than an unchecked
+/// state that the `debug_assert!`-only constructor would not catch in release.
+#[derive(Deserialize)]
+#[serde(
+    bound(deserialize = "SwapTask: Deserialize<'de> + SwapTaskT"),
+    deny_unknown_fields,
+    rename_all = "snake_case"
+)]
+struct SlippageAnomalyRaw<SwapTask, SEnum>
+where
+    SwapTask: SwapTaskT,
+{
+    spec: SwapTask,
+    acks_left: CoinsNb,
+    total_out: CoinDTO<SwapTask::OutG>,
+    in_flight_min_out: CoinDTO<SwapTask::OutG>,
+    #[serde(skip)]
+    _variant_set: PhantomData<SEnum>,
+}
+
+impl<SwapTask, SEnum> TryFrom<SlippageAnomalyRaw<SwapTask, SEnum>>
+    for SlippageAnomaly<SwapTask, SEnum>
+where
+    SwapTask: SwapTaskT,
+{
+    type Error = Error;
+
+    fn try_from(raw: SlippageAnomalyRaw<SwapTask, SEnum>) -> Result<Self> {
+        let ret = Self {
+            spec: raw.spec,
+            acks_left: raw.acks_left,
+            total_out: raw.total_out,
+            in_flight_min_out: raw.in_flight_min_out,
+            _variant_set: PhantomData,
+        };
+        if ret.invariant_held() {
+            Ok(ret)
+        } else {
+            Err(Error::SlippageAnomalyInvariantViolated)
+        }
+    }
 }
 
 impl<SwapTask, SEnum> SlippageAnomaly<SwapTask, SEnum>

--- a/protocol/packages/dex/src/impl_/slippage_anomaly.rs
+++ b/protocol/packages/dex/src/impl_/slippage_anomaly.rs
@@ -190,17 +190,25 @@ where
     /// transition back to the live swap sequence with the retry counters
     /// reset. `acks_left` is unchanged - the leg is re-opened, never
     /// advanced - so the heal re-emission promises a floor freshly pinned by
-    /// `RemoteSwap::open_leg`. Permissionless for now; an authorisation gate
-    /// is layered on by the lease wrapper.
+    /// `RemoteSwap::open_leg`. Operator-only: an unauthorised caller is
+    /// rejected before any re-quote, leaving the leg parked.
     fn heal(
         self,
         querier: QuerierWrapper<'_>,
         _env: Env,
-        _info: &MessageInfo,
+        info: &MessageInfo,
     ) -> HandlerResult<Self> {
-        RemoteSwap::<SwapTask, SEnum>::open_leg(self.spec, self.acks_left, self.total_out, querier)
+        match self.spec.authz_anomaly_resolution(querier, info) {
+            Ok(()) => RemoteSwap::<SwapTask, SEnum>::open_leg(
+                self.spec,
+                self.acks_left,
+                self.total_out,
+                querier,
+            )
             .and_then(RemoteSwap::reemit_healed)
-            .into()
+            .into(),
+            Err(err) => HandlerResult::from(err),
+        }
     }
 }
 

--- a/protocol/packages/dex/src/impl_/slippage_anomaly.rs
+++ b/protocol/packages/dex/src/impl_/slippage_anomaly.rs
@@ -46,6 +46,7 @@ use super::migration::{InspectSpec, MigrateSpec};
 const EVENT_KEY_ANOMALY: &str = "anomaly";
 const EVENT_KEY_ABSORBED: &str = "absorbed";
 const ANOMALY_PARKED: &str = "slippage-anomaly-parked";
+const ANOMALY_PRICE_ALARM_DROPPED: &str = "price-alarm-dropped";
 const ABSORB_PARKED_RESPONSE: &str = "parked-response";
 const ABSORB_PARKED_ERROR: &str = "parked-error";
 const ABSORB_PARKED_TIMEOUT: &str = "parked-timeout";
@@ -97,6 +98,12 @@ where
 
     fn emit_absorbed(&self, reason: &str) -> Emitter {
         Emitter::of_type(self.spec.label()).emit(EVENT_KEY_ABSORBED, reason)
+    }
+
+    /// The dropped-price-alarm event a parked lease emits so monitoring sees
+    /// the price move it would normally have acted on was ignored.
+    fn emit_price_alarm_dropped(&self) -> Emitter {
+        Emitter::of_type(self.spec.label()).emit(EVENT_KEY_ANOMALY, ANOMALY_PRICE_ALARM_DROPPED)
     }
 
     #[cfg(test)]
@@ -173,6 +180,10 @@ where
 
     fn on_remote_timeout(self, _querier: QuerierWrapper<'_>, _env: Env) -> HandlerResult<Self> {
         self.absorb(ABSORB_PARKED_TIMEOUT)
+    }
+
+    fn price_alarm_dropped(&self) -> Option<Emitter> {
+        Some(self.emit_price_alarm_dropped())
     }
 
     /// Re-quote the SAME in-flight leg against a fresh oracle floor and

--- a/protocol/packages/dex/src/impl_/slippage_anomaly.rs
+++ b/protocol/packages/dex/src/impl_/slippage_anomaly.rs
@@ -192,7 +192,12 @@ where
     /// advanced - so the heal re-emission promises a floor freshly pinned by
     /// `RemoteSwap::open_leg`. Permissionless for now; an authorisation gate
     /// is layered on by the lease wrapper.
-    fn heal(self, querier: QuerierWrapper<'_>, _env: Env) -> HandlerResult<Self> {
+    fn heal(
+        self,
+        querier: QuerierWrapper<'_>,
+        _env: Env,
+        _info: &MessageInfo,
+    ) -> HandlerResult<Self> {
         RemoteSwap::<SwapTask, SEnum>::open_leg(self.spec, self.acks_left, self.total_out, querier)
             .and_then(RemoteSwap::reemit_healed)
             .into()

--- a/protocol/packages/dex/src/impl_/slippage_anomaly.rs
+++ b/protocol/packages/dex/src/impl_/slippage_anomaly.rs
@@ -1,0 +1,276 @@
+//! The parked terminal a remote swap leg enters on a slippage anomaly
+//!
+//! An opened lease whose in-flight leg keeps failing - an `OperationErr`, or
+//! `OperationTimeout`s past the per-op retry budget - parks here instead of
+//! retrying forever. The node carries exactly what a [`Handler::heal`] needs
+//! to resume the SAME in-flight leg: the swap `spec`, the `acks_left`
+//! countdown identifying the leg, the accumulated `total_out`, and the floor
+//! `in_flight_min_out` pinned when the leg was last opened.
+//!
+//! While parked the lease answers state queries with
+//! `SlippageProtectionActivated` and absorbs any late acknowledgment of the
+//! original packet - reverting would strand the relayer. The at-most-once
+//! transport makes such a late callback a defensive case rather than an
+//! expected one. The operator-only heal re-quotes the leg against a fresh
+//! oracle floor and transitions back to the live [`RemoteSwap`] sequence;
+//! operators must invoke it only once the original in-flight operation is
+//! known to be unresolvable, mirroring the [`RemoteSwap`] heal contract.
+
+use std::{
+    fmt::{Display, Formatter, Result as FmtResult},
+    marker::PhantomData,
+};
+
+use serde::{Deserialize, Serialize};
+
+use finance::{coin::CoinDTO, duration::Duration, instant::Instant};
+use platform::{
+    batch::{Batch, Emit, Emitter},
+    ica::ErrorResponse as ICAErrorResponse,
+    message::Response as MessageResponse,
+};
+use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper};
+
+use crate::{
+    CoinsNb, Contract, ContractInRemoteSwap, SwapTask as SwapTaskT, TimeAlarm,
+    error::Result,
+    impl_::{
+        RemoteSwap, RemoteSwapClient,
+        response::{self, Handler, Result as HandlerResult},
+    },
+};
+
+#[cfg(feature = "migration")]
+use super::migration::{InspectSpec, MigrateSpec};
+
+const EVENT_KEY_ANOMALY: &str = "anomaly";
+const EVENT_KEY_ABSORBED: &str = "absorbed";
+const ANOMALY_PARKED: &str = "slippage-anomaly-parked";
+const ABSORB_PARKED_RESPONSE: &str = "parked-response";
+const ABSORB_PARKED_ERROR: &str = "parked-error";
+const ABSORB_PARKED_TIMEOUT: &str = "parked-timeout";
+
+/// A remote swap leg parked on a slippage anomaly
+#[derive(Serialize, Deserialize)]
+#[serde(
+    bound(
+        serialize = "SwapTask: Serialize",
+        deserialize = "SwapTask: Deserialize<'de> + SwapTaskT"
+    ),
+    deny_unknown_fields,
+    rename_all = "snake_case"
+)]
+pub struct SlippageAnomaly<SwapTask, SEnum>
+where
+    SwapTask: SwapTaskT,
+{
+    spec: SwapTask,
+    acks_left: CoinsNb,
+    total_out: CoinDTO<SwapTask::OutG>,
+    in_flight_min_out: CoinDTO<SwapTask::OutG>,
+    #[serde(skip)]
+    _state_enum: PhantomData<SEnum>,
+}
+
+impl<SwapTask, SEnum> SlippageAnomaly<SwapTask, SEnum>
+where
+    SwapTask: SwapTaskT,
+{
+    pub(super) fn new(
+        spec: SwapTask,
+        acks_left: CoinsNb,
+        total_out: CoinDTO<SwapTask::OutG>,
+        in_flight_min_out: CoinDTO<SwapTask::OutG>,
+    ) -> Self {
+        Self {
+            spec,
+            acks_left,
+            total_out,
+            in_flight_min_out,
+            _state_enum: PhantomData,
+        }
+    }
+
+    fn emit_parked(&self) -> Emitter {
+        Emitter::of_type(self.spec.label()).emit(EVENT_KEY_ANOMALY, ANOMALY_PARKED)
+    }
+
+    fn emit_absorbed(&self, reason: &str) -> Emitter {
+        Emitter::of_type(self.spec.label()).emit(EVENT_KEY_ABSORBED, reason)
+    }
+
+    #[cfg(test)]
+    pub(super) fn acks_left(&self) -> CoinsNb {
+        self.acks_left
+    }
+
+    #[cfg(test)]
+    pub(super) fn total_out(&self) -> &CoinDTO<SwapTask::OutG> {
+        &self.total_out
+    }
+
+    #[cfg(test)]
+    pub(super) fn in_flight_min_out(&self) -> &CoinDTO<SwapTask::OutG> {
+        &self.in_flight_min_out
+    }
+
+    #[cfg(test)]
+    pub(super) fn spec_mut(&mut self) -> &mut SwapTask {
+        &mut self.spec
+    }
+}
+
+impl<SwapTask, SEnum> SlippageAnomaly<SwapTask, SEnum>
+where
+    SwapTask: SwapTaskT + RemoteSwapClient,
+    Self: Handler<Response = SEnum, SwapResult = SwapTask::Result> + Into<SEnum>,
+{
+    fn absorb(self, reason: &str) -> HandlerResult<Self> {
+        let emitter = self.emit_absorbed(reason);
+        response::res_continue::<_, _, Self>(
+            MessageResponse::messages_with_event(Batch::default(), emitter),
+            self,
+        )
+        .into()
+    }
+}
+
+impl<SwapTask, SEnum> Handler for SlippageAnomaly<SwapTask, SEnum>
+where
+    SwapTask: SwapTaskT + RemoteSwapClient,
+    Self: Into<SEnum>,
+    SEnum: From<RemoteSwap<SwapTask, SEnum>>,
+    RemoteSwap<SwapTask, SEnum>:
+        Handler<Response = SEnum, SwapResult = SwapTask::Result> + Into<SEnum>,
+{
+    type Response = SEnum;
+    type SwapResult = SwapTask::Result;
+
+    fn authz_remote_callback(&self, querier: QuerierWrapper<'_>, info: &MessageInfo) -> Result<()> {
+        self.spec.authz_remote_callback(querier, info)
+    }
+
+    /// A late acknowledgment of the original packet is absorbed without
+    /// advancing or mutating the parked progress - reverting would strand
+    /// the relayer, and the frozen leg stays put for the operator heal.
+    fn on_remote_response(
+        self,
+        _data: Binary,
+        _querier: QuerierWrapper<'_>,
+        _env: Env,
+    ) -> HandlerResult<Self> {
+        self.absorb(ABSORB_PARKED_RESPONSE)
+    }
+
+    fn on_remote_error(
+        self,
+        _response: ICAErrorResponse,
+        _querier: QuerierWrapper<'_>,
+        _env: Env,
+    ) -> HandlerResult<Self> {
+        self.absorb(ABSORB_PARKED_ERROR)
+    }
+
+    fn on_remote_timeout(self, _querier: QuerierWrapper<'_>, _env: Env) -> HandlerResult<Self> {
+        self.absorb(ABSORB_PARKED_TIMEOUT)
+    }
+
+    /// Re-quote the SAME in-flight leg against a fresh oracle floor and
+    /// transition back to the live swap sequence with the retry counters
+    /// reset. `acks_left` is unchanged - the leg is re-opened, never
+    /// advanced - so the heal re-emission promises a floor freshly pinned by
+    /// `RemoteSwap::open_leg`. Permissionless for now; an authorisation gate
+    /// is layered on by the lease wrapper.
+    fn heal(self, querier: QuerierWrapper<'_>, _env: Env) -> HandlerResult<Self> {
+        RemoteSwap::<SwapTask, SEnum>::open_leg(self.spec, self.acks_left, self.total_out, querier)
+            .and_then(RemoteSwap::reemit_healed)
+            .into()
+    }
+}
+
+impl<SwapTask, SEnum> Contract for SlippageAnomaly<SwapTask, SEnum>
+where
+    SwapTask:
+        SwapTaskT + ContractInRemoteSwap<StateResponse = <SwapTask as SwapTaskT>::StateResponse>,
+{
+    type StateResponse = <SwapTask as SwapTaskT>::StateResponse;
+
+    fn state(
+        self,
+        now: Instant,
+        due_projection: Duration,
+        querier: QuerierWrapper<'_>,
+    ) -> Self::StateResponse {
+        self.spec
+            .anomaly_state(self.acks_left, now, due_projection, querier)
+    }
+}
+
+impl<SwapTask, SEnum> Display for SlippageAnomaly<SwapTask, SEnum>
+where
+    SwapTask: SwapTaskT,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str("SlippageAnomaly at ")
+            .and_then(|()| f.write_str(&Into::<String>::into(self.spec.label())))
+    }
+}
+
+impl<SwapTask, SEnum> TimeAlarm for SlippageAnomaly<SwapTask, SEnum>
+where
+    SwapTask: SwapTaskT,
+{
+    fn setup_alarm(&self, r#for: Instant) -> Result<Batch> {
+        self.spec
+            .time_alarm()
+            .setup_alarm(r#for)
+            .map_err(Into::into)
+    }
+}
+
+#[cfg(feature = "migration")]
+impl<SwapTask, SwapTaskNew, SEnum, SEnumNew> MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
+    for SlippageAnomaly<SwapTask, SEnum>
+where
+    Self: Sized,
+    SwapTask: SwapTaskT,
+    SwapTaskNew: SwapTaskT<OutG = SwapTask::OutG>,
+    SlippageAnomaly<SwapTaskNew, SEnumNew>: Into<SEnumNew>,
+{
+    type Out = SlippageAnomaly<SwapTaskNew, SEnumNew>;
+
+    fn migrate_spec<MigrateFn>(self, migrate_fn: MigrateFn) -> Self::Out
+    where
+        MigrateFn: FnOnce(SwapTask) -> SwapTaskNew,
+    {
+        SlippageAnomaly::new(
+            migrate_fn(self.spec),
+            self.acks_left,
+            self.total_out,
+            self.in_flight_min_out,
+        )
+    }
+}
+
+#[cfg(feature = "migration")]
+impl<SwapTask, R, SEnum> InspectSpec<SwapTask, R> for SlippageAnomaly<SwapTask, SEnum>
+where
+    SwapTask: SwapTaskT,
+{
+    fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R
+    where
+        InspectFn: FnOnce(&SwapTask) -> R,
+    {
+        inspect_fn(&self.spec)
+    }
+}
+
+/// The on-entry event a leg emits as it parks at the terminal.
+pub(super) fn emit_parked_on_entry<SwapTask, SEnum>(
+    terminal: &SlippageAnomaly<SwapTask, SEnum>,
+) -> Emitter
+where
+    SwapTask: SwapTaskT,
+{
+    terminal.emit_parked()
+}

--- a/protocol/packages/dex/src/impl_/slippage_anomaly.rs
+++ b/protocol/packages/dex/src/impl_/slippage_anomaly.rs
@@ -70,7 +70,7 @@ where
     total_out: CoinDTO<SwapTask::OutG>,
     in_flight_min_out: CoinDTO<SwapTask::OutG>,
     #[serde(skip)]
-    _state_enum: PhantomData<SEnum>,
+    _variant_set: PhantomData<SEnum>,
 }
 
 impl<SwapTask, SEnum> SlippageAnomaly<SwapTask, SEnum>
@@ -83,16 +83,34 @@ where
         total_out: CoinDTO<SwapTask::OutG>,
         in_flight_min_out: CoinDTO<SwapTask::OutG>,
     ) -> Self {
-        Self {
+        let ret = Self {
             spec,
             acks_left,
             total_out,
             in_flight_min_out,
-            _state_enum: PhantomData,
-        }
+            _variant_set: PhantomData,
+        };
+        debug_assert!(ret.invariant_held());
+        ret
     }
 
-    fn emit_parked(&self) -> Emitter {
+    /// The frozen leg the terminal carries is a snapshot of the live
+    /// [`RemoteSwap`] leg it parked from, so the same invariant holds: an
+    /// in-flight leg the `acks_left` countdown points at within the spec's
+    /// swappable coins, with the pinned floor denominated in the accumulated
+    /// total's currency.
+    fn invariant_held(&self) -> bool {
+        0 < self.acks_left
+            && usize::from(self.acks_left) <= self.legs_nb()
+            && self.in_flight_min_out.currency() == self.total_out.currency()
+    }
+
+    fn legs_nb(&self) -> usize {
+        super::remote_swap::swappable_coins(&self.spec, self.total_out.currency()).count()
+    }
+
+    /// The on-entry event a leg emits as it parks at the terminal.
+    pub(super) fn emit_parked(&self) -> Emitter {
         Emitter::of_type(self.spec.label()).emit(EVENT_KEY_ANOMALY, ANOMALY_PARKED)
     }
 
@@ -226,7 +244,7 @@ where
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
         self.spec
-            .anomaly_state(self.acks_left, now, due_projection, querier)
+            .anomaly_response(self.acks_left, now, due_projection, querier)
     }
 }
 
@@ -287,14 +305,4 @@ where
     {
         inspect_fn(&self.spec)
     }
-}
-
-/// The on-entry event a leg emits as it parks at the terminal.
-pub(super) fn emit_parked_on_entry<SwapTask, SEnum>(
-    terminal: &SlippageAnomaly<SwapTask, SEnum>,
-) -> Emitter
-where
-    SwapTask: SwapTaskT,
-{
-    terminal.emit_parked()
 }

--- a/protocol/packages/dex/src/impl_/transfer_in_finish.rs
+++ b/protocol/packages/dex/src/impl_/transfer_in_finish.rs
@@ -241,7 +241,12 @@ where
         self.spec.authz_remote_callback(querier, info)
     }
 
-    fn heal(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
+    fn heal(
+        self,
+        querier: QuerierWrapper<'_>,
+        env: Env,
+        _info: &MessageInfo,
+    ) -> HandlerResult<Self> {
         self.try_complete(querier, env)
     }
 

--- a/protocol/packages/dex/src/impl_/transfer_in_init.rs
+++ b/protocol/packages/dex/src/impl_/transfer_in_init.rs
@@ -156,7 +156,12 @@ where
         let state_label = self.spec.label();
         timeout::on_timeout_retry(self, state_label, querier, env)
     }
-    fn heal(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
+    fn heal(
+        self,
+        querier: QuerierWrapper<'_>,
+        env: Env,
+        _info: &sdk::cosmwasm_std::MessageInfo,
+    ) -> HandlerResult<Self> {
         self.on_response(querier, env)
     }
 }

--- a/protocol/packages/dex/src/lib.rs
+++ b/protocol/packages/dex/src/lib.rs
@@ -11,16 +11,16 @@ pub use self::{
     impl_::{
         AcceptAnyNonZeroSwap, AcceptUpToMaxSlippage, DrainStage, FundsArrival, IcaConnector,
         MaxSlippage, RemoteSwap, RemoteSwapClient, RemoteTransferOut, RemoteTransferOutTask,
-        StartDrainState, StartLocalLocalState, StartLocalRemoteState, StartOutSwapState,
-        StartSwapState, StartTransferInState, StateDrain, StateLocalOut, StateOutSwap,
-        StateRemoteOut, StateSwap, TransferOut, start_drain, start_local_local, start_local_remote,
-        start_out_swap, start_remote_local, start_swap,
+        SlippageAnomaly, StartDrainState, StartLocalLocalState, StartLocalRemoteState,
+        StartOutSwapState, StartSwapState, StartTransferInState, StateDrain, StateLocalOut,
+        StateOutSwap, StateRemoteOut, StateSwap, TransferOut, start_drain, start_local_local,
+        start_local_remote, start_out_swap, start_remote_local, start_swap,
     },
     resp_delivery::ForwardToInner,
     response::{ContinueResult, Handler, Response, Result},
     slippage::{Calculator as SlippageCalculator, WithCalculator},
     state::{Contract, ContractInRemoteSwap, ContractInSwap, Stage},
-    swap_task::{CoinsNb, SwapOutputTask, SwapTask, WithOutputTask},
+    swap_task::{CoinsNb, SlippageEscalation, SwapOutputTask, SwapTask, WithOutputTask},
     time_alarm::TimeAlarm,
 };
 

--- a/protocol/packages/dex/src/response.rs
+++ b/protocol/packages/dex/src/response.rs
@@ -162,6 +162,16 @@ where
     {
         absorb_remote_callback(self, REMOTE_CALLBACK_TIMEOUT)
     }
+
+    /// The event a parked leg emits when a price alarm is dropped
+    ///
+    /// Live legs drop price alarms silently; only the parked slippage-anomaly
+    /// terminal returns an event, so monitoring sees a frozen lease ignored a
+    /// price move it would normally have acted on. The alarm is still dropped,
+    /// never erroring.
+    fn price_alarm_dropped(&self) -> Option<Emitter> {
+        None
+    }
 }
 
 fn absorb_remote_callback<H>(state: H, kind: &str) -> Result<H>

--- a/protocol/packages/dex/src/response.rs
+++ b/protocol/packages/dex/src/response.rs
@@ -102,7 +102,7 @@ where
         Err(err(self, "handle inner to 'Continue' response"))
     }
 
-    fn heal(self, _querier: QuerierWrapper<'_>, _env: Env) -> Result<Self> {
+    fn heal(self, _querier: QuerierWrapper<'_>, _env: Env, _info: &MessageInfo) -> Result<Self> {
         Err(err(self, "handle heal")).into()
     }
 

--- a/protocol/packages/dex/src/state.rs
+++ b/protocol/packages/dex/src/state.rs
@@ -58,7 +58,7 @@ where
     /// Mirrors [`ContractInRemoteSwap::state`] but reports the anomaly rather
     /// than the in-flight progress. The leg the `acks_left` countdown points
     /// at is unchanged - the terminal froze it.
-    fn anomaly_state(
+    fn anomaly_response(
         self,
         acks_left: CoinsNb,
         now: Instant,

--- a/protocol/packages/dex/src/state.rs
+++ b/protocol/packages/dex/src/state.rs
@@ -52,6 +52,19 @@ where
         due_projection: Duration,
         querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse;
+
+    /// The state of a leg parked at the slippage-anomaly terminal
+    ///
+    /// Mirrors [`ContractInRemoteSwap::state`] but reports the anomaly rather
+    /// than the in-flight progress. The leg the `acks_left` countdown points
+    /// at is unchanged - the terminal froze it.
+    fn anomaly_state(
+        self,
+        acks_left: CoinsNb,
+        now: Instant,
+        due_projection: Duration,
+        querier: QuerierWrapper<'_>,
+    ) -> Self::StateResponse;
 }
 
 pub enum Stage {

--- a/protocol/packages/dex/src/swap_task.rs
+++ b/protocol/packages/dex/src/swap_task.rs
@@ -39,6 +39,10 @@ where
         info: &MessageInfo,
     ) -> DexResult<()>;
 
+    /// The number of consecutive remote-swap timeouts tolerated on a leg
+    /// before the slippage-anomaly terminal is entered.
+    fn timeout_retry_budget(&self) -> CoinsNb;
+
     /// Provide the coins, at least one, this swap is about.
     /// The iteration is done always in the same order.
     //

--- a/protocol/packages/dex/src/swap_task.rs
+++ b/protocol/packages/dex/src/swap_task.rs
@@ -8,6 +8,17 @@ use crate::{Account, AnomalyTreatment, error::Result as DexResult, slippage::Wit
 
 pub type CoinsNb = u8;
 
+/// How a remote swap leg escalates a slippage anomaly once its in-flight
+/// leg keeps failing - an error, or a timeout past the per-op retry budget.
+pub enum SlippageEscalation {
+    /// Park the leg at the slippage-anomaly terminal: opened legs freeze and
+    /// wait for an operator heal instead of retrying forever.
+    Park,
+    /// Re-emit the in-flight leg verbatim, unbounded: the opening swap keeps
+    /// the legacy behaviour - it has no terminal in this phase.
+    ReEmit,
+}
+
 /// Specification of a swap process
 ///
 /// Supports up to `CoinsNb::MAX` coins.
@@ -42,6 +53,11 @@ where
     /// The number of consecutive remote-swap timeouts tolerated on a leg
     /// before the slippage-anomaly terminal is entered.
     fn timeout_retry_budget(&self) -> CoinsNb;
+
+    /// How a slippage anomaly on this task's in-flight leg escalates once the
+    /// retry budget is spent - parking the opened legs while the opening swap
+    /// keeps re-emitting verbatim.
+    fn slippage_escalation(&self) -> SlippageEscalation;
 
     /// Provide the coins, at least one, this swap is about.
     /// The iteration is done always in the same order.

--- a/protocol/packages/dex/src/swap_task.rs
+++ b/protocol/packages/dex/src/swap_task.rs
@@ -50,6 +50,19 @@ where
         info: &MessageInfo,
     ) -> DexResult<()>;
 
+    /// Authorise an operator `heal` of a leg parked at the slippage-anomaly
+    /// terminal.
+    ///
+    /// The re-quoting heal is operator-only: it re-pins the floor and revives
+    /// a frozen leg. Implementations decide what "authorised" means (typically:
+    /// only the lease admin). Tasks whose legs never park reject - they are
+    /// never reached through this path.
+    fn authz_anomaly_resolution(
+        &self,
+        querier: QuerierWrapper<'_>,
+        info: &MessageInfo,
+    ) -> DexResult<()>;
+
     /// The number of consecutive remote-swap timeouts tolerated on a leg
     /// before the slippage-anomaly terminal is entered.
     fn timeout_retry_budget(&self) -> CoinsNb;

--- a/tests/src/lease/mod.rs
+++ b/tests/src/lease/mod.rs
@@ -46,6 +46,7 @@ mod remote_lease_callback;
 mod remote_lease_close;
 // TODO #142 Phase 3: enable when the OpenLease state + Status::OpenFailed land.
 mod remote_lease_open;
+mod remote_lease_slippage_terminal;
 mod remote_lease_swap;
 mod remote_lease_transfer_out;
 mod repay;

--- a/tests/src/lease/remote_lease_slippage_terminal.rs
+++ b/tests/src/lease/remote_lease_slippage_terminal.rs
@@ -51,9 +51,7 @@ use crate::common::{
     test_case::TestCase,
 };
 
-use super::{
-    DOWNPAYMENT, LeaseCoin, LeaseTestCase, LpnCoin, LpnCurrency, PaymentCurrency, repay,
-};
+use super::{DOWNPAYMENT, LeaseCoin, LeaseTestCase, LpnCoin, LpnCurrency, PaymentCurrency, repay};
 
 const LIQUIDATION_SWAP_EVENT: &str = "wasm-ls-liquidation-swap";
 const CLOSE_POSITION_EVENT: &str = "wasm-ls-close-position";
@@ -566,7 +564,9 @@ fn recorded_swap_count(test_case: &LeaseTestCase, lease: &Addr) -> u32 {
 
 /// The `min_out` floor of the latest recorded swap leg for the lease.
 fn latest_min_out(test_case: &LeaseTestCase, lease: &Addr) -> Amount {
-    super::recorded_close_swap(test_case, lease).min_out().amount()
+    super::recorded_close_swap(test_case, lease)
+        .min_out()
+        .amount()
 }
 
 #[track_caller]

--- a/tests/src/lease/remote_lease_slippage_terminal.rs
+++ b/tests/src/lease/remote_lease_slippage_terminal.rs
@@ -1,0 +1,651 @@
+//! Slippage-anomaly terminal E2E for the three opened remote-swap legs
+//! (issue #655 Phase 1).
+//!
+//! The remote-lease swap legs - repay (`BuyLpn`), liquidation and
+//! customer-close (`SellAsset`) - run one in-flight leg at a time over the
+//! remote-lease controller. Today an `OperationErr` and an
+//! `OperationTimeout` both re-emit the in-flight leg unbounded; there is no
+//! terminal, so a persistently failing swap retries forever. Phase 1
+//! restores the slippage valve:
+//!
+//! - an `OperationErr` routes immediately to a parked slippage-anomaly
+//!   terminal (no retry),
+//! - an `OperationTimeout` re-emits the in-flight leg up to a per-op budget
+//!   (liquidation 5, customer-close 2, repay 3) and then parks,
+//! - a parked lease reports `Status::SlippageProtectionActivated`, rejects
+//!   customer self-rescue (`Repay`, `ClosePosition`, `ChangeClosePolicy`)
+//!   and silently drops price alarms (emitting a dropped-alarm event),
+//! - `Heal` is operator-only on a parked lease: a non-admin caller is
+//!   rejected by the live leaser authz, the lease admin re-quotes the
+//!   in-flight leg with a fresh oracle floor (meaningful for liquidation,
+//!   a no-op for the `AcceptAnyNonZeroSwap` repay/customer-close legs) and
+//!   resets the retry counters,
+//! - the terminal absorbs late acknowledgments of the original packet.
+//!
+//! These drivers exercise the stable public surface - `ExecuteMsg`
+//! (`Repay`, `ClosePosition`, `Heal`, `PriceAlarm`, `RemoteLeaseCallback`),
+//! the `StateResponse`/`Status` query, and the controller stub's response
+//! modes - so they compile against the current code and FAIL until the
+//! Phase-1 behaviour lands.
+
+use access_control::error::Error as AccessError;
+use finance::coin::Amount;
+use lease::{
+    api::{
+        ExecuteMsg,
+        position::{FullClose, PositionClose},
+        query::{StateResponse, opened::Status},
+    },
+    error::ContractError,
+};
+use remote_lease::callback::{RemoteErrorMessage, RemoteLeaseCallback};
+use sdk::{
+    cosmwasm_std::{Addr, Event},
+    testing,
+};
+
+use crate::common::{
+    self, ADMIN, USER,
+    remote_lease_controller_stub::{self as stub, ResponseMode, op_tag},
+    test_case::TestCase,
+};
+
+use super::{
+    DOWNPAYMENT, LeaseCoin, LeaseTestCase, LpnCoin, LpnCurrency, PaymentCurrency, repay,
+};
+
+const LIQUIDATION_SWAP_EVENT: &str = "wasm-ls-liquidation-swap";
+const CLOSE_POSITION_EVENT: &str = "wasm-ls-close-position";
+
+/// The per-op timeout retry budgets settled by issue #655: the number of
+/// timeout re-emissions a leg tolerates before parking at the terminal.
+const LIQUIDATION_BUDGET: u8 = 5;
+const CUSTOMER_CLOSE_BUDGET: u8 = 2;
+const REPAY_BUDGET: u8 = 3;
+
+// --- #3 error -> immediate terminal -------------------------------------
+
+/// An `OperationErr` on a liquidation sell-asset leg routes straight to the
+/// parked terminal without a retry: the query reports
+/// `SlippageProtectionActivated`.
+#[test]
+fn error_routes_immediately_to_terminal() {
+    let mut test_case = create_test_case();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    let lease = drive_into_liquidation_swap(&mut test_case);
+
+    let swaps_before = recorded_swap_count(&test_case, &lease);
+    let reason = RemoteErrorMessage::new("swap reverted: under floor").expect("within length cap");
+    let _absorbed = stub::inject_callback(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        RemoteLeaseCallback::OperationErr(reason),
+    );
+
+    // an error must NOT re-emit the leg - it parks immediately
+    assert_eq!(swaps_before, recorded_swap_count(&test_case, &lease));
+    assert_slippage_protection_activated(&test_case, &lease);
+}
+
+// --- #4/#5/#6 timeout budget -> terminal --------------------------------
+
+/// A liquidation leg re-emits on each `OperationTimeout` up to the budget
+/// (5) and parks on the next one: the leg is still retrying right at the
+/// budget and parked one beyond it.
+#[test]
+fn timeout_budget_then_terminal_liquidation() {
+    let mut test_case = create_test_case();
+    let lease = drive_into_liquidation_swap(&mut test_case);
+
+    assert_parks_after_budget(&mut test_case, &lease, LIQUIDATION_BUDGET);
+}
+
+/// A customer-close leg parks after its budget (2).
+#[test]
+fn timeout_budget_then_terminal_customer_close() {
+    let mut test_case = create_test_case();
+    let lease = drive_into_customer_close_swap(&mut test_case);
+
+    assert_parks_after_budget(&mut test_case, &lease, CUSTOMER_CLOSE_BUDGET);
+}
+
+/// A repay leg parks after its budget (3).
+#[test]
+fn timeout_budget_then_terminal_repay() {
+    let mut test_case = create_test_case();
+    let lease = drive_into_repay_swap(&mut test_case);
+
+    assert_parks_after_budget(&mut test_case, &lease, REPAY_BUDGET);
+}
+
+// --- #7 query surfaces the terminal -------------------------------------
+
+/// A parked lease answers the state query with
+/// `Status::SlippageProtectionActivated`.
+#[test]
+fn terminal_reports_slippage_protection_activated() {
+    let mut test_case = create_test_case();
+    let lease = park_liquidation(&mut test_case);
+
+    assert_slippage_protection_activated(&test_case, &lease);
+}
+
+// --- #10/#11/#12 operator-gated re-quoting heal -------------------------
+
+/// A non-admin `Heal` on a parked lease is rejected by the live leaser
+/// authz - the customer cannot self-rescue a parked slippage anomaly.
+#[test]
+fn heal_rejects_non_admin() {
+    let mut test_case = create_test_case();
+    let lease = park_liquidation(&mut test_case);
+
+    let err = test_case
+        .app
+        .execute(testing::user(USER), lease.clone(), &ExecuteMsg::Heal(), &[])
+        .expect_err("a non-admin heal of a parked lease must be rejected");
+    assert!(
+        matches!(
+            err.downcast_ref::<ContractError>(),
+            Some(ContractError::Unauthorized(AccessError::Unauthorized {}))
+        ),
+        "expected ContractError::Unauthorized, got {err:?}"
+    );
+    assert_slippage_protection_activated(&test_case, &lease);
+}
+
+/// The lease admin heals a parked liquidation: the leg is re-emitted with a
+/// fresh oracle floor (the `percent::Calculator` re-quote pins a higher
+/// floor when the oracle price has moved up) and the retry counters reset,
+/// so the lease leaves the terminal back into the live swap sequence.
+#[test]
+fn heal_accepts_admin_requotes_and_resets_counters() {
+    let mut test_case = create_test_case();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    let lease = park_liquidation(&mut test_case);
+    let floor_before = latest_min_out(&test_case, &lease);
+
+    // raise the asset price so a fresh quote pins a strictly higher floor
+    let () = super::deliver_new_price(&mut test_case, LeaseCoin::new(1), LpnCoin::new(2))
+        .ignore_response()
+        .unwrap_response();
+
+    let healed = test_case
+        .app
+        .execute(testing::user(ADMIN), lease.clone(), &ExecuteMsg::Heal(), &[])
+        .expect("the lease admin must heal a parked lease")
+        .unwrap_response();
+    expect_attribute(&healed.events, LIQUIDATION_SWAP_EVENT, "heal", "re-emit");
+
+    // the re-quote raised the floor and the lease is back to retrying
+    let floor_after = latest_min_out(&test_case, &lease);
+    assert!(
+        floor_after > floor_before,
+        "the heal re-quote must raise the liquidation floor, was {floor_before}, now {floor_after}"
+    );
+    assert_liquidation_swap_in_flight(&test_case, &lease);
+
+    // the counters reset: the leg tolerates a full fresh budget again
+    assert_parks_after_budget(&mut test_case, &lease, LIQUIDATION_BUDGET);
+    let _ = controller;
+}
+
+/// Healing a parked customer-close leg re-emits with the same `min_out` of
+/// `1`: the `AcceptAnyNonZeroSwap` floor is constant, so a re-quote is a
+/// no-op for repay/customer-close.
+#[test]
+fn heal_requote_is_noop_for_accept_any_nonzero_floor() {
+    let mut test_case = create_test_case();
+    let lease = park_customer_close(&mut test_case);
+    let floor_before = latest_min_out(&test_case, &lease);
+
+    let () = super::deliver_new_price(&mut test_case, LeaseCoin::new(1), LpnCoin::new(2))
+        .ignore_response()
+        .unwrap_response();
+
+    let healed = test_case
+        .app
+        .execute(testing::user(ADMIN), lease.clone(), &ExecuteMsg::Heal(), &[])
+        .expect("the lease admin must heal a parked lease")
+        .unwrap_response();
+    expect_attribute(&healed.events, CLOSE_POSITION_EVENT, "heal", "re-emit");
+
+    let floor_after = latest_min_out(&test_case, &lease);
+    assert_eq!(
+        1, floor_after,
+        "AcceptAnyNonZeroSwap pins a constant floor of 1"
+    );
+    assert_eq!(
+        floor_before, floor_after,
+        "a re-quote must not change the constant floor"
+    );
+}
+
+// --- #13/#14 full park ---------------------------------------------------
+
+/// A parked lease rejects customer self-rescue: `Repay` surfaces the exact
+/// `ContractError::UnsupportedOperation("repay")`.
+#[test]
+fn full_park_rejects_repay_close_policy() {
+    let mut test_case = create_test_case();
+    let lease = park_liquidation(&mut test_case);
+
+    let payment = super::create_payment_coin(1_000);
+    test_case.send_funds_from_admin(testing::user(USER), &[common::cwcoin(payment)]);
+    let err = test_case
+        .app
+        .execute(
+            testing::user(USER),
+            lease.clone(),
+            &ExecuteMsg::Repay {},
+            &[common::cwcoin(payment)],
+        )
+        .expect_err("a parked lease must reject repay");
+    assert!(
+        matches!(
+            err.downcast_ref::<ContractError>(),
+            Some(ContractError::UnsupportedOperation(op)) if op == "repay"
+        ),
+        "expected UnsupportedOperation(\"repay\"), got {err:?}"
+    );
+
+    let err = test_case
+        .app
+        .execute(
+            testing::user(USER),
+            lease.clone(),
+            &ExecuteMsg::ClosePosition(PositionClose::FullClose(FullClose {})),
+            &[],
+        )
+        .expect_err("a parked lease must reject close-position");
+    assert!(
+        matches!(
+            err.downcast_ref::<ContractError>(),
+            Some(ContractError::UnsupportedOperation(op)) if op == "close position"
+        ),
+        "expected UnsupportedOperation(\"close position\"), got {err:?}"
+    );
+}
+
+/// A parked lease silently drops a price alarm: the alarm neither errors nor
+/// advances the swap, and a dropped-alarm event is emitted for monitoring.
+#[test]
+fn full_park_drops_price_alarm() {
+    let mut test_case = create_test_case();
+    let lease = park_liquidation(&mut test_case);
+    let swaps_before = recorded_swap_count(&test_case, &lease);
+
+    let oracle = test_case.address_book.oracle().clone();
+    let dropped = test_case
+        .app
+        .execute(oracle, lease.clone(), &ExecuteMsg::PriceAlarm(), &[])
+        .expect("a parked lease must absorb, not reject, a price alarm")
+        .unwrap_response();
+
+    // the parked terminal emits a dropped-alarm event rather than swallowing
+    // it bare - monitoring needs to see that the parked lease ignored a
+    // price move it would normally act on
+    expect_attribute(
+        &dropped.events,
+        LIQUIDATION_SWAP_EVENT,
+        "anomaly",
+        "price-alarm-dropped",
+    );
+    assert_eq!(swaps_before, recorded_swap_count(&test_case, &lease));
+    assert_slippage_protection_activated(&test_case, &lease);
+}
+
+// --- A3 regression: opening (BuyAsset) stays unbounded -------------------
+
+/// Opening is DEFERRED in Phase 1: an opening-swap leg keeps re-emitting on
+/// every `OperationTimeout`, well past any of the opened-leg budgets, and
+/// never parks. Regression guard - this passes today and must keep passing.
+#[test]
+fn buy_asset_timeout_reemits_unbounded() {
+    let (mut test_case, lease, controller) = start_open_with_delayed_swap();
+    let swaps_before = recorded_swap_count(&test_case, &lease);
+
+    // re-emit far past the largest opened-leg budget; opening never parks
+    let rounds = u32::from(LIQUIDATION_BUDGET) + 3;
+    for _ in 0..rounds {
+        let _reemit = stub::inject_callback(
+            &mut test_case.app,
+            &controller,
+            &lease,
+            RemoteLeaseCallback::OperationTimeout,
+        );
+    }
+
+    assert_eq!(
+        swaps_before + rounds,
+        recorded_swap_count(&test_case, &lease),
+        "every opening timeout must re-emit - opening has no terminal in Phase 1"
+    );
+    assert_opening_swap_in_flight(&test_case, &lease);
+}
+
+/// An `OperationErr` on an opening-swap leg re-emits verbatim (the legacy
+/// error==timeout behaviour) - opening is byte-identical to today.
+/// Regression guard.
+#[test]
+fn buy_asset_error_reemits() {
+    let (mut test_case, lease, controller) = start_open_with_delayed_swap();
+    let swaps_before = recorded_swap_count(&test_case, &lease);
+
+    let reason = RemoteErrorMessage::new("opening swap failed").expect("within length cap");
+    let _reemit = stub::inject_callback(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        RemoteLeaseCallback::OperationErr(reason),
+    );
+
+    assert_eq!(
+        swaps_before + 1,
+        recorded_swap_count(&test_case, &lease),
+        "an opening swap error must re-emit, not park"
+    );
+    assert_opening_swap_in_flight(&test_case, &lease);
+}
+
+// === drivers =============================================================
+
+fn create_test_case() -> LeaseTestCase {
+    super::create_test_case::<PaymentCurrency>()
+}
+
+/// Open a lease and drop the price into a full-liquidation, holding the
+/// liquidation sell-asset swap in flight via the `Delayed` SWAP mode. The
+/// lease sits in the `remote_swap_only` composite awaiting the swap ack.
+fn drive_into_liquidation_swap(test_case: &mut LeaseTestCase) -> Addr {
+    let lease = super::open_lease(test_case, DOWNPAYMENT, None);
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+
+    // the literal-floor opening amounts; the base is chosen close to the
+    // asset amount to trigger a full liquidation (mirrors liquidation::price)
+    let lease_amount: Amount = 2428571428570;
+    let borrowed_amount: Amount = 1857142857142;
+    let () = super::deliver_new_price(
+        test_case,
+        common::coin(lease_amount - 2),
+        common::coin(borrowed_amount),
+    )
+    .ignore_response()
+    .unwrap_response();
+
+    assert_liquidation_swap_in_flight(test_case, &lease);
+    lease
+}
+
+/// Open a lease and issue a full `ClosePosition`, holding the sell-asset
+/// swap in flight via the `Delayed` SWAP mode.
+fn drive_into_customer_close_swap(test_case: &mut LeaseTestCase) -> Addr {
+    let lease = super::open_lease(test_case, DOWNPAYMENT, None);
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+
+    let () = test_case
+        .app
+        .execute(
+            testing::user(USER),
+            lease.clone(),
+            &ExecuteMsg::ClosePosition(PositionClose::FullClose(FullClose {})),
+            &[],
+        )
+        .expect("close-position must start the sell-asset swap")
+        .ignore_response()
+        .unwrap_response();
+
+    assert_customer_close_swap_in_flight(test_case, &lease);
+    lease
+}
+
+/// Open a lease and start a full repay, holding the `BuyLpn` repay swap in
+/// flight via the `Delayed` SWAP mode.
+fn drive_into_repay_swap(test_case: &mut LeaseTestCase) -> Addr {
+    let lease = super::open_lease(test_case, DOWNPAYMENT, None);
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+
+    let payment = super::create_payment_coin(1_000);
+    test_case.send_funds_from_admin(testing::user(USER), &[common::cwcoin(payment)]);
+    let _repay = repay::send_repay(test_case, lease.clone(), payment);
+    repay::consume_repay_swap_input(
+        test_case,
+        &TestCase::ica_addr(&lease, TestCase::LEASE_ICA_ID),
+        payment,
+    );
+
+    assert_repay_swap_in_flight(test_case, &lease);
+    lease
+}
+
+/// Drive into the liquidation swap and park it by exhausting the timeout
+/// budget (budget + 1 timeouts).
+fn park_liquidation(test_case: &mut LeaseTestCase) -> Addr {
+    let lease = drive_into_liquidation_swap(test_case);
+    exhaust_budget(test_case, &lease, LIQUIDATION_BUDGET);
+    lease
+}
+
+/// Drive into the customer-close swap and park it.
+fn park_customer_close(test_case: &mut LeaseTestCase) -> Addr {
+    let lease = drive_into_customer_close_swap(test_case);
+    exhaust_budget(test_case, &lease, CUSTOMER_CLOSE_BUDGET);
+    lease
+}
+
+/// Open a lease, hold the opening swaps in flight via the `Delayed` SWAP
+/// mode, and confirm an opening swap leg is outstanding.
+fn start_open_with_delayed_swap() -> (LeaseTestCase, Addr, Addr) {
+    let mut test_case = create_test_case();
+    let lease = super::try_init_lease(&mut test_case, DOWNPAYMENT, None);
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+
+    let ica_addr = TestCase::ica_addr(&lease, TestCase::LEASE_ICA_ID);
+    let ica_port = format!("icacontroller-{ica_addr}");
+    let ica_channel = format!("channel-{ica_addr}");
+    let exp_borrow = super::quote_borrow(&test_case, DOWNPAYMENT);
+    let _ = common::lease::confirm_ica_and_transfer_funds::<PaymentCurrency, LpnCurrency>(
+        &mut test_case.app,
+        lease.clone(),
+        TestCase::DEX_CONNECTION_ID,
+        (&ica_channel, &ica_port, ica_addr),
+        (DOWNPAYMENT, exp_borrow),
+    )
+    .unwrap_response();
+
+    assert_opening_swap_in_flight(&test_case, &lease);
+    (test_case, lease, controller)
+}
+
+/// Inject `budget` timeouts (each must re-emit, still retrying) and assert
+/// the `budget + 1`th parks the lease at the terminal.
+#[track_caller]
+fn assert_parks_after_budget(test_case: &mut LeaseTestCase, lease: &Addr, budget: u8) {
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    let swaps_before = recorded_swap_count(test_case, lease);
+
+    for round in 0..budget {
+        let _reemit = stub::inject_callback(
+            &mut test_case.app,
+            &controller,
+            lease,
+            RemoteLeaseCallback::OperationTimeout,
+        );
+        // each timeout within budget re-emits exactly one swap and the lease
+        // keeps retrying (NOT parked yet)
+        assert_eq!(
+            swaps_before + u32::from(round) + 1,
+            recorded_swap_count(test_case, lease),
+            "timeout {} within budget {budget} must re-emit the in-flight leg",
+            round + 1,
+        );
+        assert!(
+            !is_slippage_protection_activated(test_case, lease),
+            "the lease must still be retrying within budget {budget}, round {}",
+            round + 1,
+        );
+    }
+
+    // the budget+1-th timeout parks - no further re-emission
+    let swaps_at_budget = recorded_swap_count(test_case, lease);
+    let _park = stub::inject_callback(
+        &mut test_case.app,
+        &controller,
+        lease,
+        RemoteLeaseCallback::OperationTimeout,
+    );
+    assert_eq!(
+        swaps_at_budget,
+        recorded_swap_count(test_case, lease),
+        "the timeout past budget {budget} must park, not re-emit",
+    );
+    assert_slippage_protection_activated(test_case, lease);
+}
+
+/// Drive exactly `budget + 1` timeouts to land the lease at the terminal,
+/// without the per-round budget assertions.
+fn exhaust_budget(test_case: &mut LeaseTestCase, lease: &Addr, budget: u8) {
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    for _ in 0..=budget {
+        let _cb = stub::inject_callback(
+            &mut test_case.app,
+            &controller,
+            lease,
+            RemoteLeaseCallback::OperationTimeout,
+        );
+    }
+    assert_slippage_protection_activated(test_case, lease);
+}
+
+// === query / recorder helpers ===========================================
+
+fn recorded_swap_count(test_case: &LeaseTestCase, lease: &Addr) -> u32 {
+    let controller = test_case.address_book.remote_lease_controller();
+    stub::recorded_swaps(&test_case.app, controller, lease)
+        .len()
+        .try_into()
+        .expect("swap count fits u32")
+}
+
+/// The `min_out` floor of the latest recorded swap leg for the lease.
+fn latest_min_out(test_case: &LeaseTestCase, lease: &Addr) -> Amount {
+    super::recorded_close_swap(test_case, lease).min_out().amount()
+}
+
+#[track_caller]
+fn assert_slippage_protection_activated(test_case: &LeaseTestCase, lease: &Addr) {
+    match super::state_query(test_case, lease.clone()) {
+        StateResponse::Opened {
+            status: Status::SlippageProtectionActivated,
+            ..
+        } => (),
+        other => panic!("expected a parked slippage-anomaly terminal, got {other:?}"),
+    }
+}
+
+fn is_slippage_protection_activated(test_case: &LeaseTestCase, lease: &Addr) -> bool {
+    matches!(
+        super::state_query(test_case, lease.clone()),
+        StateResponse::Opened {
+            status: Status::SlippageProtectionActivated,
+            ..
+        }
+    )
+}
+
+#[track_caller]
+fn assert_liquidation_swap_in_flight(test_case: &LeaseTestCase, lease: &Addr) {
+    use lease::api::query::opened::{OngoingTrx, PositionCloseTrx};
+    match super::state_query(test_case, lease.clone()) {
+        StateResponse::Opened {
+            status:
+                Status::InProgress(OngoingTrx::Liquidation {
+                    in_progress: PositionCloseTrx::Swap,
+                    ..
+                }),
+            ..
+        } => (),
+        other => panic!("expected the liquidation swap in flight, got {other:?}"),
+    }
+}
+
+#[track_caller]
+fn assert_customer_close_swap_in_flight(test_case: &LeaseTestCase, lease: &Addr) {
+    use lease::api::query::opened::{OngoingTrx, PositionCloseTrx};
+    match super::state_query(test_case, lease.clone()) {
+        StateResponse::Opened {
+            status:
+                Status::InProgress(OngoingTrx::Close {
+                    in_progress: PositionCloseTrx::Swap,
+                    ..
+                }),
+            ..
+        } => (),
+        other => panic!("expected the customer-close swap in flight, got {other:?}"),
+    }
+}
+
+#[track_caller]
+fn assert_repay_swap_in_flight(test_case: &LeaseTestCase, lease: &Addr) {
+    use lease::api::query::opened::{OngoingTrx, RepayTrx};
+    match super::state_query(test_case, lease.clone()) {
+        StateResponse::Opened {
+            status:
+                Status::InProgress(OngoingTrx::Repayment {
+                    in_progress: RepayTrx::Swap,
+                    ..
+                }),
+            ..
+        } => (),
+        other => panic!("expected the repay swap in flight, got {other:?}"),
+    }
+}
+
+#[track_caller]
+fn assert_opening_swap_in_flight(test_case: &LeaseTestCase, lease: &Addr) {
+    use lease::api::query::opening::OngoingTrx;
+    match super::state_query(test_case, lease.clone()) {
+        StateResponse::Opening {
+            in_progress: OngoingTrx::BuyAsset { .. },
+            ..
+        } => (),
+        other => panic!("expected the opening swap in flight, got {other:?}"),
+    }
+}
+
+fn expect_attribute(events: &[Event], event_type: &str, key: &str, value: &str) {
+    assert!(
+        events.iter().any(|event| {
+            event.ty == event_type
+                && event
+                    .attributes
+                    .iter()
+                    .any(|attr| attr.key == key && attr.value == value)
+        }),
+        "expected event `{event_type}` with `{key} = {value}`, got {events:?}",
+    );
+}

--- a/tests/src/lease/remote_lease_slippage_terminal.rs
+++ b/tests/src/lease/remote_lease_slippage_terminal.rs
@@ -29,6 +29,7 @@
 //! Phase-1 behaviour lands.
 
 use access_control::error::Error as AccessError;
+use dex::Error as DexError;
 use finance::coin::Amount;
 use lease::{
     api::{
@@ -45,7 +46,7 @@ use sdk::{
 };
 
 use crate::common::{
-    self, ADMIN, USER,
+    self, LEASE_ADMIN, USER,
     remote_lease_controller_stub::{self as stub, ResponseMode, op_tag},
     test_case::TestCase,
 };
@@ -147,9 +148,11 @@ fn heal_rejects_non_admin() {
     assert!(
         matches!(
             err.downcast_ref::<ContractError>(),
-            Some(ContractError::Unauthorized(AccessError::Unauthorized {}))
+            Some(ContractError::DexError(DexError::Unauthorized(
+                AccessError::Unauthorized {}
+            )))
         ),
-        "expected ContractError::Unauthorized, got {err:?}"
+        "expected DexError::Unauthorized, got {err:?}"
     );
     assert_slippage_protection_activated(&test_case, &lease);
 }
@@ -172,7 +175,12 @@ fn heal_accepts_admin_requotes_and_resets_counters() {
 
     let healed = test_case
         .app
-        .execute(testing::user(ADMIN), lease.clone(), &ExecuteMsg::Heal(), &[])
+        .execute(
+            testing::user(LEASE_ADMIN),
+            lease.clone(),
+            &ExecuteMsg::Heal(),
+            &[],
+        )
         .expect("the lease admin must heal a parked lease")
         .unwrap_response();
     expect_attribute(&healed.events, LIQUIDATION_SWAP_EVENT, "heal", "re-emit");
@@ -205,7 +213,12 @@ fn heal_requote_is_noop_for_accept_any_nonzero_floor() {
 
     let healed = test_case
         .app
-        .execute(testing::user(ADMIN), lease.clone(), &ExecuteMsg::Heal(), &[])
+        .execute(
+            testing::user(LEASE_ADMIN),
+            lease.clone(),
+            &ExecuteMsg::Heal(),
+            &[],
+        )
         .expect("the lease admin must heal a parked lease")
         .unwrap_response();
     expect_attribute(&healed.events, CLOSE_POSITION_EVENT, "heal", "re-emit");

--- a/tests/src/profit_tests.rs
+++ b/tests/src/profit_tests.rs
@@ -127,6 +127,30 @@ fn update_config_unauthorized() {
     );
 }
 
+/// Profit's `Heal` stays permissionless: threading `MessageInfo` through
+/// `Handler::heal` must not gate it. A non-privileged caller is not rejected
+/// by an authz check - an idle profit answers with an unsupported-operation
+/// error, never `Unauthorized`.
+#[test]
+fn heal_is_permissionless() {
+    let mut test_case = test_case::<Lpn>();
+
+    let err = test_case
+        .app
+        .execute(
+            testing::user(USER),
+            test_case.address_book.profit().clone(),
+            &ExecuteMsg::Heal(),
+            &[],
+        )
+        .unwrap_err()
+        .to_string();
+    assert!(
+        !err.contains("Unauthorized"),
+        "profit heal must not be authz-gated, got {err}"
+    );
+}
+
 #[test]
 fn on_alarm_from_unknown() {
     let user_addr: Addr = testing::user(USER);


### PR DESCRIPTION
Closes #655.

Restores the production slippage valve on the remote-lease (Solana) swap transport for the three opened legs — repay (BuyLpn), liquidation, and customer-close — which #648 left re-emitting a pinned floor indefinitely with no terminal and no queryable signal. The opening swap is out of scope and tracked separately in #658.

## Behaviour
- The dex `RemoteSwap` node gains persisted `#[serde(default)]` counters `timeouts`/`errors`.
- An under-floor rejection (`OperationErr`) routes immediately to a new `SlippageAnomaly` terminal — re-emitting would only reproduce the unmeetable floor.
- A swap timeout re-emits the in-flight leg verbatim up to a per-op budget (liquidation 5, customer-close 2, repay 3), then escalates to the terminal.
- The terminal surfaces the existing `opened::Status::SlippageProtectionActivated` in `{"state":{}}`, absorbs any late ack as an event without crediting, rejects repay/close/change_close_policy, and drops price alarms while emitting a `price-alarm-dropped` event for monitoring.
- An operator `heal`, gated by `AnomalyResolution` (the lease admin), re-runs the oracle quote to pin a fresh floor on the same leg, resets the counters, and re-emits. The re-quote is a meaningful re-price for liquidation and a no-op for the const-floor legs (repay/customer-close).

## Safety
- A healed re-emission can never coexist with a live original packet: terminal entry only follows a terminal IBC state (a proven timeout or an error ack — mutually exclusive and at-most-once), and the parked terminal absorbs late acks without crediting `total_out`. Covered by a dedicated double-heal test.
- `#[serde(default)]` with `deny_unknown_fields` lets in-flight leases upgrade cleanly (missing keys default to 0). This makes the lease code-id forward-only: once a counter is persisted, a downgrade to pre-#655 code would reject the unknown fields, so roll forward to fix rather than back. Live remote-lease population is zero ahead of ibc-solray; verify at deploy.
- The per-op budget is a required trait method delegated through the `Close`/`Repay` wrappers, so a missing delegation fails to compile rather than silently collapsing the budgets.

## Accepted risks
- A single under-floor error parks a liquidation immediately and drops its price alarms until an operator heals. The callback is authz-gated to the controller, so this requires a Byzantine controller; the mitigation is the `price-alarm-dropped` event plus operator alerting on a cross-lease aggregate park and a heal SLA (operational follow-up). Accepted.
- Repeated healing re-prices within `max_slippage`, so floor erosion is bounded per heal and requires a compromised lease admin. Accepted.

## Out of scope
- The `deliver_ack` underpaid-but-successful path is left re-emitting unbounded with no terminal — a rarer (Byzantine-counterparty) trigger of the same gap.
- The opening-swap unwind is tracked in #658.

## Tests
Acceptance tests in `tests/src/lease/remote_lease_slippage_terminal.rs` (error to terminal, per-budget parking for all three legs, the query surface, admin and non-admin heal, re-quote plus the const-floor no-op, full-park rejections, the dropped-alarm event, and opening-unchanged regression guards), dex unit tests (the serde brick guard, counter round-trip and migration, late-ack absorb, double-heal single-credit), and a profit permissionless-heal guard. dex 58 / lease 116 / profit 9; all 12 integration tests green.

## Review feedback
Automated review addressed:
- The public-path `unreachable!()`s on the never-parked opening path now return typed errors.
- New `state`-word identifiers renamed per the parasite-word rule (`anomaly_response`, `SLIPPAGE_PROTECTION_SENTINEL`, `_variant_set`, and the legacy-payload test/var names). The existing dex `State` vocabulary is untouched (separate follow-up).
- The new `SlippageAnomaly` node gained an `invariant_held` checked after construction.
- The parked-entry emitter became a method.

`SlippageEscalation` stays an enum: the escalation outcomes need both the `RemoteSwap` node's private fields and the composite `SEnum`, but `SwapTask` is `SEnum`-agnostic (one spec is reused across composites), so a type-level marker can't carry `SEnum`. This mirrors the existing `anomaly::Treatment` enum returned by `on_anomaly` — the policy already varies by spec type via the `slippage_escalation()` method; only its closed two-variant return is an enum, matched in one place.
