### PR TITLE
feat(lease): bounded error terminal for the opening remote-swap leg

### DIFF
--- a/protocol/contracts/lease/src/api/query.rs
+++ b/protocol/contracts/lease/src/api/query.rs
@@ -108,6 +108,12 @@ pub mod opening {
         BuyAsset {
             acks_left: u8,
         },
+        /// A swap leg hit a hard remote error and parked at the
+        /// slippage-anomaly terminal; the lease is pre-`Active` and an
+        /// operator `Heal` re-drives the pending leg. Distinct from
+        /// `BuyAsset`, whose `acks_left` means a leg is still in flight
+        /// rather than frozen.
+        SlippageProtectionActivated,
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -38,7 +38,7 @@ use crate::{
             resp_delivery::{ForwardToDexEntry, ForwardToDexEntryContinue},
         },
     },
-    error::{ContractError, ContractResult},
+    error::ContractResult,
     event::Type,
     finance::{LppRef, OracleRef},
 };
@@ -58,11 +58,6 @@ const NON_SWAP_RESPONSE: &str = "non-swap operation response";
 const OUT_NOT_AN_ASSET: &str = "swapped-out currency is not a lease asset";
 
 const TIMEOUT_RETRY_BUDGET: CoinsNb = 3;
-
-/// The operation names the never-parking opening swap reports for the two
-/// slippage-anomaly trait methods it can never legitimately reach.
-const ANOMALY_RESOLUTION_OP: &str = "slippage-anomaly resolution";
-const ANOMALY_RESPONSE_OP: &str = "slippage-anomaly state query";
 
 type AssetGroup = LeaseAssetCurrencies;
 pub(super) type StartState = StartLocalRemoteState<OpenIcaAccount, BuyAsset>;
@@ -192,27 +187,23 @@ impl SwapTask for BuyAsset {
             .map_err(DexError::Unauthorized)
     }
 
-    /// The opening swap re-emits on a slippage anomaly and never parks, so the
-    /// heal that this authorisation guards is never reached. A deserialized
-    /// `SlippageAnomaly` arm is not type-excluded, so the unreachable path
-    /// returns a typed error rather than panicking.
     fn authz_anomaly_resolution(
         &self,
-        _querier: QuerierWrapper<'_>,
-        _info: &MessageInfo,
+        querier: QuerierWrapper<'_>,
+        info: &MessageInfo,
     ) -> dex::DexResult<()> {
-        Err(DexError::UnsupportedOperation(
-            ANOMALY_RESOLUTION_OP.into(),
-            String::from(self.label()),
-        ))
+        access_control::check(&self.deps.3.anomaly_resolution_permission(querier), info)
+            .map_err(DexError::Unauthorized)
     }
 
     fn timeout_retry_budget(&self) -> CoinsNb {
         TIMEOUT_RETRY_BUDGET
     }
 
-    /// The opening swap re-emits on a slippage anomaly and never parks - a
-    /// follow-up issue owns the opening-leg terminal (see issue #655).
+    /// The opening swap re-emits a timed-out leg verbatim rather than parking
+    /// it - it must make forward progress to open. An explicit error still
+    /// parks at the slippage-anomaly terminal (see `RemoteSwap::on_remote_error`);
+    /// this governs only the timeout path.
     fn slippage_escalation(&self) -> SlippageEscalation {
         SlippageEscalation::ReEmit
     }
@@ -327,10 +318,6 @@ impl ContractInRemoteSwap for BuyAsset {
         self.state(|_ica_account| OngoingTrx::BuyAsset { acks_left })
     }
 
