### PR TITLE
feat(remote-lease): correlate callbacks to emissions via nonce

### DIFF
--- a/protocol/contracts/lease/src/api/mod.rs
+++ b/protocol/contracts/lease/src/api/mod.rs
@@ -119,7 +119,7 @@ pub enum FinalizerExecuteMsg {
 #[cfg(all(feature = "internal.test.skel", test))]
 mod test {
     use remote_lease::{
-        callback::{RemoteErrorMessage, RemoteLeaseCallback},
+        callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
         response::{CloseLeaseResponse, WireOperationResponse},
     };
     use sdk::cosmwasm_std;
@@ -131,25 +131,10 @@ mod test {
 
     #[test]
     fn test_remote_lease_callback_timeout_representation() {
-        let msg = ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback::OperationTimeout);
-        let bin = cosmwasm_std::to_json_vec(&msg).expect("serialization failed");
-        assert_eq!(
-            msg,
-            cosmwasm_std::from_json(&bin).expect("deserialization failed"),
-        );
-
-        assert_eq!(
-            msg,
-            cosmwasm_std::from_json("{\"remote_lease_callback\":\"operation_timeout\"}")
-                .expect("deserialization failed"),
-        );
-    }
-
-    #[test]
-    fn test_remote_lease_callback_operation_ok_representation() {
-        let msg = ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback::OperationOk(
-            WireOperationResponse::CloseLease(CloseLeaseResponse {}),
-        ));
+        let msg = ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback {
+            nonce: 7,
+            outcome: RemoteOperationOutcome::OperationTimeout,
+        });
         let bin = cosmwasm_std::to_json_vec(&msg).expect("serialization failed");
         assert_eq!(
             msg,
@@ -159,7 +144,30 @@ mod test {
         assert_eq!(
             msg,
             cosmwasm_std::from_json(
-                "{\"remote_lease_callback\":{\"operation_ok\":{\"close_lease\":{}}}}"
+                "{\"remote_lease_callback\":{\"nonce\":7,\"outcome\":\"operation_timeout\"}}"
+            )
+            .expect("deserialization failed"),
+        );
+    }
+
+    #[test]
+    fn test_remote_lease_callback_operation_ok_representation() {
+        let msg = ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback {
+            nonce: 7,
+            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::CloseLease(
+                CloseLeaseResponse {},
+            )),
+        });
+        let bin = cosmwasm_std::to_json_vec(&msg).expect("serialization failed");
+        assert_eq!(
+            msg,
+            cosmwasm_std::from_json(&bin).expect("deserialization failed"),
+        );
+
+        assert_eq!(
+            msg,
+            cosmwasm_std::from_json(
+                "{\"remote_lease_callback\":{\"nonce\":7,\"outcome\":{\"operation_ok\":{\"close_lease\":{}}}}}"
             )
             .expect("deserialization failed"),
         );
@@ -167,9 +175,12 @@ mod test {
 
     #[test]
     fn test_remote_lease_callback_operation_err_representation() {
-        let msg = ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback::OperationErr(
-            RemoteErrorMessage::new("solana side rejected").expect("within length cap"),
-        ));
+        let msg = ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback {
+            nonce: 7,
+            outcome: RemoteOperationOutcome::OperationErr(
+                RemoteErrorMessage::new("solana side rejected").expect("within length cap"),
+            ),
+        });
         let bin = cosmwasm_std::to_json_vec(&msg).expect("serialization failed");
         assert_eq!(
             msg,
@@ -179,7 +190,7 @@ mod test {
         assert_eq!(
             msg,
             cosmwasm_std::from_json(
-                "{\"remote_lease_callback\":{\"operation_err\":\"solana side rejected\"}}"
+                "{\"remote_lease_callback\":{\"nonce\":7,\"outcome\":{\"operation_err\":\"solana side rejected\"}}}"
             )
             .expect("deserialization failed"),
         );

--- a/protocol/contracts/lease/src/contract/state/dex.rs
+++ b/protocol/contracts/lease/src/contract/state/dex.rs
@@ -8,7 +8,7 @@ use platform::{
     state_machine,
 };
 use remote_lease::{
-    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
     response::WireOperationResponse,
 };
 use sdk::cosmwasm_std::{self, Binary, Env, MessageInfo, QuerierWrapper, Reply};
@@ -177,15 +177,16 @@ where
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> ContractResult<Response> {
-        match callback {
-            RemoteLeaseCallback::OperationOk(response) => {
-                self.deliver_remote_ok(&response, querier, env)
+        let RemoteLeaseCallback { nonce, outcome } = callback;
+        match outcome {
+            RemoteOperationOutcome::OperationOk(response) => {
+                self.deliver_remote_ok(&response, nonce, querier, env)
             }
-            RemoteLeaseCallback::OperationErr(message) => {
-                self.deliver_remote_err(&message, querier, env)
+            RemoteOperationOutcome::OperationErr(message) => {
+                self.deliver_remote_err(&message, nonce, querier, env)
             }
-            RemoteLeaseCallback::OperationTimeout => {
-                self.handler.on_remote_timeout(querier, env).into()
+            RemoteOperationOutcome::OperationTimeout => {
+                self.handler.on_remote_timeout(nonce, querier, env).into()
             }
         }
     }
@@ -193,23 +194,30 @@ where
     fn deliver_remote_ok(
         self,
         response: &WireOperationResponse,
+        nonce: u64,
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> ContractResult<Response> {
         cosmwasm_std::to_json_binary(response)
             .map_err(Into::into)
-            .and_then(|data| self.handler.on_remote_response(data, querier, env).into())
+            .and_then(|data| {
+                self.handler
+                    .on_remote_response(data, nonce, querier, env)
+                    .into()
+            })
     }
 
     fn deliver_remote_err(
         self,
         message: &RemoteErrorMessage,
+        nonce: u64,
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> ContractResult<Response> {
         self.handler
             .on_remote_error(
                 ICAErrorResponse::from(message.as_str().to_owned()),
+                nonce,
                 querier,
                 env,
             )

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
@@ -247,13 +247,18 @@ where
         &self,
         coin_in: &CoinDTO<Self::InG>,
         min_out: &CoinDTO<Self::OutG>,
+        nonce: u64,
     ) -> dex::DexResult<Batch> {
         SwapParams::new(coin_in.into_super_group(), min_out.into_super_group())
             .map_err(DexError::remote_swap_client)
             .and_then(|params| {
                 ControllerLease::new(&self.lease.lease.remote_lease_controller)
                     .swap(params, SwapParams::TIMEOUT, |params, timeout| {
-                        ControllerExecuteMsg::Swap { params, timeout }
+                        ControllerExecuteMsg::Swap {
+                            params,
+                            timeout,
+                            nonce,
+                        }
                     })
                     .map_err(Into::into)
             })
@@ -318,6 +323,7 @@ enum ControllerExecuteMsg {
     Swap {
         params: SwapParams,
         timeout: Duration,
+        nonce: u64,
     },
 }
 

--- a/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
@@ -230,13 +230,18 @@ impl RemoteSwapClient for BuyLpn {
         &self,
         coin_in: &CoinDTO<Self::InG>,
         min_out: &CoinDTO<Self::OutG>,
+        nonce: u64,
     ) -> dex::DexResult<Batch> {
         SwapParams::new(*coin_in, min_out.into_super_group())
             .map_err(DexError::remote_swap_client)
             .and_then(|params| {
                 ControllerLease::new(&self.lease.lease.remote_lease_controller)
                     .swap(params, SwapParams::TIMEOUT, |params, timeout| {
-                        ControllerExecuteMsg::Swap { params, timeout }
+                        ControllerExecuteMsg::Swap {
+                            params,
+                            timeout,
+                            nonce,
+                        }
                     })
                     .map_err(Into::into)
             })
@@ -315,6 +320,7 @@ enum ControllerExecuteMsg {
     Swap {
         params: SwapParams,
         timeout: Duration,
+        nonce: u64,
     },
 }
 

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -262,13 +262,18 @@ impl RemoteSwapClient for BuyAsset {
         &self,
         coin_in: &CoinDTO<Self::InG>,
         min_out: &CoinDTO<Self::OutG>,
+        nonce: u64,
     ) -> dex::DexResult<Batch> {
         SwapParams::new(*coin_in, min_out.into_super_group())
             .map_err(DexError::remote_swap_client)
             .and_then(|params| {
                 ControllerLease::new(&self.remote_lease_controller)
                     .swap(params, SwapParams::TIMEOUT, |params, timeout| {
-                        ControllerExecuteMsg::Swap { params, timeout }
+                        ControllerExecuteMsg::Swap {
+                            params,
+                            timeout,
+                            nonce,
+                        }
                     })
                     .map_err(Into::into)
             })
@@ -343,6 +348,7 @@ enum ControllerExecuteMsg {
     Swap {
         params: SwapParams,
         timeout: Duration,
+        nonce: u64,
     },
 }
 
@@ -425,17 +431,20 @@ mod tests {
 
     #[test]
     fn swap_msg_shape_matches_the_controller_wire() {
+        const SWAP_NONCE: u64 = 7;
         let params = swap_params();
         let msg = super::ControllerExecuteMsg::Swap {
             params: params.clone(),
             timeout: SwapParams::TIMEOUT,
+            nonce: SWAP_NONCE,
         };
 
         let expected = format!(
-            r#"{{"swap":{{"params":{},"timeout":{}}}}}"#,
+            r#"{{"swap":{{"params":{},"timeout":{},"nonce":{}}}}}"#,
             cosmwasm_std::to_json_string(&params).expect("the params should serialize"),
             cosmwasm_std::to_json_string(&SwapParams::TIMEOUT)
                 .expect("the timeout should serialize"),
+            SWAP_NONCE,
         );
         assert_eq!(
             expected,

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -14,7 +14,7 @@ use platform::{
     state_machine::Response as StateMachineResponse,
 };
 use remote_lease::{
-    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
     msg::OpenLeaseParams,
     response::{OpenLeaseResponse, RemoteLeaseId, WireOperationResponse},
     stub::{ControllerInnerMessage, Factory},
@@ -218,12 +218,15 @@ impl Contract for OpenLease {
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> ContractResult<Response> {
+        // OpenLease is a single-shot operation with no duplicate-callback
+        // exposure to close, so its callback nonce is not yet correlated; the
+        // matching arrives when this flow converts to a remote leg.
         self.authz_callback(querier, &info)
-            .and_then(|()| match callback {
-                RemoteLeaseCallback::OperationOk(WireOperationResponse::OpenLease(
+            .and_then(|()| match callback.outcome {
+                RemoteOperationOutcome::OperationOk(WireOperationResponse::OpenLease(
                     OpenLeaseResponse { remote_lease_id },
                 )) => self.on_open_lease_ack(remote_lease_id, querier, &env),
-                RemoteLeaseCallback::OperationOk(_unexpected) => {
+                RemoteOperationOutcome::OperationOk(_unexpected) => {
                     // A success ack for a non-`OpenLease` operation can only
                     // come from a buggy or hostile counterparty. Returning
                     // `Err` here would revert the controller's
@@ -238,10 +241,10 @@ impl Contract for OpenLease {
                         RemoteErrorMessage::from_static(UNEXPECTED_OPERATION_REASON),
                     )
                 }
-                RemoteLeaseCallback::OperationErr(reason) => {
+                RemoteOperationOutcome::OperationErr(reason) => {
                     self.on_open_failed(querier, &env, reason)
                 }
-                RemoteLeaseCallback::OperationTimeout => self.on_open_failed(
+                RemoteOperationOutcome::OperationTimeout => self.on_open_failed(
                     querier,
                     &env,
                     RemoteErrorMessage::from_static(TIMEOUT_REASON),

--- a/protocol/contracts/lease/src/contract/state/paid/remote_close.rs
+++ b/protocol/contracts/lease/src/contract/state/paid/remote_close.rs
@@ -20,7 +20,7 @@ use platform::{
     state_machine::Response as StateMachineResponse,
 };
 use remote_lease::{
-    callback::RemoteLeaseCallback,
+    callback::{RemoteLeaseCallback, RemoteOperationOutcome},
     msg::CloseLeaseParams,
     response::{CloseLeaseResponse, WireOperationResponse},
     stub::{ControllerInnerMessage, Lease as ControllerLease},
@@ -200,22 +200,28 @@ impl Handler for ClosingRemoteLease {
         _querier: QuerierWrapper<'_>,
         env: Env,
     ) -> ContractResult<Response> {
-        self.authz_callback(&info).and_then(|()| match callback {
-            RemoteLeaseCallback::OperationOk(WireOperationResponse::CloseLease(
-                CloseLeaseResponse {},
-            )) => Ok(self.into_closed(&env)),
-            RemoteLeaseCallback::OperationOk(_unexpected) => {
-                Ok(self.absorb(ABSORB_UNEXPECTED_VARIANT))
-            }
-            RemoteLeaseCallback::OperationErr(_reason) => Ok(self.absorb(ABSORB_REMOTE_ERROR)),
-            RemoteLeaseCallback::OperationTimeout => {
-                let emitter = self
-                    .emitter()
-                    .emit(EVENT_KEY_ID, env.contract.address.clone())
-                    .emit(EVENT_KEY_TIMEOUT, EVENT_VALUE_RETRY);
-                self.reemit(emitter)
-            }
-        })
+        // CloseLease/TransferOut over this transport are not yet
+        // nonce-correlated (they convert in a later phase), so the callback
+        // nonce is not consulted here.
+        self.authz_callback(&info)
+            .and_then(|()| match callback.outcome {
+                RemoteOperationOutcome::OperationOk(WireOperationResponse::CloseLease(
+                    CloseLeaseResponse {},
+                )) => Ok(self.into_closed(&env)),
+                RemoteOperationOutcome::OperationOk(_unexpected) => {
+                    Ok(self.absorb(ABSORB_UNEXPECTED_VARIANT))
+                }
+                RemoteOperationOutcome::OperationErr(_reason) => {
+                    Ok(self.absorb(ABSORB_REMOTE_ERROR))
+                }
+                RemoteOperationOutcome::OperationTimeout => {
+                    let emitter = self
+                        .emitter()
+                        .emit(EVENT_KEY_ID, env.contract.address.clone())
+                        .emit(EVENT_KEY_TIMEOUT, EVENT_VALUE_RETRY);
+                    self.reemit(emitter)
+                }
+            })
     }
 }
 
@@ -239,7 +245,7 @@ mod tests {
         message::Response as MessageResponse,
     };
     use remote_lease::{
-        callback::{RemoteErrorMessage, RemoteLeaseCallback},
+        callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
         msg::CloseLeaseParams,
         response::{CloseLeaseResponse, TransferOutResponse, WireOperationResponse},
     };
@@ -304,7 +310,13 @@ mod tests {
     fn error_ack_absorbed_without_reemission() {
         let reason =
             RemoteErrorMessage::new("balance mismatch with solana state").expect("within the cap");
-        let response = deliver(RemoteLeaseCallback::OperationErr(reason), controller_info());
+        let response = deliver(
+            RemoteLeaseCallback {
+                nonce: 0,
+                outcome: RemoteOperationOutcome::OperationErr(reason),
+            },
+            controller_info(),
+        );
         assert_still_closing(&response);
         assert_eq!(absorb_response("remote-error"), response.response);
     }
@@ -312,9 +324,12 @@ mod tests {
     #[test]
     fn unexpected_ok_ack_absorbed_without_reemission() {
         let response = deliver(
-            RemoteLeaseCallback::OperationOk(WireOperationResponse::TransferOut(
-                TransferOutResponse {},
-            )),
+            RemoteLeaseCallback {
+                nonce: 0,
+                outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::TransferOut(
+                    TransferOutResponse {},
+                )),
+            },
             controller_info(),
         );
         assert_still_closing(&response);
@@ -326,7 +341,13 @@ mod tests {
 
     #[test]
     fn timeout_reemits_the_close() {
-        let response = deliver(RemoteLeaseCallback::OperationTimeout, controller_info());
+        let response = deliver(
+            RemoteLeaseCallback {
+                nonce: 0,
+                outcome: RemoteOperationOutcome::OperationTimeout,
+            },
+            controller_info(),
+        );
         assert_still_closing(&response);
         assert_eq!(
             MessageResponse::messages_with_event(
@@ -484,7 +505,12 @@ mod tests {
     }
 
     fn ok_close_ack() -> RemoteLeaseCallback {
-        RemoteLeaseCallback::OperationOk(WireOperationResponse::CloseLease(CloseLeaseResponse {}))
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::CloseLease(
+                CloseLeaseResponse {},
+            )),
+        }
     }
 
     fn controller_info() -> MessageInfo {

--- a/protocol/contracts/remote_lease/src/api.rs
+++ b/protocol/contracts/remote_lease/src/api.rs
@@ -49,9 +49,16 @@ pub enum ExecuteMsg {
         timeout: Duration,
     },
     /// Outbound `Swap` packet. See [`ExecuteMsg::OpenLease`] for `timeout` semantics.
+    ///
+    /// `nonce` is the lease's per-emission correlation identifier; it rides the
+    /// packet envelope and is returned in the callback so the lease can match
+    /// the acknowledgment to the exact in-flight leg. `#[serde(default)]` keeps
+    /// it optional at decode for callers that predate the field.
     Swap {
         params: SwapParams,
         timeout: Duration,
+        #[serde(default)]
+        nonce: u64,
     },
     /// Outbound `TransferOut` packet. See [`ExecuteMsg::OpenLease`] for `timeout` semantics.
     TransferOut {

--- a/protocol/contracts/remote_lease/src/contract.rs
+++ b/protocol/contracts/remote_lease/src/contract.rs
@@ -32,6 +32,14 @@ use crate::{
 };
 
 const CONTRACT_STORAGE_VERSION: VersionSegment = 0;
+
+/// Envelope nonce for operations that are not yet callback-correlated.
+///
+/// Only the `Swap` operation carries a per-emission nonce today (issue #636);
+/// the single-packet `OpenLease`/`CloseLease`/`TransferOut` flows have no
+/// duplicate-callback exposure to close, so they ride a zero nonce until they
+/// convert in the remaining ibc-solray#142 phases.
+const NO_NONCE: u64 = 0;
 const CURRENT_RELEASE: ProtocolPackageRelease = ProtocolPackageRelease::current(
     package_name!(),
     package_version!(),
@@ -124,6 +132,7 @@ pub fn execute(
             info.sender,
             Operation::OpenLease(params),
             timeout,
+            NO_NONCE,
         ),
         ExecuteMsg::CloseLease { params, timeout } => send_operation(
             deps,
@@ -131,16 +140,27 @@ pub fn execute(
             info.sender,
             Operation::CloseLease(params),
             timeout,
+            NO_NONCE,
         ),
-        ExecuteMsg::Swap { params, timeout } => {
-            send_operation(deps, &env, info.sender, Operation::Swap(params), timeout)
-        }
+        ExecuteMsg::Swap {
+            params,
+            timeout,
+            nonce,
+        } => send_operation(
+            deps,
+            &env,
+            info.sender,
+            Operation::Swap(params),
+            timeout,
+            nonce,
+        ),
         ExecuteMsg::TransferOut { params, timeout } => send_operation(
             deps,
             &env,
             info.sender,
             Operation::TransferOut(params),
             timeout,
+            NO_NONCE,
         ),
     }
     .map(response::response_only_messages)
@@ -221,6 +241,7 @@ fn send_operation(
     caller: Addr,
     operation: Operation,
     timeout: Duration,
+    nonce: u64,
 ) -> Result<PlatformResponse> {
     let DepsMut {
         storage, querier, ..
@@ -232,6 +253,7 @@ fn send_operation(
             lease,
             operation,
             timeout,
+            nonce,
         )
     })
 }
@@ -256,11 +278,13 @@ fn build_packet(
     lease: Addr,
     operation: Operation,
     timeout: Duration,
+    nonce: u64,
 ) -> Result<PlatformResponse> {
     let envelope = PacketEnvelope {
         lease: LeaseAddrOnWire::new(lease),
         operation,
         version: ProtocolVersion,
+        nonce,
     };
     cosmwasm_std::to_json_binary(&envelope)
         .map_err(Error::from)

--- a/protocol/contracts/remote_lease/src/contract/tests/execute_outbound.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/execute_outbound.rs
@@ -36,7 +36,7 @@ fn open_lease_emits_send_packet() {
         },
     )
     .unwrap();
-    assert_send_packet(&Operation::OpenLease(params), &res.messages);
+    assert_send_packet(&Operation::OpenLease(params), 0, &res.messages);
 }
 
 #[test]
@@ -56,11 +56,13 @@ fn close_lease_emits_send_packet() {
         },
     )
     .unwrap();
-    assert_send_packet(&Operation::CloseLease(params), &res.messages);
+    assert_send_packet(&Operation::CloseLease(params), 0, &res.messages);
 }
 
 #[test]
 fn swap_emits_send_packet() {
+    const SWAP_NONCE: u64 = 7;
+
     let mut deps = deps_with_lease();
     instantiate_default(deps.as_mut());
     store_open_channel(deps.as_mut());
@@ -73,10 +75,11 @@ fn swap_emits_send_packet() {
         ExecuteMsg::Swap {
             params: params.clone(),
             timeout: PACKET_TIMEOUT,
+            nonce: SWAP_NONCE,
         },
     )
     .unwrap();
-    assert_send_packet(&Operation::Swap(params), &res.messages);
+    assert_send_packet(&Operation::Swap(params), SWAP_NONCE, &res.messages);
 }
 
 #[test]
@@ -96,7 +99,7 @@ fn transfer_out_emits_send_packet() {
         },
     )
     .unwrap();
-    assert_send_packet(&Operation::TransferOut(params), &res.messages);
+    assert_send_packet(&Operation::TransferOut(params), 0, &res.messages);
 }
 
 #[test]
@@ -182,7 +185,7 @@ fn sample_transfer_out_params() -> TransferOutParams {
         .expect("sample uses a non-zero amount")
 }
 
-fn assert_send_packet(expected_operation: &Operation, messages: &[SubMsg]) {
+fn assert_send_packet(expected_operation: &Operation, expected_nonce: u64, messages: &[SubMsg]) {
     assert_eq!(1, messages.len(), "expected exactly one outbound message");
     match &messages[0].msg {
         CosmosMsg::Ibc(IbcMsg::SendPacket {
@@ -199,6 +202,7 @@ fn assert_send_packet(expected_operation: &Operation, messages: &[SubMsg]) {
             );
             assert_eq!(expected_operation, &envelope.operation);
             assert_eq!(ProtocolVersion, envelope.version);
+            assert_eq!(expected_nonce, envelope.nonce);
         }
         other => panic!("expected CosmosMsg::Ibc(IbcMsg::SendPacket {{..}}), got {other:?}"),
     }

--- a/protocol/contracts/remote_lease/src/contract/tests/scenarios.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/scenarios.rs
@@ -1,5 +1,5 @@
 use remote_lease::{
-    callback::RemoteLeaseCallback,
+    callback::{RemoteLeaseCallback, RemoteOperationOutcome},
     response::{OpenLeaseResponse, RemoteLeaseId, WireOperationResponse},
 };
 use sdk::{
@@ -51,7 +51,10 @@ fn scenario_open_channel_through_ack_dispatches_callback() {
 
     assert_callback_to(
         &sdk_testing::user(LEASE),
-        RemoteLeaseCallback::OperationOk(response),
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(response),
+        },
         &res.messages,
     );
 }

--- a/protocol/contracts/remote_lease/src/ibc.rs
+++ b/protocol/contracts/remote_lease/src/ibc.rs
@@ -1,5 +1,5 @@
 use remote_lease::{
-    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
     envelope::{NolusLeaseAddr, PacketEnvelope},
     response::WireOperationResponse,
 };
@@ -167,8 +167,8 @@ pub fn ibc_packet_ack(
         .and_then(|envelope| {
             cosmwasm_std::from_json::<StdAck>(&msg.acknowledgement.data)
                 .map_err(Error::from)
-                .and_then(ack_to_callback)
-                .and_then(|callback| dispatch_lease_callback(deps.api, envelope, callback))
+                .and_then(ack_to_outcome)
+                .and_then(|outcome| dispatch_lease_callback(deps.api, envelope, outcome))
         })
 }
 
@@ -181,7 +181,7 @@ pub fn ibc_packet_timeout(
     cosmwasm_std::from_json::<PacketEnvelope>(&msg.packet.data)
         .map_err(Error::from)
         .and_then(|envelope| {
-            dispatch_lease_callback(deps.api, envelope, RemoteLeaseCallback::OperationTimeout)
+            dispatch_lease_callback(deps.api, envelope, RemoteOperationOutcome::OperationTimeout)
         })
 }
 
@@ -189,13 +189,13 @@ pub fn ibc_packet_timeout(
 // validation belongs to the addressee lease, which absorbs content failures.
 // Erring here on a registry mismatch would make the relayer retry the ack
 // forever, turning counterparty content drift into a stuck packet.
-fn ack_to_callback(ack: StdAck) -> Result<RemoteLeaseCallback> {
+fn ack_to_outcome(ack: StdAck) -> Result<RemoteOperationOutcome> {
     match ack {
         StdAck::Success(data) => cosmwasm_std::from_json::<WireOperationResponse>(&data)
-            .map(RemoteLeaseCallback::OperationOk)
+            .map(RemoteOperationOutcome::OperationOk)
             .map_err(Error::from),
         StdAck::Error(message) => RemoteErrorMessage::new(message)
-            .map(RemoteLeaseCallback::OperationErr)
+            .map(RemoteOperationOutcome::OperationErr)
             .map_err(Error::from),
     }
 }
@@ -210,8 +210,12 @@ fn ack_to_callback(ack: StdAck) -> Result<RemoteLeaseCallback> {
 fn dispatch_lease_callback(
     api: &dyn Api,
     envelope: PacketEnvelope,
-    callback: RemoteLeaseCallback,
+    outcome: RemoteOperationOutcome,
 ) -> Result<IbcBasicResponse> {
+    let callback = RemoteLeaseCallback {
+        nonce: envelope.nonce,
+        outcome,
+    };
     envelope
         .lease
         .into_validated(api)

--- a/protocol/contracts/remote_lease/src/ibc/tests/packets.rs
+++ b/protocol/contracts/remote_lease/src/ibc/tests/packets.rs
@@ -1,5 +1,7 @@
 use remote_lease::{
-    callback::{OPERATION_ERR_MAX_BYTES, RemoteErrorMessage, RemoteLeaseCallback},
+    callback::{
+        OPERATION_ERR_MAX_BYTES, RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome,
+    },
     envelope::{LeaseAddrOnWire, PacketEnvelope},
     msg::{CloseLeaseParams, Operation},
     response::{
@@ -71,7 +73,10 @@ fn packet_ack_success_dispatches_operation_ok() {
 
     assert_dispatched_callback(
         &lease,
-        RemoteLeaseCallback::OperationOk(response),
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(response),
+        },
         &res.messages,
     );
 }
@@ -94,9 +99,12 @@ fn packet_ack_error_dispatches_operation_err() {
 
     assert_dispatched_callback(
         &lease,
-        RemoteLeaseCallback::OperationErr(
-            RemoteErrorMessage::new(ERROR_MESSAGE).expect("test fixture under the cap"),
-        ),
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(
+                RemoteErrorMessage::new(ERROR_MESSAGE).expect("test fixture under the cap"),
+            ),
+        },
         &res.messages,
     );
 }
@@ -114,7 +122,14 @@ fn packet_timeout_dispatches_operation_timeout() {
     )
     .unwrap();
 
-    assert_dispatched_callback(&lease, RemoteLeaseCallback::OperationTimeout, &res.messages);
+    assert_dispatched_callback(
+        &lease,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationTimeout,
+        },
+        &res.messages,
+    );
 }
 
 #[test]
@@ -187,7 +202,10 @@ fn packet_ack_out_of_registry_ticker_dispatches_ok() {
 
     assert_dispatched_callback(
         &lease,
-        RemoteLeaseCallback::OperationOk(response),
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(response),
+        },
         &res.messages,
     );
 }
@@ -228,10 +246,11 @@ fn dispatched_callback_wire_shape_pinned() {
     };
 
     // Pin the JSON the lease contract must accept. Any drift in the enum tag
-    // breaks the wire contract between this controller and the lease-side
-    // `ExecuteMsg::RemoteLeaseCallback` variant.
+    // or the `{ nonce, outcome }` envelope breaks the wire contract between
+    // this controller and the lease-side `ExecuteMsg::RemoteLeaseCallback`
+    // variant. The timeout fixture rides a zero nonce (`envelope_with_close_lease`).
     assert_eq!(
-        br#"{"remote_lease_callback":"operation_timeout"}"#,
+        br#"{"remote_lease_callback":{"nonce":0,"outcome":"operation_timeout"}}"#,
         msg.as_slice(),
     );
 }
@@ -243,6 +262,7 @@ fn packet_ack_malformed_lease_addr_in_envelope_errors() {
         lease: LeaseAddrOnWire::new("NOT_BECH32!"),
         operation: Operation::CloseLease(CloseLeaseParams {}),
         version: ProtocolVersion,
+        nonce: 0,
     };
     let envelope_bytes = cosmwasm_std::to_json_binary(&envelope).expect("envelope serialises");
     let response = WireOperationResponse::CloseLease(CloseLeaseResponse {});
@@ -265,6 +285,7 @@ fn packet_timeout_malformed_lease_addr_in_envelope_errors() {
         lease: LeaseAddrOnWire::new("NOT_BECH32!"),
         operation: Operation::CloseLease(CloseLeaseParams {}),
         version: ProtocolVersion,
+        nonce: 0,
     };
     let envelope_bytes = cosmwasm_std::to_json_binary(&envelope).expect("envelope serialises");
 
@@ -310,7 +331,10 @@ fn fixture_stdack_success_open_lease_decodes_to_callback() {
     .unwrap();
     assert_dispatched_callback(
         &lease,
-        RemoteLeaseCallback::OperationOk(response),
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(response),
+        },
         &res.messages,
     );
 }
@@ -338,9 +362,12 @@ fn fixture_stdack_error_decodes_to_callback() {
     .unwrap();
     assert_dispatched_callback(
         &lease,
-        RemoteLeaseCallback::OperationErr(
-            RemoteErrorMessage::new(FIXTURE_ERROR_MESSAGE).expect("under the cap"),
-        ),
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(
+                RemoteErrorMessage::new(FIXTURE_ERROR_MESSAGE).expect("under the cap"),
+            ),
+        },
         &res.messages,
     );
 }
@@ -363,11 +390,75 @@ fn packet_ack_oversized_error_message_errors() {
     assert!(matches!(err, Error::RemoteCallback(_)), "got {err:?}");
 }
 
+// AC (#636): on an acknowledgment the controller decodes the ORIGINAL outbound
+// packet's envelope and forwards its `nonce` into the dispatched
+// `RemoteLeaseCallback`, so the lease can correlate the ack to the exact packet
+// it emitted.
+#[test]
+fn packet_ack_forwards_envelope_nonce_into_callback() {
+    const NONCE: u64 = 7;
+
+    let mut deps = deps_with_config();
+    let lease = sdk_testing::user("lease-nonce-ack");
+    let envelope_bytes = encode_envelope(&envelope_with_nonce(&lease, NONCE));
+    let response = WireOperationResponse::CloseLease(CloseLeaseResponse {});
+    let ack_bytes = StdAck::Success(cosmwasm_std::to_json_binary(&response).unwrap()).to_binary();
+
+    let res = ibc_packet_ack(
+        deps.as_mut(),
+        testing::mock_env(),
+        ack_msg(envelope_bytes, ack_bytes),
+    )
+    .unwrap();
+
+    assert_dispatched_callback(
+        &lease,
+        RemoteLeaseCallback {
+            nonce: NONCE,
+            outcome: RemoteOperationOutcome::OperationOk(response),
+        },
+        &res.messages,
+    );
+}
+
+// AC (#636): on a timeout the controller likewise decodes the original
+// packet's envelope and forwards its `nonce` into the `OperationTimeout`
+// callback.
+#[test]
+fn packet_timeout_forwards_envelope_nonce_into_callback() {
+    const NONCE: u64 = 7;
+
+    let mut deps = deps_with_config();
+    let lease = sdk_testing::user("lease-nonce-timeout");
+    let envelope_bytes = encode_envelope(&envelope_with_nonce(&lease, NONCE));
+
+    let res = ibc_packet_timeout(
+        deps.as_mut(),
+        testing::mock_env(),
+        timeout_msg(envelope_bytes),
+    )
+    .unwrap();
+
+    assert_dispatched_callback(
+        &lease,
+        RemoteLeaseCallback {
+            nonce: NONCE,
+            outcome: RemoteOperationOutcome::OperationTimeout,
+        },
+        &res.messages,
+    );
+}
+
 fn envelope_with_close_lease(lease: &Addr) -> PacketEnvelope {
+    envelope_with_nonce(lease, 0)
+}
+
+fn envelope_with_nonce(lease: &Addr, nonce: u64) -> PacketEnvelope {
     PacketEnvelope {
         lease: LeaseAddrOnWire::new(lease.as_str()),
         operation: Operation::CloseLease(CloseLeaseParams {}),
         version: ProtocolVersion,
+        nonce,
     }
 }
 

--- a/protocol/packages/dex/src/impl_/drain.rs
+++ b/protocol/packages/dex/src/impl_/drain.rs
@@ -203,15 +203,16 @@ mod impl_handler {
         fn on_remote_response(
             self,
             data: Binary,
+            nonce: u64,
             querier: QuerierWrapper<'_>,
             env: Env,
         ) -> Result<Self> {
             match self {
                 State::TransferOut(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
                 State::FundsArrival(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
             }
         }
@@ -219,26 +220,32 @@ mod impl_handler {
         fn on_remote_error(
             self,
             response: ICAErrorResponse,
+            nonce: u64,
             querier: QuerierWrapper<'_>,
             env: Env,
         ) -> Result<Self> {
             match self {
                 State::TransferOut(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
                 State::FundsArrival(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
             }
         }
 
-        fn on_remote_timeout(self, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
+        fn on_remote_timeout(
+            self,
+            nonce: u64,
+            querier: QuerierWrapper<'_>,
+            env: Env,
+        ) -> Result<Self> {
             match self {
                 State::TransferOut(inner) => {
-                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
                 }
                 State::FundsArrival(inner) => {
-                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
                 }
             }
         }

--- a/protocol/packages/dex/src/impl_/out_remote.rs
+++ b/protocol/packages/dex/src/impl_/out_remote.rs
@@ -383,27 +383,28 @@ mod impl_handler {
         fn on_remote_response(
             self,
             data: Binary,
+            nonce: u64,
             querier: QuerierWrapper<'_>,
             env: Env,
         ) -> Result<Self> {
             match self {
                 State::OpenIca(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
                 State::OpenIcaRespDelivery(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
                 State::TransferOut(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
                 State::TransferOutRespDelivery(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
                 State::RemoteSwap(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
                 State::SlippageAnomaly(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
             }
         }
@@ -411,48 +412,56 @@ mod impl_handler {
         fn on_remote_error(
             self,
             response: ICAErrorResponse,
+            nonce: u64,
             querier: QuerierWrapper<'_>,
             env: Env,
         ) -> Result<Self> {
             match self {
                 State::OpenIca(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
                 State::OpenIcaRespDelivery(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
                 State::TransferOut(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
                 State::TransferOutRespDelivery(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
                 State::RemoteSwap(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
                 State::SlippageAnomaly(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
             }
         }
 
-        fn on_remote_timeout(self, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
+        fn on_remote_timeout(
+            self,
+            nonce: u64,
+            querier: QuerierWrapper<'_>,
+            env: Env,
+        ) -> Result<Self> {
             match self {
-                State::OpenIca(inner) => Handler::on_remote_timeout(inner, querier, env).map_into(),
+                State::OpenIca(inner) => {
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
+                }
                 State::OpenIcaRespDelivery(inner) => {
-                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
                 }
                 State::TransferOut(inner) => {
-                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
                 }
                 State::TransferOutRespDelivery(inner) => {
-                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
                 }
                 State::RemoteSwap(inner) => {
-                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
                 }
                 State::SlippageAnomaly(inner) => {
-                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
                 }
             }
         }

--- a/protocol/packages/dex/src/impl_/out_swap.rs
+++ b/protocol/packages/dex/src/impl_/out_swap.rs
@@ -303,21 +303,22 @@ mod impl_handler {
         fn on_remote_response(
             self,
             data: Binary,
+            nonce: u64,
             querier: QuerierWrapper<'_>,
             env: Env,
         ) -> Result<Self> {
             match self {
                 State::TransferOut(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
                 State::TransferOutRespDelivery(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
                 State::RemoteSwap(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
                 State::SlippageAnomaly(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
             }
         }
@@ -325,38 +326,44 @@ mod impl_handler {
         fn on_remote_error(
             self,
             response: ICAErrorResponse,
+            nonce: u64,
             querier: QuerierWrapper<'_>,
             env: Env,
         ) -> Result<Self> {
             match self {
                 State::TransferOut(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
                 State::TransferOutRespDelivery(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
                 State::RemoteSwap(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
                 State::SlippageAnomaly(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
             }
         }
 
-        fn on_remote_timeout(self, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
+        fn on_remote_timeout(
+            self,
+            nonce: u64,
+            querier: QuerierWrapper<'_>,
+            env: Env,
+        ) -> Result<Self> {
             match self {
                 State::TransferOut(inner) => {
-                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
                 }
                 State::TransferOutRespDelivery(inner) => {
-                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
                 }
                 State::RemoteSwap(inner) => {
-                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
                 }
                 State::SlippageAnomaly(inner) => {
-                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
                 }
             }
         }

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -1,10 +1,13 @@
 //! # Acknowledgment-to-leg correlation trust model
 //!
-//! `OperationResponse::Swap` carries no leg identifier, so acknowledgments
-//! correlate to legs positionally: each one is credited to the single
-//! in-flight leg the `acks_left` countdown tracks. The wire contract is
-//! frozen; a per-leg nonce is a cross-repo follow-up. The positional
-//! assumption rests on:
+//! Every emission rides a per-emission `nonce` on the packet envelope. The
+//! controller reads it back from the original outbound packet on ack/timeout
+//! and returns it in the callback, so an acknowledgment is credited to the
+//! exact emission that solicited it: a callback whose nonce differs from the
+//! in-flight one is absorbed (`nonce-mismatch`) without touching progress. The
+//! node still tracks the in-flight leg positionally through the `acks_left`
+//! countdown; the nonce disambiguates *which emission* of that leg a callback
+//! belongs to. Correctness rests on:
 //!
 //! - authorization - only the remote-lease controller passes
 //!   [`Handler::authz_remote_callback`], so callbacks cannot be forged;
@@ -12,21 +15,21 @@
 //!   exactly one IBC packet addressed back to this contract, and IBC core's
 //!   packet-commitment bookkeeping makes the packet's acknowledgment and
 //!   timeout paths mutually exclusive and at-most-once;
-//! - sequential emission - the next leg goes out only once the in-flight
-//!   one is acknowledged, so the regular flow keeps at most one operation
-//!   outstanding;
-//! - the pinned per-leg floor (`in_flight_min_out`) - a stray duplicate is
-//!   mis-credited only if it also clears the *next* leg's own pinned floor.
+//! - the strictly-monotonic `in_flight_nonce` - every emission, including each
+//!   re-emission and operator [`Handler::heal`], bumps it, so a packet
+//!   superseded by a later emission carries a smaller nonce and its late
+//!   callback is rejected. This closes the duplicate-acknowledgment window that
+//!   a `heal` issued while the original packet is still resolvable would
+//!   otherwise open: the original's late ack no longer matches the in-flight
+//!   emission and is absorbed instead of positionally mis-credited to a
+//!   consecutive leg sharing the input currency;
+//! - the pinned per-leg floor (`in_flight_min_out`) - a re-emission repeats the
+//!   exact promise of the original, so the counterparty enforces one and the
+//!   same floor however many times the leg goes out.
 //!
-//! Residual risk: the controller keeps no per-lease in-flight bookkeeping
-//! and the channel is unordered, so a [`Handler::heal`] issued while the
-//! original packet is still resolvable solicits a second operation whose
-//! callback is positionally credited as well. The transport records no
-//! emission time and sets no alarm, leaving nothing to gate a heal on;
-//! `heal` therefore stays permissionless but re-emits the leg verbatim -
-//! same coin-in, same pinned floor - and operators must invoke it only
-//! once the in-flight operation is known to be unresolvable (e.g., its
-//! packet expired with no relayed timeout).
+//! `heal` therefore stays permissionless and re-emits the leg verbatim - same
+//! coin-in, same pinned floor, fresh nonce - leaving idempotency to the nonce
+//! match rather than to operator timing.
 
 use std::{
     fmt::{Display, Formatter, Result as FmtResult},
@@ -73,6 +76,10 @@ const ABSORB_UNDECODABLE: &str = "undecodable-response";
 const ABSORB_UNEXPECTED_VARIANT: &str = "unexpected-response-variant";
 const ABSORB_CURRENCY_MISMATCH: &str = "out-currency-mismatch";
 const ABSORB_OUTPUT_OVERFLOW: &str = "output-overflow";
+const ABSORB_NONCE_MISMATCH: &str = "nonce-mismatch";
+/// Predecessor nonce for the very first emission of a node: nothing has been
+/// emitted yet, so the first leg opens at `NO_PRIOR_NONCE + 1`.
+const NO_PRIOR_NONCE: u64 = 0;
 const ANOMALY_UNDER_MIN_OUT: &str = "under-min-out";
 
 /// Transport of swap legs to a remote, non-ICA counterparty
@@ -88,11 +95,15 @@ where
     /// Schedule a swap of `coin_in` with the remote counterparty
     ///
     /// The transport guarantees a single response, error, or timeout
-    /// per scheduled swap.
+    /// per scheduled swap. `nonce` is the per-emission correlation identifier
+    /// the node assigns; it must ride the packet envelope so the controller can
+    /// return it in the callback and the node can match the acknowledgment to
+    /// this emission.
     fn schedule_swap(
         &self,
         coin_in: &CoinDTO<Self::InG>,
         min_out: &CoinDTO<Self::OutG>,
+        nonce: u64,
     ) -> Result<Batch>;
 
     /// Decode a swap response payload into the swapped-out coin
@@ -131,6 +142,12 @@ where
     timeouts: CoinsNb,
     #[serde(default)]
     errors: CoinsNb,
+    /// Strictly-monotonic per-emission correlation nonce; bumped on every
+    /// emission and re-emission, matched against the callback. `#[serde(default)]`
+    /// lets a node persisted before #636 load with a zero nonce, matching the
+    /// zero an old, nonce-less in-flight packet decodes to.
+    #[serde(default)]
+    in_flight_nonce: u64,
     #[serde(skip)]
     _state_enum: PhantomData<SEnum>,
 }
@@ -236,9 +253,15 @@ where
                 querier,
                 _finisher: PhantomData::<Self>,
             }),
-            Some(acks_left) => Self::open_leg(self.spec, acks_left, total_out, querier)
-                .and_then(Self::schedule_and_continue)
-                .into(),
+            Some(acks_left) => Self::open_leg(
+                self.spec,
+                acks_left,
+                total_out,
+                querier,
+                self.in_flight_nonce,
+            )
+            .and_then(Self::schedule_and_continue)
+            .into(),
         }
     }
 
@@ -259,19 +282,22 @@ where
     }
 
     fn reemit_underpaid(self) -> ContinueResult<Self> {
-        self.schedule().and_then(|batch| {
+        let node = self.with_bumped_nonce();
+        node.schedule().and_then(|batch| {
             response::res_continue::<_, _, Self>(
-                MessageResponse::messages_with_event(batch, self.emit_anomaly()),
-                self,
+                MessageResponse::messages_with_event(batch, node.emit_anomaly()),
+                node,
             )
         })
     }
 
     /// Re-emit the in-flight leg verbatim after a transient failure, keeping
-    /// the pinned floor and the accumulated progress intact.
+    /// the pinned floor and the accumulated progress intact. The fresh nonce
+    /// supersedes the timed-out packet so a late callback for it is absorbed.
     fn reemit_in_flight(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
-        let leg_label = self.spec.label();
-        timeout::on_timeout_retry(self, leg_label, querier, env).into()
+        let node = self.with_bumped_nonce();
+        let leg_label = node.spec.label();
+        timeout::on_timeout_retry(node, leg_label, querier, env).into()
     }
 
     /// Re-emit the in-flight leg after a heal, signalling the recovery with
@@ -313,8 +339,10 @@ where
     /// the counterparty enforces one and the same floor however many
     /// times the leg goes out.
     fn schedule(&self) -> Result<Batch> {
-        self.in_flight_leg()
-            .and_then(|coin_in| self.spec.schedule_swap(&coin_in, &self.in_flight_min_out))
+        self.in_flight_leg().and_then(|coin_in| {
+            self.spec
+                .schedule_swap(&coin_in, &self.in_flight_min_out, self.in_flight_nonce)
+        })
     }
 }
 
@@ -328,15 +356,29 @@ where
     /// what the leg's emission and every re-emission promise, and what its
     /// acknowledgment is validated against. Re-opening the SAME leg, as a
     /// heal does, re-quotes the floor and resets the retry counters to zero.
+    /// `prev_nonce` is the nonce of the emission this open supersedes; the new
+    /// leg takes `prev_nonce + 1`, keeping the per-node nonce strictly
+    /// monotonic across legs and across a heal-from-terminal re-open.
     pub(super) fn open_leg(
         spec: SwapTask,
         acks_left: CoinsNb,
         total_out: CoinDTO<SwapTask::OutG>,
         querier: QuerierWrapper<'_>,
+        prev_nonce: u64,
     ) -> Result<Self> {
         in_flight_leg(&spec, total_out.currency(), acks_left)
             .and_then(|coin_in| leg_min_out(&spec, coin_in, total_out.currency(), querier))
-            .map(|min_out| Self::internal_new(spec, acks_left, total_out, min_out, 0, 0))
+            .map(|min_out| {
+                Self::internal_new(
+                    spec,
+                    acks_left,
+                    total_out,
+                    min_out,
+                    0,
+                    0,
+                    prev_nonce.saturating_add(1),
+                )
+            })
     }
 
     fn with_incremented_errors(self) -> Self {
@@ -353,6 +395,15 @@ where
         }
     }
 
+    /// Advance the in-flight nonce ahead of a same-leg re-emission, so the
+    /// superseded packet's late callback no longer matches and is absorbed.
+    fn with_bumped_nonce(self) -> Self {
+        Self {
+            in_flight_nonce: self.in_flight_nonce.saturating_add(1),
+            ..self
+        }
+    }
+
     fn internal_new(
         spec: SwapTask,
         acks_left: CoinsNb,
@@ -360,6 +411,7 @@ where
         in_flight_min_out: CoinDTO<SwapTask::OutG>,
         timeouts: CoinsNb,
         errors: CoinsNb,
+        in_flight_nonce: u64,
     ) -> Self {
         let ret = Self {
             spec,
@@ -368,6 +420,7 @@ where
             in_flight_min_out,
             timeouts,
             errors,
+            in_flight_nonce,
             _state_enum: PhantomData,
         };
         debug_assert!(ret.invariant_held());
@@ -388,6 +441,11 @@ where
         debug_assert!(self.invariant_held());
 
         in_flight_leg(&self.spec, self.total_out.currency(), self.acks_left)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn in_flight_nonce(&self) -> u64 {
+        self.in_flight_nonce
     }
 }
 
@@ -436,6 +494,7 @@ where
             self.acks_left,
             self.total_out,
             self.in_flight_min_out,
+            self.in_flight_nonce,
         );
         let emitter = terminal.emit_parked();
         response::res_continue::<_, _, Self>(
@@ -470,9 +529,13 @@ where
     fn on_remote_response(
         self,
         data: Binary,
+        nonce: u64,
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> HandlerResult<Self> {
+        if nonce != self.in_flight_nonce {
+            return self.absorb(ABSORB_NONCE_MISMATCH).into();
+        }
         match self.spec.decode_response(data.as_slice()) {
             Ok(coin_out) => self.deliver_ack(coin_out, querier, env),
             Err(Error::UnexpectedResponseVariant(_details)) => {
@@ -494,16 +557,28 @@ where
     fn on_remote_error(
         self,
         _response: ICAErrorResponse,
+        nonce: u64,
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> HandlerResult<Self> {
+        if nonce != self.in_flight_nonce {
+            return self.absorb(ABSORB_NONCE_MISMATCH).into();
+        }
         self.with_incremented_errors().escalate(querier, env)
     }
 
     /// A timeout re-emits the in-flight leg up to the spec's per-op retry
     /// budget and escalates past it - the opened legs park while the opening
     /// swap keeps re-emitting unbounded.
-    fn on_remote_timeout(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
+    fn on_remote_timeout(
+        self,
+        nonce: u64,
+        querier: QuerierWrapper<'_>,
+        env: Env,
+    ) -> HandlerResult<Self> {
+        if nonce != self.in_flight_nonce {
+            return self.absorb(ABSORB_NONCE_MISMATCH).into();
+        }
         let bumped = self.with_incremented_timeouts();
         if bumped.timeouts <= bumped.spec.timeout_retry_budget() {
             bumped.reemit_in_flight(querier, env)
@@ -513,22 +588,24 @@ where
     }
 
     /// The only operator recovery on this transport - there is neither a
-    /// sudo timeout nor a time alarm - hence re-emitting the in-flight leg
-    /// must stay idempotent: the re-emission repeats the pinned
-    /// `in_flight_min_out`, the exact promise of the original emission.
-    /// See the module doc for the duplicate-acknowledgment risk a heal
-    /// issued while the original operation is still resolvable creates.
+    /// sudo timeout nor a time alarm. The re-emission repeats the pinned
+    /// `in_flight_min_out`, the exact promise of the original emission, and
+    /// carries a fresh nonce (via [`RemoteSwap::with_bumped_nonce`]) so the
+    /// original packet's late callback is absorbed as `nonce-mismatch` rather
+    /// than mis-credited - the heal is idempotent regardless of operator
+    /// timing (see the module doc).
     fn heal(
         self,
         _querier: QuerierWrapper<'_>,
         _env: Env,
         _info: &MessageInfo,
     ) -> HandlerResult<Self> {
-        self.schedule()
+        let node = self.with_bumped_nonce();
+        node.schedule()
             .and_then(|batch| {
                 response::res_continue::<_, _, Self>(
-                    MessageResponse::messages_with_event(batch, self.emit_heal()),
-                    self,
+                    MessageResponse::messages_with_event(batch, node.emit_heal()),
+                    node,
                 )
             })
             .into()
@@ -586,10 +663,12 @@ where
 {
     type Out = RemoteSwap<SwapTaskNew, SEnumNew>;
 
-    /// The in-flight progress - `acks_left`, `total_out`, and the pinned
-    /// `in_flight_min_out` - is carried over instead of rebuilding from
-    /// the spec: a rebuild would re-issue the already-acknowledged legs
-    /// and re-price the promise made for the in-flight one.
+    /// The in-flight progress - `acks_left`, `total_out`, the pinned
+    /// `in_flight_min_out`, and the `in_flight_nonce` - is carried over instead
+    /// of rebuilding from the spec: a rebuild would re-issue the
+    /// already-acknowledged legs, re-price the promise made for the in-flight
+    /// one, and reset the nonce so the pre-migration packet's callback would
+    /// no longer match.
     fn migrate_spec<MigrateFn>(self, migrate_fn: MigrateFn) -> Self::Out
     where
         MigrateFn: FnOnce(SwapTask) -> SwapTaskNew,
@@ -601,6 +680,7 @@ where
             self.in_flight_min_out,
             self.timeouts,
             self.errors,
+            self.in_flight_nonce,
         )
     }
 }
@@ -644,6 +724,7 @@ where
                         acks_left,
                         out_total.into(),
                         self.querier,
+                        NO_PRIOR_NONCE,
                     )
                 })
                 .and_then(RemoteSwap::schedule_and_continue)
@@ -1010,10 +1091,17 @@ pub(super) mod mock {
     }
 
     impl RemoteSwapClient for MockSpec {
+        // The mock ignores the nonce in the emitted batch — the production
+        // controller puts it on the packet envelope, but the mock's
+        // `SwapRequest` payload keeps the pre-#636 coin_in/min_out shape so the
+        // existing leg/timeout response assertions stay byte-identical. The
+        // nonce is exercised through the node's callback-matching, not the
+        // emitted batch.
         fn schedule_swap(
             &self,
             coin_in: &CoinDTO<SuperGroup>,
             min_out: &CoinDTO<SuperGroup>,
+            _nonce: u64,
         ) -> Result<Batch> {
             swap_request(coin_in, min_out)
         }
@@ -1152,8 +1240,10 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
 
         let (_response, node) = continued(Node::start(spec3(), &testing::mock_env(), querier));
+        let nonce = node.in_flight_nonce;
         let (response, node) = continued(node.on_remote_response(
             payload(&coin_out(30)),
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -1179,8 +1269,10 @@ mod tests {
         let (_response, mut node) = continued(Node::start(spec, &testing::mock_env(), querier));
         node.spec.set_floor(RAISED_FLOOR);
 
+        let nonce = node.in_flight_nonce;
         let (response, node) = continued(node.on_remote_response(
             payload(&coin_out(PINNED_FLOOR)),
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -1207,9 +1299,15 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
 
         let node = after_first_ack(querier);
+        let nonce = node.in_flight_nonce;
         assert_eq!(
             coin_out(120),
-            finished(node.on_remote_response(payload(&coin_out(40)), querier, testing::mock_env()))
+            finished(node.on_remote_response(
+                payload(&coin_out(40)),
+                nonce,
+                querier,
+                testing::mock_env()
+            ))
         );
     }
 
@@ -1219,8 +1317,9 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
         let env = testing::mock_env();
 
-        let (response, node) =
-            continued(after_first_ack(querier).on_remote_timeout(querier, env.clone()));
+        let node = after_first_ack(querier);
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_timeout(nonce, querier, env.clone()));
         assert_eq!(timeout_response(&coin_in(70), &env), response);
         assert_node(1, &coin_out(80), &min_out(), &node);
         assert_eq!(1, node.timeouts);
@@ -1240,8 +1339,10 @@ mod tests {
         let (_response, mut node) = continued(Node::start(spec, &testing::mock_env(), querier));
         node.spec.set_floor(RAISED_FLOOR);
 
+        let nonce = node.in_flight_nonce;
         let (response, node) = continued(node.on_remote_response(
             payload(&coin_out(PINNED_FLOOR - 1)),
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -1264,8 +1365,11 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
         let env = testing::mock_env();
 
-        let (response, terminal) = parked(after_first_ack(querier).on_remote_error(
+        let node = after_first_ack(querier);
+        let nonce = node.in_flight_nonce;
+        let (response, terminal) = parked(node.on_remote_error(
             ICAErrorResponse::from(String::from("swap failed")),
+            nonce,
             querier,
             env,
         ));
@@ -1279,8 +1383,10 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
 
         let (_response, node) = continued(Node::start(spec3(), &testing::mock_env(), querier));
+        let nonce = node.in_flight_nonce;
         let (response, node) = continued(node.on_remote_response(
             Binary::from(b"garbage".as_slice()),
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -1294,8 +1400,10 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
 
         let (_response, node) = continued(Node::start(spec3(), &testing::mock_env(), querier));
+        let nonce = node.in_flight_nonce;
         let (response, node) = continued(node.on_remote_response(
             Binary::from(mock::WRONG_VARIANT_PAYLOAD),
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -1309,8 +1417,13 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
 
         let (_response, node) = continued(Node::start(spec3(), &testing::mock_env(), querier));
-        let (response, node) =
-            continued(node.on_remote_response(payload(&coin_in(30)), querier, testing::mock_env()));
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_response(
+            payload(&coin_in(30)),
+            nonce,
+            querier,
+            testing::mock_env(),
+        ));
         assert_eq!(absorb_response("out-currency-mismatch"), response);
         assert_node(2, &coin_out(50), &min_out(), &node);
     }
@@ -1321,8 +1434,10 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
 
         let (_response, node) = continued(Node::start(spec3(), &testing::mock_env(), querier));
+        let nonce = node.in_flight_nonce;
         let (response, node) = continued(node.on_remote_response(
             payload(&coin_out(Amount::MAX)),
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -1373,15 +1488,19 @@ mod tests {
         let mut spec = spec3();
         spec.set_reemit();
         let (_response, node) = continued(Node::start(spec, &testing::mock_env(), querier));
+        let nonce = node.in_flight_nonce;
         let (_response, mut node) = continued(node.on_remote_response(
             payload(&coin_out(30)),
+            nonce,
             querier,
             testing::mock_env(),
         ));
 
         let rounds = u16::from(mock_budget()) + 3;
         for _ in 0..rounds {
-            let (_response, next) = continued(node.on_remote_timeout(querier, testing::mock_env()));
+            let nonce = node.in_flight_nonce;
+            let (_response, next) =
+                continued(node.on_remote_timeout(nonce, querier, testing::mock_env()));
             node = next;
         }
         assert_node(1, &coin_out(80), &min_out(), &node);
@@ -1395,8 +1514,10 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
 
         let terminal = parked_terminal(querier);
+        let nonce = terminal.in_flight_nonce();
         let (response, terminal) = terminal_continued(terminal.on_remote_response(
             payload(&coin_out(40)),
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -1412,15 +1533,18 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
 
         let terminal = parked_terminal(querier);
+        let nonce = terminal.in_flight_nonce();
         let (response, terminal) = terminal_continued(terminal.on_remote_error(
             ICAErrorResponse::from(String::from("late error")),
+            nonce,
             querier,
             testing::mock_env(),
         ));
         assert_eq!(parked_absorb_response("parked-error"), response);
 
+        let nonce = terminal.in_flight_nonce();
         let (response, terminal) =
-            terminal_continued(terminal.on_remote_timeout(querier, testing::mock_env()));
+            terminal_continued(terminal.on_remote_timeout(nonce, querier, testing::mock_env()));
         assert_eq!(parked_absorb_response("parked-timeout"), response);
         assert_terminal(1, &coin_out(80), &min_out(), &terminal);
     }
@@ -1435,8 +1559,9 @@ mod tests {
         let terminal = parked_terminal(querier);
         let before = sdk::cosmwasm_std::to_json_vec(&terminal).expect("a serializable terminal");
 
+        let nonce = terminal.in_flight_nonce();
         let (_response, terminal) =
-            terminal_continued(terminal.on_remote_timeout(querier, testing::mock_env()));
+            terminal_continued(terminal.on_remote_timeout(nonce, querier, testing::mock_env()));
         let after = sdk::cosmwasm_std::to_json_vec(&terminal).expect("a serializable terminal");
         assert_eq!(before, after);
     }
@@ -1479,8 +1604,10 @@ mod tests {
 
         // the original packet lands while parked and is absorbed - no credit
         let terminal = parked_terminal(querier);
+        let nonce = terminal.in_flight_nonce();
         let (_response, terminal) = terminal_continued(terminal.on_remote_response(
             payload(&coin_out(40)),
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -1493,9 +1620,15 @@ mod tests {
 
         // exactly one acknowledgment of the re-emitted leg finishes the
         // workflow - the absorbed first packet did not also credit
+        let nonce = node.in_flight_nonce;
         assert_eq!(
             coin_out(120),
-            finished(node.on_remote_response(payload(&coin_out(40)), querier, testing::mock_env()))
+            finished(node.on_remote_response(
+                payload(&coin_out(40)),
+                nonce,
+                querier,
+                testing::mock_env()
+            ))
         );
     }
 
@@ -1638,6 +1771,211 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // #636 — per-emission nonce: callbacks of the CURRENT in-flight packet
+    // (nonce == in_flight_nonce) are handled normally; a superseded packet
+    // (smaller nonce) is absorbed with `nonce-mismatch`, leaving state intact.
+    // -----------------------------------------------------------------------
+
+    /// AC (#636): an ack carrying the node's current `in_flight_nonce` is the
+    /// acknowledgment of the in-flight packet — it is accepted and advances the
+    /// sequence exactly as the nonce-less ack did before the field existed.
+    #[test]
+    fn ack_with_matching_nonce_accepted() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let (_response, node) = continued(Node::start(spec3(), &testing::mock_env(), querier));
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_response(
+            payload(&coin_out(30)),
+            nonce,
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(
+            leg_response(&coin_in(70), &min_out(), &coin_out(80)),
+            response
+        );
+        assert_node(1, &coin_out(80), &min_out(), &node);
+    }
+
+    /// AC (#636): an ack carrying a smaller-than-current nonce is the
+    /// acknowledgment of a superseded packet — it is absorbed with
+    /// `nonce-mismatch` and leaves the node byte-identical (no advance, no
+    /// credit).
+    #[test]
+    fn ack_with_stale_nonce_absorbed() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        // advance once so the in-flight nonce is strictly greater than the
+        // first leg's nonce, giving a genuine stale value to replay
+        let node = after_first_ack(querier);
+        let stale = node.in_flight_nonce - 1;
+        let before = sdk::cosmwasm_std::to_json_vec(&node).expect("a serializable node");
+
+        let (response, node) = continued(node.on_remote_response(
+            payload(&coin_out(40)),
+            stale,
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(absorb_response("nonce-mismatch"), response);
+        assert_node(1, &coin_out(80), &min_out(), &node);
+        let after = sdk::cosmwasm_std::to_json_vec(&node).expect("a serializable node");
+        assert_eq!(before, after);
+    }
+
+    /// AC (#636): a timeout of the current packet is handled (the in-flight leg
+    /// re-emits, the timeout counter advances), and the re-emission carries a
+    /// strictly greater nonce; the now-superseded original nonce is absorbed.
+    #[test]
+    fn timeout_with_matching_nonce_retries_then_bumps() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+        let env = testing::mock_env();
+
+        let node = after_first_ack(querier);
+        let original_nonce = node.in_flight_nonce;
+
+        let (_response, node) =
+            continued(node.on_remote_timeout(original_nonce, querier, env.clone()));
+        assert_eq!(1, node.timeouts);
+        assert!(
+            original_nonce < node.in_flight_nonce,
+            "the re-emission must carry a strictly greater nonce"
+        );
+
+        // the original packet's late ack now carries a stale nonce → absorbed
+        let (response, node) = continued(node.on_remote_response(
+            payload(&coin_out(40)),
+            original_nonce,
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(absorb_response("nonce-mismatch"), response);
+        assert_node(1, &coin_out(80), &min_out(), &node);
+    }
+
+    /// AC (#636): a superseded error callback (smaller nonce) is absorbed with
+    /// `nonce-mismatch` and never escalates — the live leg is untouched.
+    #[test]
+    fn error_with_stale_nonce_absorbed() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let node = after_first_ack(querier);
+        let stale = node.in_flight_nonce - 1;
+
+        let (response, node) = continued(node.on_remote_error(
+            ICAErrorResponse::from(String::from("superseded error")),
+            stale,
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(absorb_response("nonce-mismatch"), response);
+        assert_node(1, &coin_out(80), &min_out(), &node);
+    }
+
+    /// AC (#636) — core race: a heal re-emits with a strictly greater nonce, so
+    /// the pre-heal original packet's late ack (old nonce) is absorbed while the
+    /// healed re-emission's ack (new nonce) is accepted. No double-credit.
+    #[test]
+    fn heal_bumps_nonce() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let node = after_first_ack(querier);
+        let original_nonce = node.in_flight_nonce;
+
+        let (_response, node) = continued(node.heal(querier, testing::mock_env(), &healer()));
+        let healed_nonce = node.in_flight_nonce;
+        assert!(
+            original_nonce < healed_nonce,
+            "heal must re-emit with a strictly greater nonce"
+        );
+
+        // the original packet's ack (old nonce) is absorbed - no credit
+        let (response, node) = continued(node.on_remote_response(
+            payload(&coin_out(40)),
+            original_nonce,
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(absorb_response("nonce-mismatch"), response);
+        assert_node(1, &coin_out(80), &min_out(), &node);
+
+        // the healed re-emission's ack (new nonce) is accepted and finishes
+        assert_eq!(
+            coin_out(120),
+            finished(node.on_remote_response(
+                payload(&coin_out(40)),
+                healed_nonce,
+                querier,
+                testing::mock_env(),
+            ))
+        );
+    }
+
+    /// AC (#636): a heal from the parked SlippageAnomaly terminal bumps the
+    /// nonce above the value persisted at park time — it is never reset to 0,
+    /// so a late ack of the original parked packet is still recognised as stale.
+    #[test]
+    fn heal_from_parked_terminal_bumps_nonce() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let terminal = parked_terminal(querier);
+        let parked_nonce = terminal.in_flight_nonce();
+
+        let (_response, node) =
+            terminal_healed(terminal.heal(querier, testing::mock_env(), &healer()));
+        assert!(
+            parked_nonce < node.in_flight_nonce,
+            "heal from the terminal must bump above the persisted nonce, not reset"
+        );
+
+        // the original parked packet's ack carries the now-stale nonce → absorbed
+        let (response, node) = continued(node.on_remote_response(
+            payload(&coin_out(40)),
+            parked_nonce,
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(absorb_response("nonce-mismatch"), response);
+        assert_node(1, &coin_out(80), &min_out(), &node);
+    }
+
+    /// AC (#636): a migration carries the in-flight nonce over instead of
+    /// resetting it, so a packet emitted by the pre-migration code-id is still
+    /// matched correctly after the upgrade.
+    #[cfg(feature = "migration")]
+    #[test]
+    fn migrate_preserves_nonce() {
+        use crate::impl_::migration::MigrateSpec;
+
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let node = after_first_ack(querier);
+        let nonce = node.in_flight_nonce;
+        let migrated: Node = node.migrate_spec(|spec| spec);
+        assert_eq!(nonce, migrated.in_flight_nonce);
+    }
+
+    /// AC (#636): a lease persisted before #636 carries no `in_flight_nonce`
+    /// key; `#[serde(default)]` must load it as 0 so the new code-id never
+    /// bricks an in-flight lease.
+    #[test]
+    fn legacy_remote_swap_without_nonce_deserializes_to_zero() {
+        let legacy_remote_swap = br#"{"spec":{"coins":[{"amount":"100","ticker":"ticker#2"},{"amount":"50","ticker":"ticker#1"},{"amount":"70","ticker":"ticker#2"}],"floor":1,"budget":3},"acks_left":1,"total_out":{"amount":"80","ticker":"ticker#1"},"in_flight_min_out":{"amount":"1","ticker":"ticker#1"},"timeouts":0,"errors":0}"#;
+
+        let restored: Node = sdk::cosmwasm_std::from_json(legacy_remote_swap.as_slice())
+            .expect("the pre-#636 state should deserialize");
+        assert_eq!(0, restored.in_flight_nonce);
+    }
+
     fn assert_node(
         expected_acks: CoinsNb,
         expected_total: &CoinDTO<OutG>,
@@ -1735,8 +2073,10 @@ mod tests {
 
     fn after_first_ack(querier: QuerierWrapper<'_>) -> Node {
         let (_response, node) = continued(Node::start(spec3(), &testing::mock_env(), querier));
+        let nonce = node.in_flight_nonce;
         let (_response, node) = continued(node.on_remote_response(
             payload(&coin_out(30)),
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -1749,9 +2089,11 @@ mod tests {
         let node = after_first_ack(querier);
         let budget = mock_budget();
         let node = (0..budget).fold(node, |node, _round| {
-            continued(node.on_remote_timeout(querier, testing::mock_env())).1
+            let nonce = node.in_flight_nonce;
+            continued(node.on_remote_timeout(nonce, querier, testing::mock_env())).1
         });
-        parked(node.on_remote_timeout(querier, testing::mock_env())).1
+        let nonce = node.in_flight_nonce;
+        parked(node.on_remote_timeout(nonce, querier, testing::mock_env())).1
     }
 
     fn mock_budget() -> CoinsNb {

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -398,10 +398,12 @@ where
     /// Advance the in-flight nonce ahead of a same-leg re-emission, so the
     /// superseded packet's late callback no longer matches and is absorbed.
     fn with_bumped_nonce(self) -> Self {
-        Self {
+        let ret = Self {
             in_flight_nonce: self.in_flight_nonce.saturating_add(1),
             ..self
-        }
+        };
+        debug_assert!(ret.invariant_held());
+        ret
     }
 
     fn internal_new(

--- a/protocol/packages/dex/src/impl_/remote_swap_only.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap_only.rs
@@ -30,6 +30,22 @@ where
 
 pub type StartSwapState<SwapTask> = RemoteSwap<SwapTask, State<SwapTask>>;
 
+#[cfg(test)]
+impl<SwapTask> State<SwapTask>
+where
+    SwapTask: SwapTaskT,
+{
+    /// The in-flight nonce of whichever inner node currently drives the
+    /// composite, so a test can thread the current packet's nonce into the
+    /// callbacks it forwards.
+    fn in_flight_nonce(&self) -> u64 {
+        match self {
+            State::RemoteSwap(inner) => inner.in_flight_nonce(),
+            State::SlippageAnomaly(inner) => inner.in_flight_nonce(),
+        }
+    }
+}
+
 /// Build the workflow's entry state over the swap specification
 ///
 /// Folds the coins already in the output currency and schedules the first
@@ -207,15 +223,16 @@ mod impl_handler {
         fn on_remote_response(
             self,
             data: Binary,
+            nonce: u64,
             querier: QuerierWrapper<'_>,
             env: Env,
         ) -> Result<Self> {
             match self {
                 State::RemoteSwap(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
                 State::SlippageAnomaly(inner) => {
-                    Handler::on_remote_response(inner, data, querier, env).map_into()
+                    Handler::on_remote_response(inner, data, nonce, querier, env).map_into()
                 }
             }
         }
@@ -223,26 +240,32 @@ mod impl_handler {
         fn on_remote_error(
             self,
             response: ICAErrorResponse,
+            nonce: u64,
             querier: QuerierWrapper<'_>,
             env: Env,
         ) -> Result<Self> {
             match self {
                 State::RemoteSwap(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
                 State::SlippageAnomaly(inner) => {
-                    Handler::on_remote_error(inner, response, querier, env).map_into()
+                    Handler::on_remote_error(inner, response, nonce, querier, env).map_into()
                 }
             }
         }
 
-        fn on_remote_timeout(self, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
+        fn on_remote_timeout(
+            self,
+            nonce: u64,
+            querier: QuerierWrapper<'_>,
+            env: Env,
+        ) -> Result<Self> {
             match self {
                 State::RemoteSwap(inner) => {
-                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
                 }
                 State::SlippageAnomaly(inner) => {
-                    Handler::on_remote_timeout(inner, querier, env).map_into()
+                    Handler::on_remote_timeout(inner, nonce, querier, env).map_into()
                 }
             }
         }
@@ -374,10 +397,12 @@ mod test {
         let querier = QuerierWrapper::new(&mock_querier);
 
         let state = after_first_ack(querier);
+        let nonce = state.in_flight_nonce();
         assert_eq!(
             coin_out(120),
             finished(state.on_remote_response(
                 payload(&coin_out(40)),
+                nonce,
                 querier,
                 testing::mock_env()
             ))
@@ -422,10 +447,12 @@ mod test {
             serialized,
             sdk::cosmwasm_std::to_json_vec(&restored).expect("a serializable arm"),
         );
+        let nonce = restored.in_flight_nonce();
         assert_eq!(
             coin_out(120),
             finished(restored.on_remote_response(
                 payload(&coin_out(40)),
+                nonce,
                 querier,
                 testing::mock_env(),
             ))
@@ -444,8 +471,10 @@ mod test {
         spec.set_floor(ANOMALY_FLOOR);
         let (_response, state) = continued(start(spec, &testing::mock_env(), querier).map_into());
 
+        let nonce = state.in_flight_nonce();
         let (response, _state) = continued(state.on_remote_response(
             payload(&coin_out(ANOMALY_FLOOR - 1)),
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -468,8 +497,11 @@ mod test {
         let mock_querier = MockQuerier::default();
         let querier = QuerierWrapper::new(&mock_querier);
 
-        let (response, state) = continued(after_first_ack(querier).on_remote_error(
+        let state = after_first_ack(querier);
+        let nonce = state.in_flight_nonce();
+        let (response, state) = continued(state.on_remote_error(
             ICAErrorResponse::from(String::from("swap reverted")),
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -492,8 +524,11 @@ mod test {
         let mock_querier = MockQuerier::default();
         let querier = QuerierWrapper::new(&mock_querier);
 
-        let (_response, parked) = continued(after_first_ack(querier).on_remote_error(
+        let state = after_first_ack(querier);
+        let nonce = state.in_flight_nonce();
+        let (_response, parked) = continued(state.on_remote_error(
             ICAErrorResponse::from(String::from("swap reverted")),
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -508,8 +543,10 @@ mod test {
         );
         assert!(matches!(restored, State::SlippageAnomaly(_)));
 
+        let nonce = restored.in_flight_nonce();
         let (_response, still_parked) = continued(restored.on_remote_response(
             payload(&coin_out(40)),
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -569,7 +606,14 @@ mod test {
     fn after_first_ack(querier: QuerierWrapper<'_>) -> State<MockSpec> {
         let (_response, state) =
             continued(start(spec3(), &testing::mock_env(), querier).map_into());
-        continued(state.on_remote_response(payload(&coin_out(30)), querier, testing::mock_env())).1
+        let nonce = state.in_flight_nonce();
+        continued(state.on_remote_response(
+            payload(&coin_out(30)),
+            nonce,
+            querier,
+            testing::mock_env(),
+        ))
+        .1
     }
 
     fn spec3() -> MockSpec {

--- a/protocol/packages/dex/src/impl_/remote_transfer_out.rs
+++ b/protocol/packages/dex/src/impl_/remote_transfer_out.rs
@@ -292,6 +292,7 @@ where
     fn on_remote_response(
         self,
         data: Binary,
+        _nonce: u64,
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> HandlerResult<Self> {
@@ -308,13 +309,19 @@ where
     fn on_remote_error(
         self,
         _response: ICAErrorResponse,
+        _nonce: u64,
         _querier: QuerierWrapper<'_>,
         _env: Env,
     ) -> HandlerResult<Self> {
         self.absorb(ABSORB_REMOTE_ERROR).into()
     }
 
-    fn on_remote_timeout(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
+    fn on_remote_timeout(
+        self,
+        _nonce: u64,
+        querier: QuerierWrapper<'_>,
+        env: Env,
+    ) -> HandlerResult<Self> {
         let state_label = self.spec.label();
         timeout::on_timeout_retry(self, state_label, querier, env).into()
     }
@@ -325,8 +332,11 @@ where
     /// absorbed error acknowledgment. See the module doc of
     /// [`RemoteSwap`][super::remote_swap::RemoteSwap] for the
     /// duplicate-acknowledgment risk a heal issued while the original
-    /// operation is still resolvable creates - with no payload to
-    /// cross-check, this transport is credulous to it by construction.
+    /// operation is still resolvable creates. `RemoteSwap` now closes that
+    /// window with a per-emission nonce; this payload-less transport does
+    /// not yet carry one - its adoption is deferred to the remaining
+    /// ibc-solray#142 phases - so it stays credulous to the risk by
+    /// construction until it does.
     fn heal(
         self,
         _querier: QuerierWrapper<'_>,
@@ -576,7 +586,7 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
 
         let (response, node) =
-            continued(started().on_remote_response(ok_payload(), querier, testing::mock_env()));
+            continued(started().on_remote_response(ok_payload(), 0, querier, testing::mock_env()));
         assert_eq!(transfer_response(&coin2(70), 1), response);
         assert_acks_left(1, &node);
     }
@@ -588,7 +598,7 @@ mod tests {
         let env = testing::mock_env();
 
         let node = after_first_ack(querier);
-        let resp = match node.on_remote_response(ok_payload(), querier, env.clone()) {
+        let resp = match node.on_remote_response(ok_payload(), 0, querier, env.clone()) {
             HandlerResult::Continue(Ok(resp)) => resp,
             HandlerResult::Continue(Err(err)) => panic!("expected a continuation, got {err}"),
             HandlerResult::Finished(_result) => panic!("expected a continuation, got a finish"),
@@ -606,7 +616,7 @@ mod tests {
         node.spec.set_received(true);
         assert_eq!(
             mock::FINISH_RESULT,
-            finished(node.on_remote_response(ok_payload(), querier, testing::mock_env()))
+            finished(node.on_remote_response(ok_payload(), 0, querier, testing::mock_env()))
         );
     }
 
@@ -619,6 +629,7 @@ mod tests {
 
         let (response, node) = continued(started().on_remote_error(
             ICAErrorResponse::from(String::from("transfer failed")),
+            0,
             querier,
             testing::mock_env(),
         ));
@@ -632,7 +643,7 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
         let env = testing::mock_env();
 
-        let (response, node) = continued(started().on_remote_timeout(querier, env.clone()));
+        let (response, node) = continued(started().on_remote_timeout(0, querier, env.clone()));
         assert_eq!(timeout_response(&coin1(100), &env), response);
         assert_acks_left(2, &node);
     }
@@ -644,6 +655,7 @@ mod tests {
 
         let (response, node) = continued(started().on_remote_response(
             Binary::from(b"garbage".as_slice()),
+            0,
             querier,
             testing::mock_env(),
         ));
@@ -658,6 +670,7 @@ mod tests {
 
         let (response, node) = continued(started().on_remote_response(
             Binary::from(mock::WRONG_VARIANT_PAYLOAD),
+            0,
             querier,
             testing::mock_env(),
         ));
@@ -724,7 +737,7 @@ mod tests {
 
     fn after_first_ack(querier: QuerierWrapper<'_>) -> Node {
         let (_response, node) =
-            continued(started().on_remote_response(ok_payload(), querier, testing::mock_env()));
+            continued(started().on_remote_response(ok_payload(), 0, querier, testing::mock_env()));
         node
     }
 

--- a/protocol/packages/dex/src/impl_/slippage_anomaly.rs
+++ b/protocol/packages/dex/src/impl_/slippage_anomaly.rs
@@ -4,17 +4,18 @@
 //! `OperationTimeout`s past the per-op retry budget - parks here instead of
 //! retrying forever. The node carries exactly what a [`Handler::heal`] needs
 //! to resume the SAME in-flight leg: the swap `spec`, the `acks_left`
-//! countdown identifying the leg, the accumulated `total_out`, and the floor
-//! `in_flight_min_out` pinned when the leg was last opened.
+//! countdown identifying the leg, the accumulated `total_out`, the floor
+//! `in_flight_min_out` pinned when the leg was last opened, and the
+//! `in_flight_nonce` the parked packet carried.
 //!
 //! While parked the lease answers state queries with
 //! `SlippageProtectionActivated` and absorbs any late acknowledgment of the
-//! original packet - reverting would strand the relayer. The at-most-once
-//! transport makes such a late callback a defensive case rather than an
-//! expected one. The operator-only heal re-quotes the leg against a fresh
-//! oracle floor and transitions back to the live [`RemoteSwap`] sequence;
-//! operators must invoke it only once the original in-flight operation is
-//! known to be unresolvable, mirroring the [`RemoteSwap`] heal contract.
+//! original packet - reverting would strand the relayer. The operator-only
+//! heal re-quotes the leg against a fresh oracle floor, bumps the nonce above
+//! the parked value, and transitions back to the live [`RemoteSwap`] sequence;
+//! the bumped nonce makes the heal idempotent - the original parked packet's
+//! late ack is absorbed as stale rather than mis-credited - so it is safe
+//! regardless of operator timing, mirroring the [`RemoteSwap`] heal contract.
 
 use std::{
     fmt::{Display, Formatter, Result as FmtResult},
@@ -74,6 +75,10 @@ where
     acks_left: CoinsNb,
     total_out: CoinDTO<SwapTask::OutG>,
     in_flight_min_out: CoinDTO<SwapTask::OutG>,
+    /// The nonce the parked leg was last emitted with (#636). A heal bumps
+    /// above this value, never resetting, so a late ack of the original parked
+    /// packet stays recognisable as stale.
+    in_flight_nonce: u64,
     #[serde(skip)]
     _variant_set: PhantomData<SEnum>,
 }
@@ -96,6 +101,11 @@ where
     acks_left: CoinsNb,
     total_out: CoinDTO<SwapTask::OutG>,
     in_flight_min_out: CoinDTO<SwapTask::OutG>,
+    /// `#[serde(default)]` lets a terminal parked before #636 restore with a
+    /// zero nonce, matching the zero its old, nonce-less in-flight packet
+    /// decodes to.
+    #[serde(default)]
+    in_flight_nonce: u64,
     #[serde(skip)]
     _variant_set: PhantomData<SEnum>,
 }
@@ -113,6 +123,7 @@ where
             acks_left: raw.acks_left,
             total_out: raw.total_out,
             in_flight_min_out: raw.in_flight_min_out,
+            in_flight_nonce: raw.in_flight_nonce,
             _variant_set: PhantomData,
         };
         if ret.invariant_held() {
@@ -132,12 +143,14 @@ where
         acks_left: CoinsNb,
         total_out: CoinDTO<SwapTask::OutG>,
         in_flight_min_out: CoinDTO<SwapTask::OutG>,
+        in_flight_nonce: u64,
     ) -> Self {
         let ret = Self {
             spec,
             acks_left,
             total_out,
             in_flight_min_out,
+            in_flight_nonce,
             _variant_set: PhantomData,
         };
         debug_assert!(ret.invariant_held());
@@ -189,6 +202,14 @@ where
         &self.in_flight_min_out
     }
 
+    // #636: the persisted nonce the parked leg last emitted with. A heal must
+    // bump above this value, never reset, so a late ack of the original parked
+    // packet is still recognised as stale.
+    #[cfg(test)]
+    pub(super) fn in_flight_nonce(&self) -> u64 {
+        self.in_flight_nonce
+    }
+
     #[cfg(test)]
     pub(super) fn spec_mut(&mut self) -> &mut SwapTask {
         &mut self.spec
@@ -231,6 +252,7 @@ where
     fn on_remote_response(
         self,
         _data: Binary,
+        _nonce: u64,
         _querier: QuerierWrapper<'_>,
         _env: Env,
     ) -> HandlerResult<Self> {
@@ -240,13 +262,19 @@ where
     fn on_remote_error(
         self,
         _response: ICAErrorResponse,
+        _nonce: u64,
         _querier: QuerierWrapper<'_>,
         _env: Env,
     ) -> HandlerResult<Self> {
         self.absorb(ABSORB_PARKED_ERROR)
     }
 
-    fn on_remote_timeout(self, _querier: QuerierWrapper<'_>, _env: Env) -> HandlerResult<Self> {
+    fn on_remote_timeout(
+        self,
+        _nonce: u64,
+        _querier: QuerierWrapper<'_>,
+        _env: Env,
+    ) -> HandlerResult<Self> {
         self.absorb(ABSORB_PARKED_TIMEOUT)
     }
 
@@ -258,8 +286,11 @@ where
     /// transition back to the live swap sequence with the retry counters
     /// reset. `acks_left` is unchanged - the leg is re-opened, never
     /// advanced - so the heal re-emission promises a floor freshly pinned by
-    /// `RemoteSwap::open_leg`. Operator-only: an unauthorised caller is
-    /// rejected before any re-quote, leaving the leg parked.
+    /// `RemoteSwap::open_leg`. The persisted `in_flight_nonce` seeds the
+    /// re-open so the healed emission carries a strictly greater nonce and the
+    /// original parked packet's late ack is absorbed. Operator-only: an
+    /// unauthorised caller is rejected before any re-quote, leaving the leg
+    /// parked.
     fn heal(
         self,
         querier: QuerierWrapper<'_>,
@@ -272,6 +303,7 @@ where
                 self.acks_left,
                 self.total_out,
                 querier,
+                self.in_flight_nonce,
             )
             .and_then(RemoteSwap::reemit_healed)
             .into(),
@@ -340,6 +372,7 @@ where
             self.acks_left,
             self.total_out,
             self.in_flight_min_out,
+            self.in_flight_nonce,
         )
     }
 }

--- a/protocol/packages/dex/src/response.rs
+++ b/protocol/packages/dex/src/response.rs
@@ -126,9 +126,14 @@ where
     /// the counterparty controller's acknowledgment transaction and strand
     /// the relayer, while advancing the current leg would corrupt its
     /// progress. Only legs that schedule remote operations override this.
+    ///
+    /// `nonce` is the per-emission identifier the controller read back from the
+    /// original outbound packet; overriding handlers match it against the
+    /// in-flight emission. The absorbing default ignores it.
     fn on_remote_response(
         self,
         _data: Binary,
+        _nonce: u64,
         _querier: QuerierWrapper<'_>,
         _env: Env,
     ) -> Result<Self>
@@ -140,10 +145,12 @@ where
 
     /// The entry point of a remote, non-ICA counterparty error
     ///
-    /// See [`Handler::on_remote_response`] for the absorbing default.
+    /// See [`Handler::on_remote_response`] for the absorbing default and the
+    /// `nonce` semantics.
     fn on_remote_error(
         self,
         _response: ICAErrorResponse,
+        _nonce: u64,
         _querier: QuerierWrapper<'_>,
         _env: Env,
     ) -> Result<Self>
@@ -155,8 +162,9 @@ where
 
     /// The entry point of a remote, non-ICA counterparty timeout
     ///
-    /// See [`Handler::on_remote_response`] for the absorbing default.
-    fn on_remote_timeout(self, _querier: QuerierWrapper<'_>, _env: Env) -> Result<Self>
+    /// See [`Handler::on_remote_response`] for the absorbing default and the
+    /// `nonce` semantics.
+    fn on_remote_timeout(self, _nonce: u64, _querier: QuerierWrapper<'_>, _env: Env) -> Result<Self>
     where
         Self: Into<Self::Response>,
     {

--- a/protocol/packages/remote_lease/src/callback.rs
+++ b/protocol/packages/remote_lease/src/callback.rs
@@ -4,6 +4,20 @@ pub use remote_lease_wire::callback::{OPERATION_ERR_MAX_BYTES, RemoteErrorMessag
 
 use crate::response::WireOperationResponse;
 
+/// A remote operation outcome paired with the nonce of the emission it
+/// resolves.
+///
+/// The controller reads `nonce` back from its own committed outbound packet
+/// on ack/timeout (never from the counterparty's reply) and returns it here,
+/// so the addressee lease can credit the outcome to the exact in-flight
+/// emission and reject a duplicate, stale, or heal-superseded callback.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct RemoteLeaseCallback {
+    pub nonce: u64,
+    pub outcome: RemoteOperationOutcome,
+}
+
 /// Outcome of a remote operation as reported back to the Nolus controller.
 ///
 /// `OperationOk` carries the wire-shaped response verbatim when Solana
@@ -19,7 +33,7 @@ use crate::response::WireOperationResponse;
 /// side until the channel times out).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub enum RemoteLeaseCallback {
+pub enum RemoteOperationOutcome {
     OperationOk(WireOperationResponse),
     OperationErr(RemoteErrorMessage),
     OperationTimeout,

--- a/protocol/packages/remote_lease/src/envelope.rs
+++ b/protocol/packages/remote_lease/src/envelope.rs
@@ -14,12 +14,20 @@ use crate::msg::Operation;
 /// receiver MUST convert it through [`NolusLeaseAddr::into_validated`] before
 /// using it for dispatch — the type prevents accidental use of the raw string
 /// as a `cosmwasm_std::Addr`.
+///
+/// `nonce` is a per-emission identifier the lease chooses; the controller
+/// reads it back from its own committed outbound packet on ack/timeout and
+/// returns it in the callback, letting the lease reject a callback that does
+/// not match the in-flight emission. `#[serde(default)]` keeps it optional at
+/// decode so a packet authored before the field existed decodes to `0`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct PacketEnvelope {
     pub lease: LeaseAddrOnWire,
     pub operation: Operation,
     pub version: ProtocolVersion,
+    #[serde(default)]
+    pub nonce: u64,
 }
 
 /// Nolus-side validation extension for [`LeaseAddrOnWire`].

--- a/protocol/packages/remote_lease/src/tests.rs
+++ b/protocol/packages/remote_lease/src/tests.rs
@@ -19,7 +19,9 @@ use finance::coin::Coin;
 
 use crate::{
     PORT_PREFIX, VERSION,
-    callback::{OPERATION_ERR_MAX_BYTES, RemoteErrorMessage, RemoteLeaseCallback},
+    callback::{
+        OPERATION_ERR_MAX_BYTES, RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome,
+    },
     envelope::{LeaseAddrOnWire, PacketEnvelope},
     error::Error,
     msg::{CloseLeaseParams, OpenLeaseParams, Operation, SwapParams, TransferOutParams},
@@ -112,14 +114,15 @@ fn transfer_out_response_serde() {
 
 #[test]
 fn callback_operation_ok_serde() {
-    let value =
-        RemoteLeaseCallback::OperationOk(WireOperationResponse::CloseLease(CloseLeaseResponse {}));
+    let value = RemoteOperationOutcome::OperationOk(WireOperationResponse::CloseLease(
+        CloseLeaseResponse {},
+    ));
     assert_round_trip_eq(r#"{"operation_ok":{"close_lease":{}}}"#, &value);
 }
 
 #[test]
 fn callback_operation_err_serde() {
-    let value = RemoteLeaseCallback::OperationErr(
+    let value = RemoteOperationOutcome::OperationErr(
         RemoteErrorMessage::new("dex pool drained").expect("short message must be accepted"),
     );
     assert_round_trip_eq(r#"{"operation_err":"dex pool drained"}"#, &value);
@@ -127,7 +130,7 @@ fn callback_operation_err_serde() {
 
 #[test]
 fn callback_operation_timeout_serde() {
-    let value = RemoteLeaseCallback::OperationTimeout;
+    let value = RemoteOperationOutcome::OperationTimeout;
     assert_round_trip_eq(r#""operation_timeout""#, &value);
 }
 
@@ -157,6 +160,23 @@ fn callback_error_message_deserialize_over_cap_rejected() {
         .expect_err("over-cap payload must fail deserialization");
 }
 
+// AC (#636): the typed callback carries the per-emission `nonce` alongside the
+// outcome and round-trips byte-identically to the wire shape the controller
+// dispatches into the lease.
+#[test]
+fn callback_round_trips_with_nonce() {
+    let value = RemoteLeaseCallback {
+        nonce: 7,
+        outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::CloseLease(
+            CloseLeaseResponse {},
+        )),
+    };
+    assert_round_trip_eq(
+        r#"{"nonce":7,"outcome":{"operation_ok":{"close_lease":{}}}}"#,
+        &value,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 4. PacketEnvelope — round-trip + literal JSON
 // ---------------------------------------------------------------------------
@@ -167,9 +187,10 @@ fn packet_envelope_serde() {
         lease: LeaseAddrOnWire::new("nolus1leaseaddr"),
         operation: Operation::CloseLease(CloseLeaseParams {}),
         version: ProtocolVersion,
+        nonce: 0,
     };
     assert_round_trip_eq(
-        r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}},"version":"nls-remote-lease.v1"}"#,
+        r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}},"version":"nls-remote-lease.v1","nonce":0}"#,
         &value,
     );
 }
@@ -192,6 +213,33 @@ fn packet_envelope_missing_version_rejected() {
 fn lease_addr_on_wire_round_trip_is_bare_string() {
     let value = LeaseAddrOnWire::new("nolus1leaseaddr");
     assert_round_trip_eq(r#""nolus1leaseaddr""#, &value);
+}
+
+// AC (#636): the typed envelope carries `nonce` as its last field (after
+// `version`) and a non-zero nonce round-trips byte-identically to the wire
+// JSON the Solana side consumes.
+#[test]
+fn packet_envelope_round_trips_with_nonce() {
+    let value = PacketEnvelope {
+        lease: LeaseAddrOnWire::new("nolus1leaseaddr"),
+        operation: Operation::CloseLease(CloseLeaseParams {}),
+        version: ProtocolVersion,
+        nonce: 7,
+    };
+    assert_round_trip_eq(
+        r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}},"version":"nls-remote-lease.v1","nonce":7}"#,
+        &value,
+    );
+}
+
+// AC (#636): `nonce` is `#[serde(default)]`, so a packet that predates the
+// field decodes with `nonce == 0` instead of being rejected.
+#[test]
+fn packet_envelope_decodes_without_nonce_to_zero() {
+    let wire = r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}},"version":"nls-remote-lease.v1"}"#;
+    let envelope: PacketEnvelope =
+        serde_json::from_str(wire).expect("a payload without nonce must default it to zero");
+    assert_eq!(0, envelope.nonce);
 }
 
 // ---------------------------------------------------------------------------

--- a/protocol/packages/remote_lease/src/tests.rs
+++ b/protocol/packages/remote_lease/src/tests.rs
@@ -4,7 +4,11 @@
 //! variant against `cosmwasm_std::to_json_binary` output. The Solana-side
 //! consumer is a foreign codebase, so every literal-JSON pin below is part of
 //! the wire contract — **any edit to a literal pin is a breaking protocol
-//! change and MUST bump [`crate::VERSION`]**.
+//! change and MUST bump [`crate::VERSION`]**, with one exception: an additive
+//! field marked `#[serde(default)]` (e.g. `nonce`, #636) extends the wire
+//! without a version bump, because updated consumers decode both the old and
+//! new shapes and the rollout is coordinated consumer-first rather than
+//! signalled by the version.
 
 use std::fmt::Debug;
 

--- a/protocol/packages/remote_lease/tests/cross_surface.rs
+++ b/protocol/packages/remote_lease/tests/cross_surface.rs
@@ -19,7 +19,7 @@ use currencies::{
 use finance::coin::Coin;
 
 use remote_lease::{
-    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
     envelope::{LeaseAddrOnWire, PacketEnvelope},
     msg::{CloseLeaseParams, OpenLeaseParams, Operation, SwapParams, TransferOutParams},
     response::{
@@ -30,8 +30,10 @@ use remote_lease::{
 };
 
 use remote_lease_wire::{
-    callback::RemoteLeaseCallback as WireCallback, envelope::PacketEnvelope as WireEnvelope,
-    msg::Operation as WireOperation, response::OperationResponse as WireResponse,
+    callback::{RemoteLeaseCallback as WireCallback, RemoteOperationOutcome as WireOutcome},
+    envelope::PacketEnvelope as WireEnvelope,
+    msg::Operation as WireOperation,
+    response::OperationResponse as WireResponse,
 };
 
 #[test]
@@ -86,32 +88,51 @@ fn response_transfer_out_byte_identical() {
 
 #[test]
 fn callback_operation_ok_byte_identical() {
-    let typed = RemoteLeaseCallback::OperationOk(WireResponse::CloseLease(CloseLeaseResponse {}));
-    assert_cross_surface_eq::<RemoteLeaseCallback, WireCallback>(&typed);
+    let typed =
+        RemoteOperationOutcome::OperationOk(WireResponse::CloseLease(CloseLeaseResponse {}));
+    assert_cross_surface_eq::<RemoteOperationOutcome, WireOutcome>(&typed);
 }
 
 #[test]
 fn callback_operation_err_byte_identical() {
-    let typed = RemoteLeaseCallback::OperationErr(
+    let typed = RemoteOperationOutcome::OperationErr(
         RemoteErrorMessage::new("dex pool drained").expect("short message"),
     );
-    assert_cross_surface_eq::<RemoteLeaseCallback, WireCallback>(&typed);
+    assert_cross_surface_eq::<RemoteOperationOutcome, WireOutcome>(&typed);
 }
 
 #[test]
 fn callback_operation_timeout_byte_identical() {
-    let typed = RemoteLeaseCallback::OperationTimeout;
-    assert_cross_surface_eq::<RemoteLeaseCallback, WireCallback>(&typed);
+    let typed = RemoteOperationOutcome::OperationTimeout;
+    assert_cross_surface_eq::<RemoteOperationOutcome, WireOutcome>(&typed);
 }
 
+// AC (#636): a NON-ZERO nonce on the envelope crosses the typed→JSON→wire→JSON
+// surface byte-identically, so field-order drift between the typed and wire
+// `PacketEnvelope` (nonce must be the last field, after `version`) is caught.
 #[test]
 fn packet_envelope_byte_identical() {
     let typed = PacketEnvelope {
         lease: LeaseAddrOnWire::new("nolus1leaseaddr"),
         operation: Operation::Swap(swap()),
         version: ProtocolVersion,
+        nonce: 7,
     };
     assert_cross_surface_eq::<PacketEnvelope, WireEnvelope>(&typed);
+}
+
+// AC (#636): a NON-ZERO nonce on the callback crosses the typed→wire surface
+// byte-identically, so the `{ nonce, outcome }` field order stays in lockstep
+// between the typed and wire `RemoteLeaseCallback`.
+#[test]
+fn callback_carries_nonce_byte_identical() {
+    let typed = RemoteLeaseCallback {
+        nonce: 7,
+        outcome: RemoteOperationOutcome::OperationOk(WireResponse::CloseLease(
+            CloseLeaseResponse {},
+        )),
+    };
+    assert_cross_surface_eq::<RemoteLeaseCallback, WireCallback>(&typed);
 }
 
 fn assert_cross_surface_eq<T, W>(typed: &T)

--- a/protocol/packages/remote_lease_wire/src/callback.rs
+++ b/protocol/packages/remote_lease_wire/src/callback.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 use crate::{error::Error, response::OperationResponse};
 
-/// Maximum byte length of a [`RemoteLeaseCallback::OperationErr`] payload.
+/// Maximum byte length of a [`RemoteOperationOutcome::OperationErr`] payload.
 ///
 /// Why a cap: the string is authored by the Solana counterparty and consumed
 /// by Nolus storage / event emission. Without a bound, a hostile or
@@ -12,6 +12,20 @@ use crate::{error::Error, response::OperationResponse};
 /// arbitrarily. 512 bytes is enough to carry a structured short message
 /// ("dex error: <code> <reason>") but small enough to forbid abuse.
 pub const OPERATION_ERR_MAX_BYTES: usize = 512;
+
+/// A remote operation outcome paired with the nonce of the emission it
+/// resolves.
+///
+/// The controller reads `nonce` back from its own committed outbound packet
+/// on ack/timeout (never from the counterparty's reply) and returns it here,
+/// so the lease can credit the outcome to the exact in-flight emission and
+/// reject a duplicate, stale, or heal-superseded callback.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct RemoteLeaseCallback {
+    pub nonce: u64,
+    pub outcome: RemoteOperationOutcome,
+}
 
 /// Outcome of a remote operation as reported back to the Nolus controller.
 ///
@@ -24,7 +38,7 @@ pub const OPERATION_ERR_MAX_BYTES: usize = 512;
 /// be in flight on the Solana side until the channel times out).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub enum RemoteLeaseCallback {
+pub enum RemoteOperationOutcome {
     OperationOk(OperationResponse),
     OperationErr(RemoteErrorMessage),
     OperationTimeout,

--- a/protocol/packages/remote_lease_wire/src/envelope.rs
+++ b/protocol/packages/remote_lease_wire/src/envelope.rs
@@ -11,12 +11,22 @@ use crate::{msg::Operation, version::ProtocolVersion};
 /// consumers MUST validate the string through their own `Addr` constructor
 /// before using it for dispatch — the type prevents accidental use of the raw
 /// string as an authenticated address.
+///
+/// `nonce` is a per-emission identifier the Nolus lease chooses; the
+/// controller reads it back from its own committed outbound packet on
+/// ack/timeout and returns it in the callback, letting the lease reject a
+/// callback that does not match the in-flight emission. `#[serde(default)]`
+/// keeps the field optional at decode so an envelope authored before the
+/// field existed (nonce absent) decodes to `0`; the counterparty neither
+/// inspects nor echoes it.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct PacketEnvelope {
     pub lease: LeaseAddrOnWire,
     pub operation: Operation,
     pub version: ProtocolVersion,
+    #[serde(default)]
+    pub nonce: u64,
 }
 
 /// On-wire encoding of a Nolus lease address.

--- a/protocol/packages/remote_lease_wire/src/tests.rs
+++ b/protocol/packages/remote_lease_wire/src/tests.rs
@@ -14,7 +14,9 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     PORT_PREFIX, VERSION,
-    callback::{OPERATION_ERR_MAX_BYTES, RemoteErrorMessage, RemoteLeaseCallback},
+    callback::{
+        OPERATION_ERR_MAX_BYTES, RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome,
+    },
     coin::WireCoin,
     envelope::{LeaseAddrOnWire, PacketEnvelope},
     error::Error,
@@ -110,13 +112,13 @@ fn transfer_out_response_serde() {
 #[test]
 fn callback_operation_ok_serde() {
     let value =
-        RemoteLeaseCallback::OperationOk(OperationResponse::CloseLease(CloseLeaseResponse {}));
+        RemoteOperationOutcome::OperationOk(OperationResponse::CloseLease(CloseLeaseResponse {}));
     assert_round_trip_eq(r#"{"operation_ok":{"close_lease":{}}}"#, &value);
 }
 
 #[test]
 fn callback_operation_err_serde() {
-    let value = RemoteLeaseCallback::OperationErr(
+    let value = RemoteOperationOutcome::OperationErr(
         RemoteErrorMessage::new("dex pool drained").expect("short message must be accepted"),
     );
     assert_round_trip_eq(r#"{"operation_err":"dex pool drained"}"#, &value);
@@ -124,7 +126,7 @@ fn callback_operation_err_serde() {
 
 #[test]
 fn callback_operation_timeout_serde() {
-    let value = RemoteLeaseCallback::OperationTimeout;
+    let value = RemoteOperationOutcome::OperationTimeout;
     assert_round_trip_eq(r#""operation_timeout""#, &value);
 }
 
@@ -160,7 +162,7 @@ fn callback_error_message_from_static_accepted() {
     assert_eq!("timeout", value.as_str());
     assert_round_trip_eq(
         r#"{"operation_err":"timeout"}"#,
-        &RemoteLeaseCallback::OperationErr(value),
+        &RemoteOperationOutcome::OperationErr(value),
     );
 }
 
@@ -175,6 +177,23 @@ fn callback_error_message_from_static_over_cap_panics_in_debug() {
     let _ = RemoteErrorMessage::from_static(over_cap);
 }
 
+// AC (#636): the callback wraps a per-emission `nonce` alongside the outcome,
+// so the controller can correlate an acknowledgment to the exact packet that
+// solicited it; the nonce round-trips on the wire.
+#[test]
+fn callback_round_trips_with_nonce() {
+    let value = RemoteLeaseCallback {
+        nonce: 7,
+        outcome: RemoteOperationOutcome::OperationOk(OperationResponse::CloseLease(
+            CloseLeaseResponse {},
+        )),
+    };
+    assert_round_trip_eq(
+        r#"{"nonce":7,"outcome":{"operation_ok":{"close_lease":{}}}}"#,
+        &value,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 4. PacketEnvelope — round-trip + literal JSON
 // ---------------------------------------------------------------------------
@@ -185,9 +204,10 @@ fn packet_envelope_serde() {
         lease: LeaseAddrOnWire::new("nolus1leaseaddr"),
         operation: Operation::CloseLease(CloseLeaseParams {}),
         version: ProtocolVersion,
+        nonce: 0,
     };
     assert_round_trip_eq(
-        r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}},"version":"nls-remote-lease.v1"}"#,
+        r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}},"version":"nls-remote-lease.v1","nonce":0}"#,
         &value,
     );
 }
@@ -210,6 +230,34 @@ fn packet_envelope_missing_version_rejected() {
 fn lease_addr_on_wire_round_trip_is_bare_string() {
     let value = LeaseAddrOnWire::new("nolus1leaseaddr");
     assert_round_trip_eq(r#""nolus1leaseaddr""#, &value);
+}
+
+// AC (#636): the envelope carries a per-emission `nonce` as its last field
+// (after `version`); a non-zero nonce round-trips byte-identically so the
+// Solana side can echo it back unchanged on the acknowledgment.
+#[test]
+fn packet_envelope_round_trips_with_nonce() {
+    let value = PacketEnvelope {
+        lease: LeaseAddrOnWire::new("nolus1leaseaddr"),
+        operation: Operation::CloseLease(CloseLeaseParams {}),
+        version: ProtocolVersion,
+        nonce: 7,
+    };
+    assert_round_trip_eq(
+        r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}},"version":"nls-remote-lease.v1","nonce":7}"#,
+        &value,
+    );
+}
+
+// AC (#636): `nonce` is `#[serde(default)]`, so a payload that predates the
+// field — a legacy packet from a counterparty that has not yet upgraded —
+// decodes with `nonce == 0` rather than being rejected.
+#[test]
+fn packet_envelope_decodes_without_nonce_to_zero() {
+    let wire = r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}},"version":"nls-remote-lease.v1"}"#;
+    let envelope: PacketEnvelope =
+        serde_json::from_str(wire).expect("a payload without nonce must default it to zero");
+    assert_eq!(0, envelope.nonce);
 }
 
 // ---------------------------------------------------------------------------

--- a/protocol/packages/remote_lease_wire/src/tests.rs
+++ b/protocol/packages/remote_lease_wire/src/tests.rs
@@ -5,7 +5,11 @@
 //! The cross-surface integration test under `remote_lease/tests/` validates
 //! that equivalence end-to-end; this module locks the wire encoding so the
 //! Solana side can rely on a stable surface — **any edit to a literal pin is
-//! a breaking protocol change and MUST bump [`crate::VERSION`]**.
+//! a breaking protocol change and MUST bump [`crate::VERSION`]**, with one
+//! exception: an additive field marked `#[serde(default)]` (e.g. `nonce`,
+//! #636) extends the wire without a version bump, because updated consumers
+//! decode both the old and new shapes and the rollout is coordinated
+//! consumer-first rather than signalled by the version.
 
 use std::fmt::Debug;
 

--- a/tests/src/common/remote_lease_controller_stub.rs
+++ b/tests/src/common/remote_lease_controller_stub.rs
@@ -53,7 +53,7 @@ use currency::{self, CurrencyDef, Group, MemberOf};
 use finance::coin::{Amount, Coin, CoinDTO, WithCoin};
 use platform::contract::{Code, CodeId};
 use remote_lease::{
-    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
     msg::{CloseLeaseParams, OpenLeaseParams, SwapParams, TransferOutParams},
     response::{
         CloseLeaseResponse, OpenLeaseResponse, OperationResponse, RemoteLeaseId, SwapResponse,
@@ -132,9 +132,14 @@ pub enum StubExecuteMsg {
         params: CloseLeaseParams,
         timeout: finance::duration::Duration,
     },
+    // #636: `Swap` carries the per-emission `nonce` the lease tags the packet
+    // with; the stand-in echoes it into the synthesised callback exactly as the
+    // production controller forwards `envelope.nonce`.
     Swap {
         params: SwapParams,
         timeout: finance::duration::Duration,
+        #[serde(default)]
+        nonce: u64,
     },
     TransferOut {
         params: TransferOutParams,
@@ -164,6 +169,16 @@ pub enum StubExecuteMsg {
         to: Addr,
         callback: RemoteLeaseCallback,
     },
+    /// Test-only (#636): send a callback carrying a SPECIFIC `nonce` to a
+    /// lease, so a driver can replay the original packet's nonce as a stale
+    /// duplicate or deliver a healed re-emission's fresh nonce. Mirrors
+    /// [`InjectCallback`] but lets the driver control the per-emission nonce
+    /// the production controller would otherwise forward from the envelope.
+    InjectCallbackWithNonce {
+        to: Addr,
+        nonce: u64,
+        outcome: RemoteOperationOutcome,
+    },
 }
 
 /// Stand-in `QueryMsg` — the production variants mirror
@@ -181,6 +196,13 @@ pub enum StubQueryMsg {
     },
     /// Report every `TransferOutParams` the given lease has emitted, in order.
     RecordedTransferOuts {
+        lease: Addr,
+    },
+    /// Test-only (#636): report the per-emission `nonce` of every `Swap` the
+    /// given lease has emitted, in order, so a driver can replay the in-flight
+    /// nonce (matching), the original after a heal (stale), or the healed
+    /// re-emission (fresh).
+    RecordedSwapNonces {
         lease: Addr,
     },
     /// Report how many `CloseLease` executes the given lease has emitted.
@@ -202,6 +224,10 @@ const MODES: Map<&str, ResponseMode> = Map::new("stub_modes");
 const PENDING: Map<&str, PendingCallback> = Map::new("stub_pending");
 const LEASE_PDA_COUNTER: Item<u64> = Item::new("stub_pda_counter");
 const RECORDED_SWAPS: Map<&Addr, Vec<SwapParams>> = Map::new("stub_recorded_swaps");
+/// #636: the per-emission nonce each recorded swap went out with, parallel to
+/// [`RECORDED_SWAPS`]. Lets a driver replay the in-flight nonce (matching) or
+/// the superseded one after a heal (stale).
+const RECORDED_SWAP_NONCES: Map<&Addr, Vec<u64>> = Map::new("stub_recorded_swap_nonces");
 const RECORDED_TRANSFER_OUTS: Map<&Addr, Vec<TransferOutParams>> =
     Map::new("stub_recorded_transfer_outs");
 const RECORDED_CLOSES: Map<&Addr, u32> = Map::new("stub_recorded_closes");
@@ -276,19 +302,20 @@ pub fn execute(
             Ok(CwResponse::new())
         }
         StubExecuteMsg::OpenLease { params, .. } => {
-            handle_outbound(deps, info, op_tag::OPEN_LEASE, |storage| {
+            handle_outbound(deps, info, op_tag::OPEN_LEASE, 0, |storage| {
                 synth_open_lease_response(storage, &params)
             })
         }
         StubExecuteMsg::CloseLease { .. } => {
             record_close(deps.storage, &info.sender)?;
-            handle_outbound(deps, info, op_tag::CLOSE_LEASE, |_storage| {
+            handle_outbound(deps, info, op_tag::CLOSE_LEASE, 0, |_storage| {
                 Ok(OperationResponse::CloseLease(CloseLeaseResponse {}))
             })
         }
-        StubExecuteMsg::Swap { params, .. } => {
+        StubExecuteMsg::Swap { params, nonce, .. } => {
             record_swap(deps.storage, &info.sender, &params)?;
-            handle_outbound(deps, info, op_tag::SWAP, |storage| {
+            record_swap_nonce(deps.storage, &info.sender, nonce)?;
+            handle_outbound(deps, info, op_tag::SWAP, nonce, |storage| {
                 Ok(OperationResponse::Swap(SwapResponse {
                     amount_out: next_swap_output(storage, &params)?,
                 }))
@@ -296,7 +323,7 @@ pub fn execute(
         }
         StubExecuteMsg::TransferOut { params, .. } => {
             record_transfer_out(deps.storage, &info.sender, &params)?;
-            handle_outbound(deps, info, op_tag::TRANSFER_OUT, |_storage| {
+            handle_outbound(deps, info, op_tag::TRANSFER_OUT, 0, |_storage| {
                 Ok(OperationResponse::TransferOut(TransferOutResponse {}))
             })
         }
@@ -310,8 +337,23 @@ pub fn execute(
         }
         StubExecuteMsg::DeliverPending { op } => deliver_pending(deps.storage, op.as_str()),
         StubExecuteMsg::InjectCallback { to, callback } => {
-            Ok(CwResponse::new().add_message(callback_msg(to, callback)?))
+            // #636: a manually-injected "valid" callback must carry the lease's
+            // current in-flight nonce so a live swap leg matches it (the leg
+            // absorbs any other nonce as `nonce-mismatch`). Stamp the last
+            // recorded swap nonce for `to` over the caller's placeholder; if the
+            // lease has emitted no swap yet (open/close/transfer-out flows that
+            // ignore the nonce), fall back to the caller's value.
+            let nonce = last_recorded_swap_nonce(deps.storage, &to)?.unwrap_or(callback.nonce);
+            Ok(CwResponse::new().add_message(callback_msg(
+                to,
+                RemoteLeaseCallback {
+                    nonce,
+                    outcome: callback.outcome,
+                },
+            )?))
         }
+        StubExecuteMsg::InjectCallbackWithNonce { to, nonce, outcome } => Ok(CwResponse::new()
+            .add_message(callback_msg(to, RemoteLeaseCallback { nonce, outcome })?)),
     }
 }
 
@@ -346,6 +388,11 @@ pub fn query(deps: Deps<'_>, _env: Env, msg: StubQueryMsg) -> StdResult<Binary> 
                 .may_load(deps.storage, &lease)?
                 .unwrap_or_default(),
         ),
+        StubQueryMsg::RecordedSwapNonces { lease } => to_json_binary(
+            &RECORDED_SWAP_NONCES
+                .may_load(deps.storage, &lease)?
+                .unwrap_or_default(),
+        ),
         StubQueryMsg::RecordedCloses { lease } => to_json_binary(
             &RECORDED_CLOSES
                 .may_load(deps.storage, &lease)?
@@ -358,6 +405,7 @@ fn handle_outbound<F>(
     deps: cosmwasm_std::DepsMut<'_>,
     info: MessageInfo,
     op: &str,
+    nonce: u64,
     build_ok: F,
 ) -> Result<CwResponse, StubError>
 where
@@ -372,31 +420,41 @@ where
         .may_load(deps.storage, op)?
         .unwrap_or(ResponseMode::Ok);
 
-    let callback = match mode {
-        ResponseMode::Ok => RemoteLeaseCallback::OperationOk(build_ok(deps.storage)?.into()),
-        ResponseMode::Err(reason) => RemoteLeaseCallback::OperationErr(reason),
+    // #636: the synthesised callback echoes the emitting packet's `nonce`
+    // exactly as the production controller forwards `envelope.nonce`, so a
+    // live swap leg credits it instead of absorbing it as `nonce-mismatch`.
+    // Non-swap operations pass `0`; their callback handlers ignore the nonce.
+    let outcome = match mode {
+        ResponseMode::Ok => RemoteOperationOutcome::OperationOk(build_ok(deps.storage)?.into()),
+        ResponseMode::Err(reason) => RemoteOperationOutcome::OperationErr(reason),
         ResponseMode::Delayed => {
-            let payload = RemoteLeaseCallback::OperationOk(build_ok(deps.storage)?.into());
+            let payload = RemoteOperationOutcome::OperationOk(build_ok(deps.storage)?.into());
             PENDING.save(
                 deps.storage,
                 op,
                 &PendingCallback {
                     sender: info.sender.clone(),
-                    callback: payload,
+                    callback: RemoteLeaseCallback {
+                        nonce,
+                        outcome: payload,
+                    },
                 },
             )?;
             return Ok(CwResponse::new());
         }
         ResponseMode::UnderpayingOnce => {
             MODES.save(deps.storage, op, &ResponseMode::Ok)?;
-            RemoteLeaseCallback::OperationOk(underpay(build_ok(deps.storage)?).into())
+            RemoteOperationOutcome::OperationOk(underpay(build_ok(deps.storage)?).into())
         }
         // The Err reverts this whole sub-execution, so the per-op
         // recorders written earlier in the same call roll back with it.
         ResponseMode::FailSync => return Err(StubError::SyncFailure { op: op.to_owned() }),
     };
 
-    Ok(CwResponse::new().add_message(callback_msg(info.sender, callback)?))
+    Ok(CwResponse::new().add_message(callback_msg(
+        info.sender,
+        RemoteLeaseCallback { nonce, outcome },
+    )?))
 }
 
 /// The output a happy-path counterparty pays for a swap.
@@ -496,6 +554,30 @@ fn record_swap(
         })
         .map(|_recorded| ())
         .map_err(Into::into)
+}
+
+fn record_swap_nonce(
+    storage: &mut dyn Storage,
+    sender: &Addr,
+    nonce: u64,
+) -> Result<(), StubError> {
+    RECORDED_SWAP_NONCES
+        .update(storage, sender, |recorded| -> Result<_, StdError> {
+            let mut recorded = recorded.unwrap_or_default();
+            recorded.push(nonce);
+            Ok(recorded)
+        })
+        .map(|_recorded| ())
+        .map_err(Into::into)
+}
+
+/// #636: the last `nonce` the given lease emitted a swap with, i.e. its
+/// current in-flight swap nonce. `None` when the lease has emitted no swap
+/// yet (open/close/transfer-out flows that ignore the nonce).
+fn last_recorded_swap_nonce(storage: &dyn Storage, lease: &Addr) -> Result<Option<u64>, StubError> {
+    Ok(RECORDED_SWAP_NONCES
+        .may_load(storage, lease)?
+        .and_then(|nonces| nonces.last().copied()))
 }
 
 fn record_close(storage: &mut dyn Storage, sender: &Addr) -> Result<(), StubError> {
@@ -658,6 +740,26 @@ pub fn inject_callback(
         .expect("InjectCallback must succeed against the stand-in")
 }
 
+/// Deliver a callback carrying a SPECIFIC nonce to a lease from the stand-in's
+/// (authorised) address (#636). Lets a driver replay the original packet's
+/// nonce as a stale duplicate, or deliver a healed re-emission's fresh nonce.
+pub fn inject_callback_with_nonce(
+    app: &mut App,
+    controller: &Addr,
+    lease: &Addr,
+    nonce: u64,
+    outcome: RemoteOperationOutcome,
+) -> sdk::cw_multi_test::AppResponse {
+    let msg = StubExecuteMsg::InjectCallbackWithNonce {
+        to: lease.clone(),
+        nonce,
+        outcome,
+    };
+    app.execute(sdk::testing::user(ADMIN), controller.clone(), &msg, &[])
+        .map(|response| response.unwrap_response())
+        .expect("InjectCallbackWithNonce must succeed against the stand-in")
+}
+
 /// Report every `SwapParams` the given lease has emitted.
 pub fn recorded_swaps(app: &App, controller: &Addr, lease: &Addr) -> Vec<SwapParams> {
     app.query()
@@ -668,6 +770,19 @@ pub fn recorded_swaps(app: &App, controller: &Addr, lease: &Addr) -> Vec<SwapPar
             },
         )
         .expect("RecordedSwaps must succeed against the stand-in")
+}
+
+/// Report the per-emission nonce of every `Swap` the given lease has emitted
+/// (#636), parallel to [`recorded_swaps`].
+pub fn recorded_swap_nonces(app: &App, controller: &Addr, lease: &Addr) -> Vec<u64> {
+    app.query()
+        .query_wasm_smart(
+            controller.clone(),
+            &StubQueryMsg::RecordedSwapNonces {
+                lease: lease.clone(),
+            },
+        )
+        .expect("RecordedSwapNonces must succeed against the stand-in")
 }
 
 /// Report every `TransferOutParams` the given lease has emitted.

--- a/tests/src/lease/heal.rs
+++ b/tests/src/lease/heal.rs
@@ -9,7 +9,7 @@ use lease::{
     error::ContractError,
 };
 use remote_lease::{
-    callback::RemoteLeaseCallback,
+    callback::{RemoteLeaseCallback, RemoteOperationOutcome},
     response::{TransferOutResponse, WireOperationResponse},
 };
 use sdk::{
@@ -105,9 +105,12 @@ fn swap_on_repay() {
     );
     assert_repay_swap_in_flight(&test_case, &lease);
 
-    let wrong_variant = RemoteLeaseCallback::OperationOk(WireOperationResponse::TransferOut(
-        TransferOutResponse {},
-    ));
+    let wrong_variant = RemoteLeaseCallback {
+        nonce: 0,
+        outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::TransferOut(
+            TransferOutResponse {},
+        )),
+    };
     let absorbed = stub::inject_callback(&mut test_case.app, &controller, &lease, wrong_variant);
     expect_attribute(
         &absorbed.events,

--- a/tests/src/lease/remote_lease_callback.rs
+++ b/tests/src/lease/remote_lease_callback.rs
@@ -22,7 +22,7 @@ use lease::{
     error::ContractError,
 };
 use remote_lease::{
-    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
     response::{CloseLeaseResponse, WireOperationResponse},
 };
 use sdk::{
@@ -50,7 +50,10 @@ fn rejects_mismatched_sender_at_swap_state() {
         &mut test_case.app,
         &lease,
         testing::user(common::USER),
-        RemoteLeaseCallback::OperationTimeout,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationTimeout,
+        },
     );
 
     let contract_err = err
@@ -69,13 +72,17 @@ fn rejects_mismatched_sender_at_swap_state() {
 fn operation_timeout_retries_the_in_flight_leg() {
     let (mut test_case, lease) = drive_to_swap_pending();
     let controller = controller_addr(&test_case);
+    let nonce = in_flight_nonce(&test_case, &controller, &lease);
 
     let response = test_case
         .app
         .execute(
             controller,
             lease.clone(),
-            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback::OperationTimeout),
+            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback {
+                nonce,
+                outcome: RemoteOperationOutcome::OperationTimeout,
+            }),
             &[],
         )
         .expect("authorised OperationTimeout must re-emit the leg and return Ok")
@@ -88,6 +95,7 @@ fn operation_timeout_retries_the_in_flight_leg() {
 fn operation_err_retries_the_in_flight_leg() {
     let (mut test_case, lease) = drive_to_swap_pending();
     let controller = controller_addr(&test_case);
+    let nonce = in_flight_nonce(&test_case, &controller, &lease);
     let payload = RemoteErrorMessage::new("solana side rejected").expect("within the length cap");
 
     let response = test_case
@@ -95,7 +103,10 @@ fn operation_err_retries_the_in_flight_leg() {
         .execute(
             controller,
             lease.clone(),
-            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback::OperationErr(payload)),
+            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback {
+                nonce,
+                outcome: RemoteOperationOutcome::OperationErr(payload),
+            }),
             &[],
         )
         .expect("authorised OperationErr must re-emit the leg and return Ok")
@@ -108,6 +119,7 @@ fn operation_err_retries_the_in_flight_leg() {
 fn non_swap_operation_ok_is_absorbed() {
     let (mut test_case, lease) = drive_to_swap_pending();
     let controller = controller_addr(&test_case);
+    let nonce = in_flight_nonce(&test_case, &controller, &lease);
     let payload = WireOperationResponse::CloseLease(CloseLeaseResponse {});
 
     let response = test_case
@@ -115,7 +127,10 @@ fn non_swap_operation_ok_is_absorbed() {
         .execute(
             controller,
             lease.clone(),
-            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback::OperationOk(payload)),
+            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback {
+                nonce,
+                outcome: RemoteOperationOutcome::OperationOk(payload),
+            }),
             &[],
         )
         .expect("a non-swap success ack must be absorbed, committing the controller's tx")
@@ -182,6 +197,14 @@ fn assert_swap_pending(test_case: &LeaseTestCase, lease: Addr) {
 
 fn controller_addr(test_case: &LeaseTestCase) -> Addr {
     test_case.address_book.remote_lease_controller().clone()
+}
+
+/// The nonce the in-flight swap leg was last emitted with (#636): a callback
+/// must carry it to be credited rather than absorbed as `nonce-mismatch`.
+fn in_flight_nonce(test_case: &LeaseTestCase, controller: &Addr, lease: &Addr) -> u64 {
+    *stub::recorded_swap_nonces(&test_case.app, controller, lease)
+        .last()
+        .expect("the in-flight swap leg must have recorded a nonce")
 }
 
 fn send_callback(

--- a/tests/src/lease/remote_lease_close.rs
+++ b/tests/src/lease/remote_lease_close.rs
@@ -27,7 +27,7 @@ use lease::{
     error::ContractError,
 };
 use remote_lease::{
-    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
     response::{CloseLeaseResponse, WireOperationResponse},
 };
 use sdk::{
@@ -175,7 +175,10 @@ fn close_timeout_reemits() {
         &mut test_case.app,
         &controller,
         &lease,
-        RemoteLeaseCallback::OperationTimeout,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationTimeout,
+        },
     );
     timeout_response.assert_event(
         &Event::new(CLOSING_REMOTE_LEASE_EVENT)
@@ -337,7 +340,12 @@ fn completion_event(lease: &Addr) -> Event {
 }
 
 fn close_lease_ack() -> RemoteLeaseCallback {
-    RemoteLeaseCallback::OperationOk(WireOperationResponse::CloseLease(CloseLeaseResponse {}))
+    RemoteLeaseCallback {
+        nonce: 0,
+        outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::CloseLease(
+            CloseLeaseResponse {},
+        )),
+    }
 }
 
 fn deliver_price_alarm(test_case: &mut LeaseTestCase, lease: Addr) -> AppResponse {

--- a/tests/src/lease/remote_lease_open.rs
+++ b/tests/src/lease/remote_lease_open.rs
@@ -11,7 +11,7 @@ use lease::api::{
     query::{StateResponse, opening::OngoingTrx as OpeningOngoingTrx},
 };
 use remote_lease::{
-    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
     response::{CloseLeaseResponse, OpenLeaseResponse, RemoteLeaseId, WireOperationResponse},
 };
 use sdk::{cosmwasm_std::Addr, testing};
@@ -146,8 +146,12 @@ fn open_failed_on_unexpected_operation_refunds_and_finalises() {
     // from a buggy or hostile counterparty. The lease must treat it as an
     // open failure — refund and move to terminal — rather than returning
     // `Err`, which would revert the controller's ack and strand the relayer.
-    let unexpected =
-        RemoteLeaseCallback::OperationOk(WireOperationResponse::CloseLease(CloseLeaseResponse {}));
+    let unexpected = RemoteLeaseCallback {
+        nonce: 0,
+        outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::CloseLease(
+            CloseLeaseResponse {},
+        )),
+    };
     let failed = test_case
         .app
         .execute(
@@ -223,13 +227,17 @@ fn late_open_lease_ack_after_open_failed_is_absorbed() {
 
     // Synthesise the late OK ack that ibc-go would deliver against the
     // already-terminal lease on an UNORDERED channel.
-    let late_callback =
-        RemoteLeaseCallback::OperationOk(WireOperationResponse::OpenLease(OpenLeaseResponse {
-            remote_lease_id: RemoteLeaseId::new(
-                "StubPdaLate111111111111111111111111111".to_owned(),
-            )
-            .expect("base58 sample"),
-        }));
+    let late_callback = RemoteLeaseCallback {
+        nonce: 0,
+        outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::OpenLease(
+            OpenLeaseResponse {
+                remote_lease_id: RemoteLeaseId::new(
+                    "StubPdaLate111111111111111111111111111".to_owned(),
+                )
+                .expect("base58 sample"),
+            },
+        )),
+    };
     let late = test_case
         .app
         .execute(

--- a/tests/src/lease/remote_lease_slippage_terminal.rs
+++ b/tests/src/lease/remote_lease_slippage_terminal.rs
@@ -39,7 +39,7 @@ use lease::{
     },
     error::ContractError,
 };
-use remote_lease::callback::{RemoteErrorMessage, RemoteLeaseCallback};
+use remote_lease::callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome};
 use sdk::{
     cosmwasm_std::{Addr, Event},
     testing,
@@ -79,7 +79,10 @@ fn error_routes_immediately_to_terminal() {
         &mut test_case.app,
         &controller,
         &lease,
-        RemoteLeaseCallback::OperationErr(reason),
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(reason),
+        },
     );
 
     // an error must NOT re-emit the leg - it parks immediately
@@ -323,7 +326,10 @@ fn buy_asset_timeout_reemits_unbounded() {
             &mut test_case.app,
             &controller,
             &lease,
-            RemoteLeaseCallback::OperationTimeout,
+            RemoteLeaseCallback {
+                nonce: 0,
+                outcome: RemoteOperationOutcome::OperationTimeout,
+            },
         );
     }
 
@@ -348,7 +354,10 @@ fn buy_asset_error_reemits() {
         &mut test_case.app,
         &controller,
         &lease,
-        RemoteLeaseCallback::OperationErr(reason),
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(reason),
+        },
     );
 
     assert_eq!(
@@ -504,7 +513,10 @@ fn assert_parks_after_budget(test_case: &mut LeaseTestCase, lease: &Addr, budget
             &mut test_case.app,
             &controller,
             lease,
-            RemoteLeaseCallback::OperationTimeout,
+            RemoteLeaseCallback {
+                nonce: 0,
+                outcome: RemoteOperationOutcome::OperationTimeout,
+            },
         );
         // each timeout within budget re-emits exactly one swap and the lease
         // keeps retrying (NOT parked yet)
@@ -527,7 +539,10 @@ fn assert_parks_after_budget(test_case: &mut LeaseTestCase, lease: &Addr, budget
         &mut test_case.app,
         &controller,
         lease,
-        RemoteLeaseCallback::OperationTimeout,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationTimeout,
+        },
     );
     assert_eq!(
         swaps_at_budget,
@@ -546,7 +561,10 @@ fn exhaust_budget(test_case: &mut LeaseTestCase, lease: &Addr, budget: u8) {
             &mut test_case.app,
             &controller,
             lease,
-            RemoteLeaseCallback::OperationTimeout,
+            RemoteLeaseCallback {
+                nonce: 0,
+                outcome: RemoteOperationOutcome::OperationTimeout,
+            },
         );
     }
     assert_slippage_protection_activated(test_case, lease);

--- a/tests/src/lease/remote_lease_swap.rs
+++ b/tests/src/lease/remote_lease_swap.rs
@@ -40,6 +40,12 @@
 //! - `out_of_registry_ticker_absorbed_at_lease` — a success ack naming a
 //!   ticker outside the currency registry passes the controller
 //!   wire-shaped and is absorbed at the lease (`undecodable-response`).
+//! - `duplicate_ack_not_miscredited` — replaying a leg's superseded nonce
+//!   after the sequence advances is absorbed (`nonce-mismatch`); no second
+//!   leg is mis-credited (#636).
+//! - `heal_race_original_ack_absorbed` — a `Heal()` re-emits with a fresh
+//!   nonce; the original packet's late ack (old nonce) is absorbed while the
+//!   healed re-emission's ack (new nonce) credits exactly once (#636).
 
 use currencies::PaymentGroup;
 use currency::{CurrencyDef, MemberOf};
@@ -55,7 +61,7 @@ use lease::api::{
     query::{StateResponse, opening::OngoingTrx as OpeningOngoingTrx},
 };
 use remote_lease::{
-    callback::RemoteLeaseCallback,
+    callback::{RemoteLeaseCallback, RemoteOperationOutcome},
     response::{
         OperationResponse, SwapResponse, Ticker, TransferOutResponse, WireCoin,
         WireOperationResponse, WireSwapResponse,
@@ -251,12 +257,15 @@ fn swap_ack_in_transfer_leg_absorbed() {
     // a swap acknowledgment arrives while both transfer acknowledgments
     // are still outstanding - it must neither error nor advance the
     // transfer countdown
-    let unexpected = RemoteLeaseCallback::OperationOk(
-        OperationResponse::Swap(SwapResponse {
-            amount_out: Coin::<LeaseCurrency>::new(1).into(),
-        })
-        .into(),
-    );
+    let unexpected = RemoteLeaseCallback {
+        nonce: 0,
+        outcome: RemoteOperationOutcome::OperationOk(
+            OperationResponse::Swap(SwapResponse {
+                amount_out: Coin::<LeaseCurrency>::new(1).into(),
+            })
+            .into(),
+        ),
+    };
     let injected = stub::inject_callback(&mut test_case.app, &controller, &lease, unexpected);
     expect_attribute(&injected.events, ABSORB_EVENT, "absorbed", "response");
     assert_transfers_pending(&test_case, lease.clone());
@@ -296,9 +305,12 @@ fn wrong_variant_callback_absorbed_then_heal_recovers() {
     let _response = transfer_funds(&mut test_case, &lease, DOWNPAYMENT);
     assert_eq!(2, opening_acks_left(&test_case, lease.clone()));
 
-    let wrong_variant = RemoteLeaseCallback::OperationOk(WireOperationResponse::TransferOut(
-        TransferOutResponse {},
-    ));
+    let wrong_variant = RemoteLeaseCallback {
+        nonce: 0,
+        outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::TransferOut(
+            TransferOutResponse {},
+        )),
+    };
     let injected = stub::inject_callback(&mut test_case.app, &controller, &lease, wrong_variant);
     expect_attribute(
         &injected.events,
@@ -329,6 +341,149 @@ fn wrong_variant_callback_absorbed_then_heal_recovers() {
     let _amount = opened_amount(&test_case, lease);
 }
 
+// AC (#636): a stale/duplicate ack must not be miscredited. The first leg's
+// ack credits normally and the sequence advances; replaying that leg's (now
+// superseded) nonce after the advance is absorbed with `nonce-mismatch` - no
+// second leg is mis-credited, the countdown and the recorded-swap set are
+// unchanged.
+#[test]
+fn duplicate_ack_not_miscredited() {
+    let (mut test_case, lease, controller) = start_open(DOWNPAYMENT);
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+
+    let _response = transfer_funds(&mut test_case, &lease, DOWNPAYMENT);
+    assert_eq!(2, opening_acks_left(&test_case, lease.clone()));
+
+    // the first leg's ack credits normally and advances to the second leg
+    let _delivery = stub::deliver_pending_callback(&mut test_case.app, &controller, op_tag::SWAP);
+    assert_eq!(1, opening_acks_left(&test_case, lease.clone()));
+
+    let swaps_before = stub::recorded_swaps(&test_case.app, &controller, &lease).len();
+    let nonces = stub::recorded_swap_nonces(&test_case.app, &controller, &lease);
+    let stale_nonce = nonces[0];
+
+    // replay the first leg's now-superseded nonce with an otherwise-creditable
+    // amount: only the nonce check stops it from advancing the second leg
+    let duplicate = RemoteOperationOutcome::OperationOk(
+        OperationResponse::Swap(SwapResponse {
+            amount_out: Coin::<LeaseCurrency>::new(1_000).into(),
+        })
+        .into(),
+    );
+    let injected = stub::inject_callback_with_nonce(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        stale_nonce,
+        duplicate,
+    );
+    expect_attribute(
+        &injected.events,
+        OPENING_SWAP_EVENT,
+        "absorbed",
+        "nonce-mismatch",
+    );
+
+    // no second leg mis-credited: the countdown and the recorded-swap set are
+    // untouched by the stale duplicate
+    assert_eq!(1, opening_acks_left(&test_case, lease.clone()));
+    assert_eq!(
+        swaps_before,
+        stub::recorded_swaps(&test_case.app, &controller, &lease).len()
+    );
+}
+
+// AC (#636) - core race: an operator Heal() re-emits the in-flight leg with a
+// fresh nonce. The ORIGINAL packet's late ack (old nonce) is then absorbed
+// while the healed re-emission's ack (new nonce) is credited - proving no
+// double-credit when a heal races a still-resolvable original packet.
+#[test]
+fn heal_race_original_ack_absorbed() {
+    let (mut test_case, lease, controller) = start_open(DOWNPAYMENT);
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+
+    let _response = transfer_funds(&mut test_case, &lease, DOWNPAYMENT);
+    assert_eq!(2, opening_acks_left(&test_case, lease.clone()));
+    let original_nonce = stub::recorded_swap_nonces(&test_case.app, &controller, &lease)[0];
+
+    // the operator heals the still-in-flight leg, re-emitting it with a fresh
+    // nonce
+    let healed = test_case
+        .app
+        .execute(
+            testing::user(ADMIN),
+            lease.clone(),
+            &ExecuteMsg::Heal(),
+            &[],
+        )
+        .expect("heal must re-emit the in-flight leg")
+        .unwrap_response();
+    expect_attribute(&healed.events, OPENING_SWAP_EVENT, "heal", "re-emit");
+
+    let nonces = stub::recorded_swap_nonces(&test_case.app, &controller, &lease);
+    let healed_nonce = nonces[1];
+    assert!(
+        original_nonce < healed_nonce,
+        "heal must re-emit with a strictly greater nonce"
+    );
+
+    // the original packet's late ack carries the now-stale nonce → absorbed
+    let stale = RemoteOperationOutcome::OperationOk(
+        OperationResponse::Swap(SwapResponse {
+            amount_out: Coin::<LeaseCurrency>::new(1_000).into(),
+        })
+        .into(),
+    );
+    let injected = stub::inject_callback_with_nonce(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        original_nonce,
+        stale,
+    );
+    expect_attribute(
+        &injected.events,
+        OPENING_SWAP_EVENT,
+        "absorbed",
+        "nonce-mismatch",
+    );
+    assert_eq!(2, opening_acks_left(&test_case, lease.clone()));
+
+    // the healed re-emission's ack (fresh nonce) credits exactly once. The
+    // amount must clear the healed leg's pinned floor (`min_out`), or production
+    // would treat it as under-min-out and re-emit instead of crediting - the
+    // amount a real counterparty pays is always at or above that floor.
+    let healed_floor = stub::recorded_swaps(&test_case.app, &controller, &lease)
+        .last()
+        .expect("the healed re-emission was recorded")
+        .min_out()
+        .amount();
+    let fresh = RemoteOperationOutcome::OperationOk(
+        OperationResponse::Swap(SwapResponse {
+            amount_out: Coin::<LeaseCurrency>::new(healed_floor).into(),
+        })
+        .into(),
+    );
+    let _credited = stub::inject_callback_with_nonce(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        healed_nonce,
+        fresh,
+    );
+    assert_eq!(1, opening_acks_left(&test_case, lease.clone()));
+}
+
 // The controller forwards success acks wire-shaped (issue #637): a ticker
 // outside the currency registry reaches the lease, whose typed decode fails
 // and absorbs the callback - the controller's ack tx commits.
@@ -345,10 +500,14 @@ fn out_of_registry_ticker_absorbed_at_lease() {
     let _response = transfer_funds(&mut test_case, &lease, DOWNPAYMENT);
     assert_eq!(2, opening_acks_left(&test_case, lease.clone()));
 
-    let alien_ticker =
-        RemoteLeaseCallback::OperationOk(WireOperationResponse::Swap(WireSwapResponse {
-            amount_out: WireCoin::new(42, Ticker::new("NOT_IN_REGISTRY")),
-        }));
+    let alien_ticker = RemoteLeaseCallback {
+        nonce: 0,
+        outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::Swap(
+            WireSwapResponse {
+                amount_out: WireCoin::new(42, Ticker::new("NOT_IN_REGISTRY")),
+            },
+        )),
+    };
     let injected = stub::inject_callback(&mut test_case.app, &controller, &lease, alien_ticker);
     expect_attribute(
         &injected.events,

--- a/tests/src/lease/remote_lease_transfer_out.rs
+++ b/tests/src/lease/remote_lease_transfer_out.rs
@@ -48,7 +48,7 @@ use lease::{
     error::ContractError,
 };
 use remote_lease::{
-    callback::{RemoteErrorMessage, RemoteLeaseCallback},
+    callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
     response::{TransferOutResponse, WireOperationResponse},
 };
 use sdk::{
@@ -336,5 +336,10 @@ fn open_and_close(test_case: &mut LeaseTestCase) -> Addr {
 }
 
 fn transfer_out_ack() -> RemoteLeaseCallback {
-    RemoteLeaseCallback::OperationOk(WireOperationResponse::TransferOut(TransferOutResponse {}))
+    RemoteLeaseCallback {
+        nonce: 0,
+        outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::TransferOut(
+            TransferOutResponse {},
+        )),
+    }
 }


### PR DESCRIPTION
## What

Adds a per-emission `nonce: u64` to the remote-lease IBC `PacketEnvelope` so the lease correlates each operation callback (ack / error / timeout) to the exact in-flight emission, instead of positionally.

## Why

Acknowledgments were correlated to the lease's sequential single-coin swap legs *positionally* (the `acks_left` countdown). A duplicate or late callback — an operator `Heal()` re-emission racing the original packet's resolution — was credited to whatever leg was positionally current. The residual window: two consecutive legs sharing the input currency (the LPN-denominated downpayment).

IBC already binds each ack to its packet, and the controller already decodes the original outbound packet's envelope on ack/timeout — so closing this needs only an identifier that rides the envelope and returns through the callback, with no counterparty echo.

## How

- `PacketEnvelope` gains `nonce`, chosen by the lease per emission. Decoders treat it as `serde(default)` / optional-at-decode, so **no channel-version bump**.
- The controller reads the nonce back from its **own committed outbound packet** (never the counterparty's reply) on both ack and timeout, and returns it in `RemoteLeaseCallback { nonce, outcome }`.
- The dex `RemoteSwap` node holds a strictly-monotonic `in_flight_nonce`, bumped on every emission and re-emission (including `Heal()`), and absorbs any callback whose nonce differs from the in-flight one with a dedicated `nonce-mismatch` event — collapsing duplicate / out-of-order / re-emission-race callbacks into one rejected class and making `Heal()` idempotent.
- The slippage-anomaly terminal carries the nonce so a heal-from-parked re-emission bumps above the parked value rather than resetting.
- Non-swap operations (OpenLease / CloseLease / TransferOut) ride a zero nonce for now; they adopt matching when they convert (remaining ibc-solray#142 phases).

## Migration / compatibility

- Persisted `RemoteSwap` nodes from before this change load with `in_flight_nonce = 0`, matching the zero an old nonce-less in-flight packet decodes to.
- ⚠️ **Deploy ordering:** `serde(default)` protects the *decode* direction only. The Solana counterparty must tolerate the new envelope field (**ibc-solray#393**) **before** this controller starts emitting it, or it would reject inbound lease packets. Sequence: ibc-solray#393 first, this second.

## Tests

- Wire serde round-trip + optional-at-decode (typed + wire crates) and cross-surface byte-identity with a non-zero nonce.
- Controller forwards the original envelope's nonce on both ack and timeout (unit, against recorded packets).
- `RemoteSwap` nonce matching: a matching ack credits; a stale ack/error/timeout is absorbed (`nonce-mismatch`, node byte-identical); timeout-retry and heal bump the nonce; migration preserves it; a legacy node deserializes to zero.
- Integration drivers: a duplicate ack is not mis-credited, and a `Heal()` racing the original packet absorbs the stale ack while the healed re-emission credits exactly once.

Full gate green (build / format / lint / test) across the wire, controller, dex, lease, and integration workspaces. Reviewed for the standard bug checklist, security, and project-rule conformance; no correctness or security blockers found — the single operational item is the cross-repo deploy ordering noted above.

Closes #636.


## Review feedback — dispositions

Fixed:
- `with_bumped_nonce` now asserts `invariant_held()` after constructing the bumped node, matching `internal_new` and the invariant-after-mutation rule.
- The two wire-pin test headers now carve out the one exception to the must-bump-`VERSION` rule: an additive `#[serde(default)]` field (the nonce) extends the wire without a version bump.

Resolved without a code change (rationale):
- **`saturating_add` on the nonce at `u64::MAX`:** unreachable (2^64 emissions). `saturating_add` is the panic-free counter convention under the release `overflow-checks=true` profile; the only strictly-monotonic alternatives (panic / `Err`) would introduce a worse failure — a stranded leg — for a state that cannot occur. Monotonicity holds for every reachable state.
- **No `VERSION` bump for the new envelope / callback / `ExecuteMsg::Swap` field:** deliberate — `nonce` is additive and optional-at-decode (`serde(default)`). A version bump is operationally inert here (an un-upgraded decoder rejects an unknown field regardless of the version string); the cross-repo rollout is coordinated consumer-first (ibc-solray#393). The wire docs were updated alongside.
- **`state` test bindings in `remote_swap_only.rs`:** `state` is the established sibling convention for the dex composite `State` type (the documented Code-Style carve-out); renaming only the new bindings would break consistency with the existing uses in the same module.


_Update: a re-review re-flagged the wire-doc shape/version as a "design contract drift." The review docs are current (the wire-contract doc already reflects the `{nonce, outcome}` shape and the no-version-bump rationale); the re-flag came from an earlier docs snapshot. No change needed._