-    /// The opening swap re-emits on a slippage anomaly and never parks, so a
-    /// persisted `SlippageAnomaly` arm for it can only be a corrupt or
-    /// out-of-protocol state. A deserialized state is not type-excluded, so
-    /// the unreachable path returns a typed error rather than panicking.
     fn anomaly_response(
         self,
         _acks_left: CoinsNb,
@@ -338,7 +325,7 @@ impl ContractInRemoteSwap for BuyAsset {
         _due_projection: Duration,
         _querier: QuerierWrapper<'_>,
     ) -> Self::StateResponse {
-        Err(ContractError::unsupported_operation(ANOMALY_RESPONSE_OP))
+        self.state(|_ica_account| OngoingTrx::SlippageProtectionActivated)
     }
 }
 

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -480,9 +480,10 @@ where
     Self: Into<SEnum>,
     SlippageAnomaly<SwapTask, SEnum>: Into<SEnum>,
 {
-    /// Escalate a spent in-flight leg per the spec's policy: park the opened
-    /// legs at the slippage-anomaly terminal, or re-emit the opening swap
-    /// verbatim.
+    /// Escalate a leg whose timeout retry budget is spent, per the spec's
+    /// policy: park the opened legs at the slippage-anomaly terminal, or
+    /// re-emit the opening swap verbatim. An explicit error never reaches
+    /// here - it parks unconditionally (see `on_remote_error`).
     fn escalate(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
         match self.spec.slippage_escalation() {
             SlippageEscalation::ReEmit => self.reemit_in_flight(querier, env),
@@ -547,26 +548,26 @@ where
         }
     }
 
-    /// An error on the in-flight leg escalates immediately - there is no
-    /// retry budget for an explicit under-floor rejection. Opened legs park
-    /// at the slippage-anomaly terminal; the opening swap re-emits verbatim,
-    /// the legacy error-equals-timeout behaviour, and never parks.
+    /// An explicit error on the in-flight leg is an under-floor rejection: it
+    /// parks at the slippage-anomaly terminal unconditionally, with no retry
+    /// budget and without consulting the spec's timeout escalation policy. An
+    /// operator `heal` re-drives the parked leg.
     ///
     /// Anomalies are deliberately not routed through the spec's `on_anomaly`,
     /// whose `Retry` treatment rebuilds the node from the spec and would
-    /// re-issue the already-acknowledged legs. Only the in-flight leg is
-    /// re-emitted, preserving the accumulated progress.
+    /// re-issue the already-acknowledged legs. Only the in-flight leg's
+    /// accumulated progress carries into the terminal.
     fn on_remote_error(
         self,
         _response: ICAErrorResponse,
         nonce: u64,
-        querier: QuerierWrapper<'_>,
-        env: Env,
+        _querier: QuerierWrapper<'_>,
+        _env: Env,
     ) -> HandlerResult<Self> {
         if nonce != self.in_flight_nonce {
             return self.absorb(ABSORB_NONCE_MISMATCH).into();
         }
-        self.with_incremented_errors().escalate(querier, env)
+        self.with_incremented_errors().park()
     }
 
     /// A timeout re-emits the in-flight leg up to the spec's per-op retry
@@ -1379,6 +1380,75 @@ mod tests {
         assert_terminal(1, &coin_out(80), &min_out(), &terminal);
     }
 
+    /// #638 (TARGET): an explicit error parks UNCONDITIONALLY at the
+    /// node level - even for a spec whose `slippage_escalation()` is
+    /// `ReEmit` (the opening swap). An under-floor rejection is a slippage
+    /// anomaly regardless of the spec's timeout-escalation policy, so the
+    /// in-flight leg freezes at the terminal rather than re-emitting.
+    ///
+    /// FAILS against the current code (a `ReEmit` spec re-emits on error via
+    /// `escalate`); the #638 change routes `on_remote_error` straight to
+    /// `park`, ignoring the spec policy.
+    #[test]
+    fn error_parks_even_when_spec_reemits() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+        let env = testing::mock_env();
+
+        let mut spec = spec3();
+        spec.set_reemit();
+        let (_response, node) = continued(Node::start(spec, &testing::mock_env(), querier));
+        let nonce = node.in_flight_nonce;
+        let (_response, node) = continued(node.on_remote_response(
+            payload(&coin_out(30)),
+            nonce,
+            querier,
+            testing::mock_env(),
+        ));
+
+        let nonce = node.in_flight_nonce;
+        let (response, terminal) = parked(node.on_remote_error(
+            ICAErrorResponse::from(String::from("opening swap under floor")),
+            nonce,
+            querier,
+            env,
+        ));
+        assert_eq!(parked_response(), response);
+        assert_terminal(1, &coin_out(80), &min_out(), &terminal);
+    }
+
+    /// #638 (D2 contrast): with a `ReEmit` spec a TIMEOUT still follows the
+    /// spec policy - it re-emits past the budget and never parks - while an
+    /// error parks (see `error_parks_even_when_spec_reemits`). Error and
+    /// timeout escalation are decoupled: the spec knob governs the
+    /// timeout-past-budget path only.
+    #[test]
+    fn timeout_reemits_when_spec_reemits() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let mut spec = spec3();
+        spec.set_reemit();
+        let (_response, node) = continued(Node::start(spec, &testing::mock_env(), querier));
+        let nonce = node.in_flight_nonce;
+        let (_response, mut node) = continued(node.on_remote_response(
+            payload(&coin_out(30)),
+            nonce,
+            querier,
+            testing::mock_env(),
+        ));
+
+        // re-emit well past the budget - a `ReEmit` spec never parks on timeout
+        let rounds = u16::from(mock_budget()) + 3;
+        for _ in 0..rounds {
+            let nonce = node.in_flight_nonce;
+            let (_response, next) =
+                continued(node.on_remote_timeout(nonce, querier, testing::mock_env()));
+            node = next;
+        }
+        assert_node(1, &coin_out(80), &min_out(), &node);
+    }
+
     #[test]
     fn garbage_payload_absorbed_without_state_change() {
         let mock_querier = MockQuerier::default();
@@ -1480,8 +1550,10 @@ mod tests {
         assert_terminal(1, &coin_out(80), &min_out(), &terminal);
     }
 
-    /// The opening swap escalation re-emits past the budget instead of
-    /// parking - opening keeps the legacy unbounded behaviour.
+    /// The `ReEmit` timeout-escalation policy re-emits past the budget
+    /// instead of parking - the opening swap keeps the legacy unbounded
+    /// behaviour on TIMEOUT (an error, by contrast, parks unconditionally
+    /// after #638 - see `error_parks_even_when_spec_reemits`).
     #[test]
     fn reemit_escalation_never_parks() {
         let mock_querier = MockQuerier::default();

--- a/protocol/packages/dex/src/swap_task.rs
+++ b/protocol/packages/dex/src/swap_task.rs
@@ -8,14 +8,16 @@ use crate::{Account, AnomalyTreatment, error::Result as DexResult, slippage::Wit
 
 pub type CoinsNb = u8;
 
-/// How a remote swap leg escalates a slippage anomaly once its in-flight
-/// leg keeps failing - an error, or a timeout past the per-op retry budget.
+/// How a remote swap leg escalates once its in-flight leg keeps timing out
+/// past the per-op retry budget. An explicit swap *error* is an under-floor
+/// rejection and parks unconditionally; this policy governs the timeout path
+/// only.
 pub enum SlippageEscalation {
-    /// Park the leg at the slippage-anomaly terminal: opened legs freeze and
-    /// wait for an operator heal instead of retrying forever.
+    /// Park the leg at the slippage-anomaly terminal: the leg freezes and
+    /// waits for an operator heal instead of retrying forever.
     Park,
     /// Re-emit the in-flight leg verbatim, unbounded: the opening swap keeps
-    /// the legacy behaviour - it has no terminal in this phase.
+    /// re-driving a timed-out leg rather than parking it.
     ReEmit,
 }
 
@@ -67,9 +69,10 @@ where
     /// before the slippage-anomaly terminal is entered.
     fn timeout_retry_budget(&self) -> CoinsNb;
 
-    /// How a slippage anomaly on this task's in-flight leg escalates once the
-    /// retry budget is spent - parking the opened legs while the opening swap
-    /// keeps re-emitting verbatim.
+    /// How this task's in-flight leg escalates once the timeout retry budget
+    /// is spent - parking the opened legs while the opening swap keeps
+    /// re-emitting verbatim. An explicit swap error parks unconditionally and
+    /// does not consult this.
     fn slippage_escalation(&self) -> SlippageEscalation;
 
     /// Provide the coins, at least one, this swap is about.

--- a/tests/src/lease/mod.rs
+++ b/tests/src/lease/mod.rs
@@ -46,6 +46,7 @@ mod remote_lease_callback;
 mod remote_lease_close;
 // TODO #142 Phase 3: enable when the OpenLease state + Status::OpenFailed land.
 mod remote_lease_open;
+mod remote_lease_opening_terminal;
 mod remote_lease_slippage_terminal;
 mod remote_lease_swap;
 mod remote_lease_transfer_out;

--- a/tests/src/lease/remote_lease_callback.rs
+++ b/tests/src/lease/remote_lease_callback.rs
@@ -92,7 +92,7 @@ fn operation_timeout_retries_the_in_flight_leg() {
 }
 
 #[test]
-fn operation_err_retries_the_in_flight_leg() {
+fn operation_err_parks_the_in_flight_leg() {
     let (mut test_case, lease) = drive_to_swap_pending();
     let controller = controller_addr(&test_case);
     let nonce = in_flight_nonce(&test_case, &controller, &lease);
@@ -109,10 +109,15 @@ fn operation_err_retries_the_in_flight_leg() {
             }),
             &[],
         )
-        .expect("authorised OperationErr must re-emit the leg and return Ok")
+        .expect("authorised OperationErr must park the leg and return Ok")
         .unwrap_response();
-    expect_attribute(&response.events, OPENING_SWAP_EVENT, "timeout", "retry");
-    assert_swap_pending(&test_case, lease);
+    expect_attribute(
+        &response.events,
+        OPENING_SWAP_EVENT,
+        "anomaly",
+        "slippage-anomaly-parked",
+    );
+    assert_parked(&test_case, lease);
 }
 
 #[test]
@@ -192,6 +197,16 @@ fn assert_swap_pending(test_case: &LeaseTestCase, lease: Addr) {
             ..
         } => assert_eq!(1, acks_left),
         other => panic!("expected the in-flight swap leg, got {other:?}"),
+    }
+}
+
+fn assert_parked(test_case: &LeaseTestCase, lease: Addr) {
+    match super::state_query(test_case, lease) {
+        StateResponse::Opening {
+            in_progress: OpeningOngoingTrx::SlippageProtectionActivated,
+            ..
+        } => {}
+        other => panic!("expected the parked opening leg, got {other:?}"),
     }
 }
 

--- a/tests/src/lease/remote_lease_open.rs
+++ b/tests/src/lease/remote_lease_open.rs
@@ -35,7 +35,15 @@ fn open_lifecycle_happy_path() {
     let remote_lease = match state {
         StateResponse::Opening { in_progress, .. } => match in_progress {
             OpeningOngoingTrx::OpenLease { remote_lease } => remote_lease,
-            other => panic!("expected OngoingTrx::OpenLease, got {other:?}"),
+            // #638 (FM4): the parked opening terminal is a distinct opening
+            // sub-state; name it so the happy path's expectation stays exact
+            // and a future variant is not silently caught by a wildcard.
+            in_progress @ (OpeningOngoingTrx::RequestingOpenLease
+            | OpeningOngoingTrx::TransferOut { .. }
+            | OpeningOngoingTrx::BuyAsset { .. }
+            | OpeningOngoingTrx::SlippageProtectionActivated) => {
+                panic!("expected OngoingTrx::OpenLease, got {in_progress:?}")
+            }
         },
         other => panic!("expected StateResponse::Opening, got {other:?}"),
     };

--- a/tests/src/lease/remote_lease_opening_terminal.rs
+++ b/tests/src/lease/remote_lease_opening_terminal.rs
@@ -1,0 +1,579 @@
+//! Slippage-anomaly terminal E2E for the OPENING remote-swap leg
+//! (`BuyAsset`, issue #638).
+//!
+//! The opening swap runs two sequential single-coin legs over the
+//! remote-lease controller: leg 1 the downpayment, leg 2 the loan
+//! principal, decrementing `acks_left` per acknowledgment. Today
+//! (pre-#638) an `OperationErr` on an opening leg re-emits the in-flight
+//! leg unbounded - there is no terminal, so an under-floor rejection
+//! retries forever. #638 reuses the opened-leg `SlippageAnomaly` terminal
+//! for the opening leg, parking it on a hard error:
+//!
+//! - an `OperationErr` parks the in-flight opening leg immediately at the
+//!   `SlippageProtectionActivated` terminal (no retry), preserving the
+//!   accumulated `total_out` of the already-acked legs (complete-forward),
+//! - an `OperationTimeout` is UNCHANGED - it re-emits the in-flight leg
+//!   verbatim, unbounded, never parking (D2: error and timeout are
+//!   structurally separate),
+//! - the parked opening leg is queryable as
+//!   `StateResponse::Opening { in_progress:
+//!   opening::OngoingTrx::SlippageProtectionActivated, .. }` and emits the
+//!   `slippage-anomaly-parked` event under the `wasm-ls-open-swap` label,
+//! - `Heal` is `lease_admin`-gated on the parked opening terminal: a
+//!   non-`lease_admin` caller is rejected `Unauthorized`, the lease admin
+//!   re-quotes the in-flight leg against the `opening` slippage bound and
+//!   re-drives it, preserving the already-acked proceeds, so the opening
+//!   completes into the live `Active` lease,
+//! - the terminal absorbs a late ack/err/timeout of the pre-park emission.
+//!
+//! These drivers exercise the stable public surface - `ExecuteMsg`
+//! (`Heal`, `RemoteLeaseCallback` via the controller stand-in), the
+//! `StateResponse` query, and the controller stub's response modes.
+//!
+//! The CHARACTERIZATION / failing-first test (#1,
+//! `opening_error_reemits_unbounded_today`) lives in the sibling
+//! `remote_lease_slippage_terminal` module instead - it must compile and
+//! PASS against the current code, while every test here references the
+//! post-#638 query variant `opening::OngoingTrx::SlippageProtectionActivated`
+//! and so will NOT compile until production lands.
+//!
+//! Test inventory (all TARGET API - do not compile until #638 lands):
+//!
+//! - `opening_error_parks` (#2), `opening_error_parks_emits_anomaly_event`
+//!   (#2), `opening_timeout_reemits_not_parks` (#3),
+//!   `parked_opening_absorbs_late_acks` (#4),
+//!   `opening_error_reason_dropped_on_park` (#5),
+//!   `heal_completes_forward_to_active` (#6),
+//!   `heal_rejects_non_lease_admin` (#7),
+//!   `leg_one_error_parks_forward_only` (#8),
+//!   `nonce_interleave_stale_error_absorbed_current_error_parks` (#9).
+
+use access_control::error::Error as AccessError;
+use dex::Error as DexError;
+use finance::{coin::Amount, zero::Zero};
+use lease::{
+    api::{
+        ExecuteMsg,
+        query::{StateResponse, opening::OngoingTrx as OpeningOngoingTrx},
+    },
+    error::ContractError,
+};
+use remote_lease::callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome};
+use remote_lease::response::{OperationResponse, SwapResponse};
+use sdk::{
+    cosmwasm_std::{Addr, Event},
+    cw_multi_test::AppResponse,
+    testing,
+};
+
+use crate::common::{
+    self, ADMIN, LEASE_ADMIN,
+    remote_lease_controller_stub::{self as stub, ResponseMode, op_tag},
+    test_case::TestCase,
+};
+
+use super::{DOWNPAYMENT, LeaseCoin, LeaseTestCase, LpnCurrency, PaymentCurrency};
+
+const OPENING_SWAP_EVENT: &str = "wasm-ls-open-swap";
+
+/// Far past any plausible retry budget - an opening leg with a terminal
+/// would have parked long before this many re-emissions.
+const UNBOUNDED_ROUNDS: u32 = 16;
+
+// === #2 error -> Park terminal ==========================================
+
+/// TARGET (#2): a deterministic `OperationErr` on the in-flight opening leg
+/// parks the lease at the `SlippageProtectionActivated` terminal in bounded
+/// steps - the error emits no further swap. (Behaviour assertion.)
+#[test]
+fn opening_error_parks() {
+    let (mut test_case, lease, controller) = start_opening_leg_two_in_flight();
+    let swaps_before = recorded_swap_count(&test_case, &lease);
+
+    inject_opening_error(&mut test_case, &controller, &lease, "under floor");
+
+    assert_eq!(
+        swaps_before,
+        recorded_swap_count(&test_case, &lease),
+        "an opening swap error must park, not re-emit",
+    );
+    assert_opening_slippage_protection_activated(&test_case, &lease);
+}
+
+/// TARGET (#2): the opening leg parks under the opening swap event label
+/// (`wasm-ls-open-swap`) with the on-entry `slippage-anomaly-parked` reason.
+#[test]
+fn opening_error_parks_emits_anomaly_event() {
+    let (mut test_case, lease, controller) = start_opening_leg_two_in_flight();
+
+    let parked = inject_opening_error(&mut test_case, &controller, &lease, "under floor");
+
+    expect_attribute(
+        &parked.events,
+        OPENING_SWAP_EVENT,
+        "anomaly",
+        "slippage-anomaly-parked",
+    );
+}
+
+// === #3 error != timeout (D2) ===========================================
+
+/// TARGET (#3, D2): an `OperationTimeout` on the in-flight opening leg keeps
+/// re-emitting verbatim, unbounded past any retry budget, and never parks -
+/// contrasting #2 (error parks). Error and timeout stay structurally
+/// separate.
+#[test]
+fn opening_timeout_reemits_not_parks() {
+    let (mut test_case, lease, controller) = start_opening_leg_two_in_flight();
+    let swaps_before = recorded_swap_count(&test_case, &lease);
+
+    for _ in 0..UNBOUNDED_ROUNDS {
+        let _reemit = stub::inject_callback(
+            &mut test_case.app,
+            &controller,
+            &lease,
+            RemoteLeaseCallback {
+                nonce: 0,
+                outcome: RemoteOperationOutcome::OperationTimeout,
+            },
+        );
+    }
+
+    assert_eq!(
+        swaps_before + UNBOUNDED_ROUNDS,
+        recorded_swap_count(&test_case, &lease),
+        "every opening timeout must re-emit - opening never parks on timeout (D2)",
+    );
+    assert_opening_swap_in_flight(&test_case, &lease);
+}
+
+// === #4 terminal absorbs late acks ======================================
+
+/// TARGET (#4): after the opening leg parks, a late ack of the pre-park
+/// emission (carrying the parked leg's nonce) is absorbed with a
+/// `parked-response` reason and does NOT re-credit or leave the terminal.
+#[test]
+fn parked_opening_absorbs_late_acks() {
+    let (mut test_case, lease, controller) = start_opening_leg_two_in_flight();
+    inject_opening_error(&mut test_case, &controller, &lease, "under floor");
+    let swaps_after_park = recorded_swap_count(&test_case, &lease);
+
+    // a late OK ack of the original parked packet (the stand-in stamps the
+    // parked leg's in-flight nonce) is absorbed, not re-credited
+    let late_ok = stub::inject_callback(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(
+                OperationResponse::Swap(SwapResponse {
+                    amount_out: super::LeaseCoin::new(1_000).into(),
+                })
+                .into(),
+            ),
+        },
+    );
+    expect_attribute(&late_ok.events, OPENING_SWAP_EVENT, "absorbed", "parked-response");
+
+    // a late error of the original packet is absorbed too
+    let reason = RemoteErrorMessage::new("late error").expect("within length cap");
+    let late_err = stub::inject_callback(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(reason),
+        },
+    );
+    expect_attribute(&late_err.events, OPENING_SWAP_EVENT, "absorbed", "parked-error");
+
+    // neither absorbed callback re-emitted or left the terminal
+    assert_eq!(
+        swaps_after_park,
+        recorded_swap_count(&test_case, &lease),
+        "an absorbed late callback must not re-emit",
+    );
+    assert_opening_slippage_protection_activated(&test_case, &lease);
+}
+
+// === #5 bounded / dropped error reason ==================================
+
+/// TARGET (#5): the counterparty error message is bounded to
+/// `OPERATION_ERR_MAX_BYTES` at the wire boundary (the type rejects an
+/// over-cap construction) and is DROPPED on the park path - the parked
+/// event surfaces no counterparty-controlled `reason` attribute, so a
+/// hostile counterparty cannot inflate events/storage through a parked
+/// opening leg.
+#[test]
+fn opening_error_reason_dropped_on_park() {
+    use remote_lease::callback::OPERATION_ERR_MAX_BYTES;
+
+    // the wire type refuses to carry an over-cap reason: it never reaches
+    // the lease in the first place
+    let over_cap = "x".repeat(OPERATION_ERR_MAX_BYTES + 1);
+    assert!(
+        RemoteErrorMessage::new(over_cap).is_err(),
+        "an over-cap counterparty reason must be rejected at the wire boundary",
+    );
+
+    // a within-cap but distinctive reason is dropped on park: the parked
+    // event carries no `reason` attribute
+    let (mut test_case, lease, controller) = start_opening_leg_two_in_flight();
+    let secret = "counterparty-controlled-leak";
+    let parked = inject_opening_error(&mut test_case, &controller, &lease, secret);
+
+    let parked_event = parked
+        .events
+        .iter()
+        .find(|event| event.ty == OPENING_SWAP_EVENT)
+        .expect("the park must emit under the opening swap label");
+    assert!(
+        parked_event
+            .attributes
+            .iter()
+            .all(|attr| attr.value != secret),
+        "the counterparty error reason must be dropped on park, got {parked_event:?}",
+    );
+}
+
+// === #6 heal complete-forward (LEASE_ADMIN) =============================
+
+/// TARGET (#6): leg 1 acks (total_out > 0), leg 2 errors -> parks. The lease
+/// admin heals: leg 2 is re-emitted with leg 1's proceeds preserved
+/// (complete-forward) and acks, driving the opening to the live `Opened`
+/// lease. The heal re-quotes a fresh leg (a strictly greater nonce, a floor
+/// freshly pinned against the `opening` bound).
+#[test]
+fn heal_completes_forward_to_active() {
+    let (mut test_case, lease, controller) = start_opening_leg_two_in_flight();
+    let total_before = recorded_total_out(&test_case, &lease);
+    assert!(
+        total_before > LeaseCoin::ZERO,
+        "leg 1 must have acked with non-zero proceeds before leg 2 parks",
+    );
+
+    inject_opening_error(&mut test_case, &controller, &lease, "under floor");
+    assert_opening_slippage_protection_activated(&test_case, &lease);
+
+    let nonce_before = latest_swap_nonce(&test_case, &lease);
+
+    // re-emitted legs ack inline under the default `Ok` mode
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Ok,
+    );
+    let healed = test_case
+        .app
+        .execute(
+            testing::user(LEASE_ADMIN),
+            lease.clone(),
+            &ExecuteMsg::Heal(),
+            &[],
+        )
+        .expect("the lease admin must heal a parked opening lease")
+        .unwrap_response();
+    expect_attribute(&healed.events, OPENING_SWAP_EVENT, "heal", "re-emit");
+
+    // the heal re-quoted: a fresh emission with a strictly greater nonce
+    let nonce_after = latest_swap_nonce(&test_case, &lease);
+    assert!(
+        nonce_before < nonce_after,
+        "the heal must re-emit with a strictly greater nonce, was {nonce_before}, now {nonce_after}",
+    );
+
+    // complete-forward: leg 1's proceeds were preserved, so the opened
+    // amount is at least what leg 1 had already accumulated and the lease is
+    // live
+    let opened = opened_amount(&test_case, &lease);
+    assert!(
+        opened >= total_before,
+        "the opened amount must preserve leg 1's proceeds, leg1 {total_before}, opened {opened}",
+    );
+}
+
+// === #7 negative authz ==================================================
+
+/// TARGET (#7): a `Heal` of a parked opening lease from a non-`lease_admin`
+/// caller is rejected `Unauthorized` and leaves the lease parked. Mirrors
+/// the opened-leg `heal_rejects_unauthorised_operator`; `ADMIN` is the
+/// protocol admin, NOT the lease admin, so it must be rejected.
+#[test]
+fn heal_rejects_non_lease_admin() {
+    let (mut test_case, lease, controller) = start_opening_leg_two_in_flight();
+    inject_opening_error(&mut test_case, &controller, &lease, "under floor");
+
+    let err = test_case
+        .app
+        .execute(testing::user(ADMIN), lease.clone(), &ExecuteMsg::Heal(), &[])
+        .expect_err("a non-lease-admin heal of a parked opening lease must be rejected");
+    assert!(
+        matches!(
+            err.downcast_ref::<ContractError>(),
+            Some(ContractError::DexError(DexError::Unauthorized(
+                AccessError::Unauthorized {}
+            )))
+        ),
+        "expected DexError::Unauthorized, got {err:?}",
+    );
+    assert_opening_slippage_protection_activated(&test_case, &lease);
+}
+
+// === #8 leg-1 forward-only park =========================================
+
+/// TARGET (#8, Ivan's uniform-park decision): an `OperationErr` on LEG 1
+/// (the downpayment leg, total_out == 0) parks forward-only - it must reach
+/// the queryable terminal, NOT a clean refund and NOT `OpenFailed`. This
+/// locks in the uniform-park decision so a future "add a refund for leg 1"
+/// change is caught as a regression.
+#[test]
+fn leg_one_error_parks_forward_only() {
+    let (mut test_case, lease, controller) = start_opening_leg_one_in_flight();
+    let total_before = recorded_total_out(&test_case, &lease);
+    assert_eq!(
+        LeaseCoin::ZERO,
+        total_before,
+        "leg 1 parks with no acked proceeds yet (total_out == 0)",
+    );
+
+    inject_opening_error(&mut test_case, &controller, &lease, "downpayment leg under floor");
+
+    // forward-only park: a queryable terminal, NOT a refund / OpenFailed
+    match super::state_query(&test_case, lease.clone()) {
+        StateResponse::Opening {
+            in_progress: OpeningOngoingTrx::SlippageProtectionActivated,
+            ..
+        } => (),
+        StateResponse::OpenFailed { .. } => {
+            panic!("leg 1 must PARK forward-only, not refund into OpenFailed")
+        }
+        other => panic!("expected the parked opening terminal, got {other:?}"),
+    }
+}
+
+// === #9 nonce interleave ================================================
+
+/// TARGET (#9): an opening timeout re-emits with a bumped nonce (N -> N+1);
+/// a stale-nonce (N) error then arrives and is absorbed as `nonce-mismatch`
+/// (NOT parked - it resolves a superseded packet); a current-nonce (N+1)
+/// error then PARKS. Proves error-park is gated on the live in-flight nonce.
+#[test]
+fn nonce_interleave_stale_error_absorbed_current_error_parks() {
+    let (mut test_case, lease, controller) = start_opening_leg_two_in_flight();
+    let stale_nonce = latest_swap_nonce(&test_case, &lease);
+
+    // a timeout re-emits the in-flight leg with a strictly greater nonce
+    let _reemit = stub::inject_callback(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationTimeout,
+        },
+    );
+    let current_nonce = latest_swap_nonce(&test_case, &lease);
+    assert!(
+        stale_nonce < current_nonce,
+        "the timeout re-emission must bump the nonce, was {stale_nonce}, now {current_nonce}",
+    );
+    let swaps_after_reemit = recorded_swap_count(&test_case, &lease);
+
+    // a stale-nonce error resolves the superseded packet -> absorbed, NOT
+    // parked
+    let stale_reason = RemoteErrorMessage::new("superseded error").expect("within length cap");
+    let stale_err = stub::inject_callback_with_nonce(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        stale_nonce,
+        RemoteOperationOutcome::OperationErr(stale_reason),
+    );
+    expect_attribute(&stale_err.events, OPENING_SWAP_EVENT, "absorbed", "nonce-mismatch");
+    assert_eq!(
+        swaps_after_reemit,
+        recorded_swap_count(&test_case, &lease),
+        "a stale-nonce error must be absorbed, not re-emit or park",
+    );
+    assert_opening_swap_in_flight(&test_case, &lease);
+
+    // a current-nonce error parks
+    let current_reason = RemoteErrorMessage::new("under floor").expect("within length cap");
+    let _park = stub::inject_callback_with_nonce(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        current_nonce,
+        RemoteOperationOutcome::OperationErr(current_reason),
+    );
+    assert_opening_slippage_protection_activated(&test_case, &lease);
+}
+
+// === drivers ============================================================
+
+fn create_test_case() -> LeaseTestCase {
+    super::create_test_case::<PaymentCurrency>()
+}
+
+/// Open a lease, hold the opening swaps in flight via `Delayed`, and ack
+/// leg 1 so leg 2 (the loan-principal leg, total_out > 0) is the in-flight
+/// leg. Returns with leg 2 outstanding.
+fn start_opening_leg_two_in_flight() -> (LeaseTestCase, Addr, Addr) {
+    let (mut test_case, lease, controller) = start_opening_leg_one_in_flight();
+
+    // ack leg 1: advances to leg 2, which is also held by `Delayed`
+    let _leg_one_ack =
+        stub::deliver_pending_callback(&mut test_case.app, &controller, op_tag::SWAP);
+    assert_eq!(
+        1,
+        opening_acks_left(&test_case, &lease),
+        "leg 1 must have acked, leaving leg 2 in flight",
+    );
+
+    (test_case, lease, controller)
+}
+
+/// Open a lease and hold the opening swaps in flight via the `Delayed` SWAP
+/// mode, with leg 1 (the downpayment leg, total_out == 0) outstanding.
+fn start_opening_leg_one_in_flight() -> (LeaseTestCase, Addr, Addr) {
+    let mut test_case = create_test_case();
+    let lease = super::try_init_lease(&mut test_case, DOWNPAYMENT, None);
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+
+    let ica_addr = TestCase::ica_addr(&lease, TestCase::LEASE_ICA_ID);
+    let ica_port = format!("icacontroller-{ica_addr}");
+    let ica_channel = format!("channel-{ica_addr}");
+    let exp_borrow = super::quote_borrow(&test_case, DOWNPAYMENT);
+    let _ = common::lease::confirm_ica_and_transfer_funds::<PaymentCurrency, LpnCurrency>(
+        &mut test_case.app,
+        lease.clone(),
+        TestCase::DEX_CONNECTION_ID,
+        (&ica_channel, &ica_port, ica_addr),
+        (DOWNPAYMENT, exp_borrow),
+    )
+    .unwrap_response();
+
+    assert_eq!(
+        2,
+        opening_acks_left(&test_case, &lease),
+        "both opening legs must be outstanding with leg 1 in flight",
+    );
+    (test_case, lease, controller)
+}
+
+/// Inject a deterministic `OperationErr` carrying the lease's current
+/// in-flight swap nonce (the stand-in stamps the last recorded nonce).
+fn inject_opening_error(
+    test_case: &mut LeaseTestCase,
+    controller: &Addr,
+    lease: &Addr,
+    reason: &str,
+) -> AppResponse {
+    let reason = RemoteErrorMessage::new(reason.to_owned()).expect("within length cap");
+    stub::inject_callback(
+        &mut test_case.app,
+        controller,
+        lease,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(reason),
+        },
+    )
+}
+
+// === query / recorder helpers ===========================================
+
+fn recorded_swap_count(test_case: &LeaseTestCase, lease: &Addr) -> u32 {
+    let controller = test_case.address_book.remote_lease_controller();
+    stub::recorded_swaps(&test_case.app, controller, lease)
+        .len()
+        .try_into()
+        .expect("swap count fits u32")
+}
+
+/// The sum of the `min_out` floors of every recorded swap leg - the
+/// accumulated proceeds an opening leg credits at the literal floor. Leg 1
+/// acked credits its floor; leg 2 not yet acked contributes nothing to the
+/// node's `total_out`, but the recorded floors are the test-side mirror of
+/// the proceeds threaded through the park.
+fn recorded_total_out(test_case: &LeaseTestCase, lease: &Addr) -> LeaseCoin {
+    let controller = test_case.address_book.remote_lease_controller();
+    let acks_left = opening_acks_left(test_case, lease);
+    let swaps = stub::recorded_swaps(&test_case.app, controller, lease);
+    // acked legs are every recorded leg except the in-flight (last) one
+    let acked = swaps.len().saturating_sub(usize::from(acks_left));
+    let summed: Amount = swaps
+        .iter()
+        .take(acked)
+        .map(|params| params.min_out().amount())
+        .sum();
+    LeaseCoin::new(summed)
+}
+
+fn latest_swap_nonce(test_case: &LeaseTestCase, lease: &Addr) -> u64 {
+    let controller = test_case.address_book.remote_lease_controller();
+    *stub::recorded_swap_nonces(&test_case.app, controller, lease)
+        .last()
+        .expect("at least one swap recorded")
+}
+
+fn opening_acks_left(test_case: &LeaseTestCase, lease: &Addr) -> u8 {
+    match super::state_query(test_case, lease.clone()) {
+        StateResponse::Opening {
+            in_progress: OpeningOngoingTrx::BuyAsset { acks_left },
+            ..
+        } => acks_left,
+        other => panic!("expected the in-flight opening swap leg, got {other:?}"),
+    }
+}
+
+fn opened_amount(test_case: &LeaseTestCase, lease: &Addr) -> LeaseCoin {
+    match super::state_query(test_case, lease.clone()) {
+        StateResponse::Opened { amount, .. } => amount.try_into().unwrap(),
+        other => panic!("expected an opened lease, got {other:?}"),
+    }
+}
+
+#[track_caller]
+fn assert_opening_slippage_protection_activated(test_case: &LeaseTestCase, lease: &Addr) {
+    match super::state_query(test_case, lease.clone()) {
+        StateResponse::Opening {
+            in_progress: OpeningOngoingTrx::SlippageProtectionActivated,
+            ..
+        } => (),
+        other => panic!("expected the parked opening slippage-anomaly terminal, got {other:?}"),
+    }
+}
+
+#[track_caller]
+fn assert_opening_swap_in_flight(test_case: &LeaseTestCase, lease: &Addr) {
+    match super::state_query(test_case, lease.clone()) {
+        StateResponse::Opening {
+            in_progress: OpeningOngoingTrx::BuyAsset { .. },
+            ..
+        } => (),
+        other => panic!("expected the opening swap in flight, got {other:?}"),
+    }
+}
+
+fn expect_attribute(events: &[Event], event_type: &str, key: &str, value: &str) {
+    assert!(
+        events.iter().any(|event| {
+            event.ty == event_type
+                && event
+                    .attributes
+                    .iter()
+                    .any(|attr| attr.key == key && attr.value == value)
+        }),
+        "expected event `{event_type}` with `{key} = {value}`, got {events:?}",
+    );
+}

--- a/tests/src/lease/remote_lease_opening_terminal.rs
+++ b/tests/src/lease/remote_lease_opening_terminal.rs
@@ -174,7 +174,12 @@ fn parked_opening_absorbs_late_acks() {
             ),
         },
     );
-    expect_attribute(&late_ok.events, OPENING_SWAP_EVENT, "absorbed", "parked-response");
+    expect_attribute(
+        &late_ok.events,
+        OPENING_SWAP_EVENT,
+        "absorbed",
+        "parked-response",
+    );
 
     // a late error of the original packet is absorbed too
     let reason = RemoteErrorMessage::new("late error").expect("within length cap");
@@ -187,7 +192,12 @@ fn parked_opening_absorbs_late_acks() {
             outcome: RemoteOperationOutcome::OperationErr(reason),
         },
     );
-    expect_attribute(&late_err.events, OPENING_SWAP_EVENT, "absorbed", "parked-error");
+    expect_attribute(
+        &late_err.events,
+        OPENING_SWAP_EVENT,
+        "absorbed",
+        "parked-error",
+    );
 
     // neither absorbed callback re-emitted or left the terminal
     assert_eq!(
@@ -308,7 +318,12 @@ fn heal_rejects_non_lease_admin() {
 
     let err = test_case
         .app
-        .execute(testing::user(ADMIN), lease.clone(), &ExecuteMsg::Heal(), &[])
+        .execute(
+            testing::user(ADMIN),
+            lease.clone(),
+            &ExecuteMsg::Heal(),
+            &[],
+        )
         .expect_err("a non-lease-admin heal of a parked opening lease must be rejected");
     assert!(
         matches!(
@@ -339,7 +354,12 @@ fn leg_one_error_parks_forward_only() {
         "leg 1 parks with no acked proceeds yet (total_out == 0)",
     );
 
-    inject_opening_error(&mut test_case, &controller, &lease, "downpayment leg under floor");
+    inject_opening_error(
+        &mut test_case,
+        &controller,
+        &lease,
+        "downpayment leg under floor",
+    );
 
     // forward-only park: a queryable terminal, NOT a refund / OpenFailed
     match super::state_query(&test_case, lease.clone()) {
@@ -392,7 +412,12 @@ fn nonce_interleave_stale_error_absorbed_current_error_parks() {
         stale_nonce,
         RemoteOperationOutcome::OperationErr(stale_reason),
     );
-    expect_attribute(&stale_err.events, OPENING_SWAP_EVENT, "absorbed", "nonce-mismatch");
+    expect_attribute(
+        &stale_err.events,
+        OPENING_SWAP_EVENT,
+        "absorbed",
+        "nonce-mismatch",
+    );
     assert_eq!(
         swaps_after_reemit,
         recorded_swap_count(&test_case, &lease),

--- a/tests/src/lease/remote_lease_slippage_terminal.rs
+++ b/tests/src/lease/remote_lease_slippage_terminal.rs
@@ -341,16 +341,17 @@ fn buy_asset_timeout_reemits_unbounded() {
     assert_opening_swap_in_flight(&test_case, &lease);
 }
 
-/// An `OperationErr` on an opening-swap leg re-emits verbatim (the legacy
-/// error==timeout behaviour) - opening is byte-identical to today.
+/// An `OperationErr` on an opening-swap leg parks at the slippage-anomaly
+/// terminal instead of re-emitting (#638); the error and timeout paths are
+/// structurally separate - the opening timeout still re-emits unbounded.
 /// Regression guard.
 #[test]
-fn buy_asset_error_reemits() {
+fn buy_asset_error_parks() {
     let (mut test_case, lease, controller) = start_open_with_delayed_swap();
     let swaps_before = recorded_swap_count(&test_case, &lease);
 
     let reason = RemoteErrorMessage::new("opening swap failed").expect("within length cap");
-    let _reemit = stub::inject_callback(
+    let _parked = stub::inject_callback(
         &mut test_case.app,
         &controller,
         &lease,
@@ -361,11 +362,11 @@ fn buy_asset_error_reemits() {
     );
 
     assert_eq!(
-        swaps_before + 1,
+        swaps_before,
         recorded_swap_count(&test_case, &lease),
-        "an opening swap error must re-emit, not park"
+        "an opening swap error must park, not re-emit"
     );
-    assert_opening_swap_in_flight(&test_case, &lease);
+    assert_opening_parked(&test_case, &lease);
 }
 
 // === drivers =============================================================
@@ -665,6 +666,18 @@ fn assert_opening_swap_in_flight(test_case: &LeaseTestCase, lease: &Addr) {
             ..
         } => (),
         other => panic!("expected the opening swap in flight, got {other:?}"),
+    }
+}
+
+#[track_caller]
+fn assert_opening_parked(test_case: &LeaseTestCase, lease: &Addr) {
+    use lease::api::query::opening::OngoingTrx;
+    match super::state_query(test_case, lease.clone()) {
+        StateResponse::Opening {
+            in_progress: OngoingTrx::SlippageProtectionActivated,
+            ..
+        } => (),
+        other => panic!("expected the parked opening leg, got {other:?}"),
     }
 }
 


### PR DESCRIPTION
## What
The opening lease swap was the last remote-swap leg without a failure terminal:
a hard `OperationErr` collapsed into the timeout re-emission, so a deterministic
under-floor rejection re-emitted forever at relayer speed with no recovery state.

Route an explicit error to the existing `SlippageAnomaly` terminal:

- The error path parks **unconditionally** for every remote-swap leg; the per-spec
  escalation knob now governs only the **timeout-past-budget** path, so the opening
  leg keeps re-emitting a timed-out leg verbatim and the opened legs are unchanged.
- A parked opening leg is queryable as
  `StateResponse::Opening { in_progress: SlippageProtectionActivated }`.
- `Heal` of the parked terminal is `lease_admin`-gated; it re-quotes against the
  `opening` max-slippage bound and completes forward, preserving acked proceeds.
- A first-leg (downpayment) error parks with no proceeds and likewise completes
  forward on heal — there is no refund from a parked swap leg.
- The counterparty error message is dropped, never stored or echoed.

No new persisted state variant (reuses the terminal from #659); no wire/cross-repo change.

## Tests
- dex node: error parks even when the spec re-emits on timeout; timeout still re-emits.
- opening leg E2E: error→park, timeout→re-emit, late-ack absorption, bounded error
  reason, `lease_admin` heal-complete-forward, unauthorized-heal rejection, first-leg
  forward-only park, nonce-interleave race — all through the public `ExecuteMsg` and
  query surface.
- updated the prior opening-error regression guards from re-emit to park.

## Operational note
Once deployed, a parked-opening lease makes the lease code-id forward-only for
serviceability (an older code-id loads the state but rejects its query and heal).
Gate any rollback on zero parked-opening leases.

## Follow-up (out of scope)
The new `Opening::SlippageProtectionActivated` query response will be rejected by
strict deserializers that don't yet know the variant; downstream lease-state
consumers should learn it before a parked-opening lease appears.

Closes #638.

## Design note — nonce idempotency bound
The per-emission swap nonce bumps by one (`saturating_add(1)`) on every
emission / re-emission / heal. The opening-terminal tests assert a strictly-greater
nonce after a heal or re-emission, which holds for every reachable state — reaching
`u64::MAX` would take ~1.8e19 single-leg IBC emissions, unreachable in practice.
`saturating_add` is the deliberate defensive choice: wrapping would collide with the
`0` / first-leg sentinel and `checked_add` would strand the leg. The strict-monotonic
assertion and the `nonce-mismatch` stale-callback absorption therefore hold for all
reachable nonces; the `u64::MAX` boundary is intentionally not tested.
