### PR TITLE
refactor: replace Uint64 code ids with a validated external::Code wrapper

### DIFF
--- a/platform/contracts/admin/src/contracts/impl_mod.rs
+++ b/platform/contracts/admin/src/contracts/impl_mod.rs
@@ -1,6 +1,10 @@
 use serde::{Serialize, de::DeserializeOwned};
 
-use platform::{batch::Batch, message::Response as MessageResponse};
+use platform::{
+    batch::Batch,
+    contract::{self, CodeId, external},
+    message::Response as MessageResponse,
+};
 use sdk::cosmwasm_std::{self, Addr, Binary, QuerierWrapper, Storage, WasmMsg};
 use versioning::{
     MigrationMessage, PlatformPackageRelease, ProtocolPackageRelease, ProtocolPackageReleaseId,
@@ -62,7 +66,7 @@ where
     Package: UpdatablePackage + Serialize + DeserializeOwned,
     Package::ReleaseId: Serialize,
 {
-    schedule_migration_message::<Package>(
+    validate_and_schedule_migration::<Package>(
         querier,
         migration_batch,
         address.clone(),
@@ -71,13 +75,44 @@ where
         migrate_message,
     )
     .and_then(|()| {
-        post_migrate_execute.map_or(const { Ok(()) }, |post_migrate_execute_msg| {
-            schedule_execute_message(
-                post_migration_execute_batch,
+        schedule_post_migrate_execute(post_migration_execute_batch, address, post_migrate_execute)
+    })
+}
+
+fn validate_and_schedule_migration<Package>(
+    querier: QuerierWrapper<'_>,
+    migration_batch: &mut Batch,
+    address: Addr,
+    to_release: <Package as UpdatablePackage>::ReleaseId,
+    code_id: external::Code,
+    migrate_message: json_value::JsonValue,
+) -> Result<()>
+where
+    Package: UpdatablePackage + Serialize + DeserializeOwned,
+    Package::ReleaseId: Serialize,
+{
+    code_id
+        .try_validate(&contract::validator(querier))
+        .map_err(Into::into)
+        .and_then(|code_id| {
+            schedule_migration_message::<Package>(
+                querier,
+                migration_batch,
                 address,
-                post_migrate_execute_msg,
+                to_release,
+                CodeId::from(code_id),
+                migrate_message,
             )
         })
+}
+
+fn schedule_post_migrate_execute(
+    batch: &mut Batch,
+    address: Addr,
+    post_migrate_execute: Option<ExecuteSpec>,
+) -> Result<()> {
+    post_migrate_execute.map_or(const { Ok(()) }, |post_migrate_execute_msg| {
+        schedule_execute_message(batch, address, post_migrate_execute_msg)
     })
 }
 
@@ -284,7 +319,7 @@ fn schedule_migration_message<Package>(
     migration_batch: &mut Batch,
     address: Addr,
     to_release: <Package as UpdatablePackage>::ReleaseId,
-    code_id: cosmwasm_std::Uint64,
+    code_id: CodeId,
     migrate_message: json_value::JsonValue,
 ) -> Result<()>
 where
@@ -303,7 +338,7 @@ where
         .map(|message| {
             migration_batch.schedule_execute_no_reply(WasmMsg::Migrate {
                 contract_addr: address.into_string(),
-                new_code_id: code_id.u64(),
+                new_code_id: code_id,
                 msg: Binary::new(message),
             })
         })

--- a/platform/contracts/admin/src/contracts/mod.rs
+++ b/platform/contracts/admin/src/contracts/mod.rs
@@ -2,9 +2,9 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use ::platform::contract::CodeId;
+use ::platform::contract::external;
 use json_value::JsonValue;
-use sdk::cosmwasm_std::{Addr, Uint64};
+use sdk::cosmwasm_std::Addr;
 use versioning::ReleaseId;
 
 #[cfg(feature = "contract")]
@@ -109,12 +109,8 @@ pub type ContractsExecute =
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
-pub struct MigrationSpec
-where
-    Uint64: Into<CodeId>,
-    CodeId: Into<Uint64>,
-{
-    pub code_id: Uint64,
+pub struct MigrationSpec {
+    pub code_id: external::Code,
     pub migrate_message: JsonValue,
     pub post_migrate_execute: Option<ExecuteSpec>,
 }

--- a/platform/contracts/admin/src/endpoints.rs
+++ b/platform/contracts/admin/src/endpoints.rs
@@ -1,5 +1,9 @@
 use access_control::ContractOwnerAccess;
-use platform::{batch::Batch, response};
+use platform::{
+    batch::Batch,
+    contract::{self, CodeId},
+    response,
+};
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
     cosmwasm_std::{
@@ -83,14 +87,16 @@ pub fn execute(
         } => {
             ensure_sender_is_owner(deps.storage, &info)?;
 
-            ExpectedInstantiation::new(code_id.u64(), expected_address).store(deps.storage)?;
+            let code_id = CodeId::from(code_id.try_validate(&contract::validator(deps.querier))?);
+
+            ExpectedInstantiation::new(code_id, expected_address).store(deps.storage)?;
 
             let mut batch: Batch = Batch::default();
 
             batch.schedule_execute_reply_on_success(
                 WasmMsg::Instantiate2 {
                     admin: Some(env.contract.address.into_string()),
-                    code_id: code_id.u64(),
+                    code_id,
                     label,
                     msg: Binary::new(message.into_bytes()),
                     funds: info.funds,
@@ -159,8 +165,9 @@ pub fn reply(deps: DepsMut<'_>, _: Env, msg: Reply) -> ContractResult<CwResponse
 pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::InstantiateAddress { code_id, protocol } => {
-            let CodeInfoResponse { checksum, .. } =
-                deps.querier.query_wasm_code_info(code_id.u64())?;
+            let code_id = CodeId::from(code_id.try_validate(&contract::validator(deps.querier))?);
+
+            let CodeInfoResponse { checksum, .. } = deps.querier.query_wasm_code_info(code_id)?;
 
             let creator = deps.api.addr_canonicalize(env.contract.address.as_str())?;
 

--- a/platform/contracts/admin/src/msg.rs
+++ b/platform/contracts/admin/src/msg.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use platform::contract::CodeId;
-use sdk::cosmwasm_std::{Addr, Uint64};
+use platform::contract::external;
+use sdk::cosmwasm_std::Addr;
 use versioning::ReleaseId;
 
 pub use crate::contracts::{
@@ -25,13 +25,9 @@ pub struct MigrateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub enum ExecuteMsg
-where
-    Uint64: Into<CodeId>,
-    CodeId: Into<Uint64>,
-{
+pub enum ExecuteMsg {
     Instantiate {
-        code_id: Uint64,
+        code_id: external::Code,
         expected_address: Addr,
         protocol: String,
         label: String,
@@ -73,13 +69,9 @@ pub struct MigrateContracts {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
-pub enum QueryMsg
-where
-    Uint64: Into<CodeId>,
-    CodeId: Into<Uint64>,
-{
+pub enum QueryMsg {
     InstantiateAddress {
-        code_id: Uint64,
+        code_id: external::Code,
         protocol: String,
     },
     Protocols {},

--- a/platform/packages/platform/src/contract.rs
+++ b/platform/packages/platform/src/contract.rs
@@ -6,6 +6,8 @@ use sdk::cosmwasm_std::{Addr, CodeInfoResponse, ContractInfoResponse, QuerierWra
 
 use crate::{error::Error, result::Result};
 
+pub mod external;
+
 pub type CodeId = u64;
 
 /// Abstracts the platform specific validation of smart cotract codes and instances
@@ -69,8 +71,8 @@ impl Validator for CosmwasmValidator<'_> {
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case", transparent)]
 /// A valid Cosmwasm code that may be stored and transferred
-/// Not indended to be used in external APIs since there is no way to integrate validation on deserialization!
-/// Instead, use [CodeId], or Uint64, in APIs and [Code::try_new] to validate the input.
+/// Not intended to be used directly in external APIs since there is no way to integrate validation on deserialization!
+/// Instead, use [external::Code] in external APIs and [external::Code::try_validate] to validate the input.
 pub struct Code {
     id: CodeId,
 }

--- a/platform/packages/platform/src/contract/external.rs
+++ b/platform/packages/platform/src/contract/external.rs
@@ -1,0 +1,76 @@
+use serde::{Deserialize, Serialize};
+
+use sdk::cosmwasm_std::Uint64;
+
+use crate::{
+    contract::{CodeId, Validator},
+    result::Result,
+};
+
+/// A code id as it arrives on an external, user- or script-facing API boundary.
+///
+/// Serializes to and deserializes from the exact JSON form of [`Uint64`] (a
+/// stringified `u64`), so it is a drop-in replacement for a `Uint64` code-id
+/// field with no change on the wire. Unlike [`super::Code`], whose only
+/// constructor goes through chain validation, this type holds an unvalidated
+/// wire value; the sole way to obtain a validated [`super::Code`] from it is
+/// [`Self::try_validate`]. Mirrors the boundary discipline of the external
+/// coin wrapper in `finance`.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct Code(Uint64);
+
+impl Code {
+    /// Confirm against the chain that the code id exists and coerce to a
+    /// validated [`super::Code`].
+    pub fn try_validate<V>(self, validator: &V) -> Result<super::Code>
+    where
+        V: Validator,
+    {
+        super::Code::try_new(self.0.u64(), validator)
+    }
+}
+
+impl From<CodeId> for Code {
+    fn from(id: CodeId) -> Self {
+        Self(Uint64::new(id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sdk::cosmwasm_std::{self, QuerierWrapper, Uint64, testing::MockQuerier};
+
+    use crate::contract::{CodeId, validator};
+
+    use super::Code;
+
+    const ID: CodeId = 42;
+
+    #[test]
+    fn wire_form_is_uint64_string() {
+        assert_eq!(
+            cosmwasm_std::to_json_string(&Uint64::new(ID)).unwrap(),
+            cosmwasm_std::to_json_string(&Code::from(ID)).unwrap(),
+        );
+        assert_eq!(
+            "\"42\"",
+            cosmwasm_std::to_json_string(&Code::from(ID)).unwrap(),
+        );
+    }
+
+    #[test]
+    fn deserializes_from_the_uint64_string_form() {
+        assert_eq!(
+            Code::from(ID),
+            cosmwasm_std::from_json::<Code>("\"42\"").unwrap(),
+        );
+    }
+
+    #[test]
+    fn try_validate_rejects_an_unknown_code() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+        assert!(Code::from(ID).try_validate(&validator(querier)).is_err());
+    }
+}

--- a/protocol/contracts/leaser/src/contract.rs
+++ b/protocol/contracts/leaser/src/contract.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use access_control::ContractOwnerAccess;
 use lease::api::MigrateMsg as LeaseMigrateMsg;
 use platform::{
-    contract::{self, Code, CodeId, Validator},
+    contract::{self, Code, Validator, external},
     error as platform_error,
     message::Response as MessageResponse,
     reply, response,
@@ -300,12 +300,11 @@ fn check_no_leases(storage: &dyn Storage) -> ContractResult<()> {
     }
 }
 
-fn new_code<C, V>(new_code_id: C, addr_validator: &V) -> ContractResult<Code>
+fn new_code<V>(new_code_id: external::Code, addr_validator: &V) -> ContractResult<Code>
 where
-    C: Into<CodeId>,
     V: Validator,
 {
-    Code::try_new(new_code_id.into(), addr_validator).map_err(Into::into)
+    new_code_id.try_validate(addr_validator).map_err(Into::into)
 }
 
 fn migrate_msg(

--- a/protocol/contracts/leaser/src/msg/mod.rs
+++ b/protocol/contracts/leaser/src/msg/mod.rs
@@ -10,7 +10,8 @@ use finance::{
 use lease::api::{
     DownpaymentCoin, LeaseCoin, LpnCoinDTO, limits::MaxSlippages, open::PositionSpecDTO,
 };
-use sdk::cosmwasm_std::{Addr, Uint64};
+use platform::contract::external;
+use sdk::cosmwasm_std::Addr;
 use versioning::ProtocolPackageReleaseId;
 
 use crate::finance::LeaseCurrencies;
@@ -24,7 +25,7 @@ mod config;
 #[cfg_attr(feature = "testing", derive(Debug))]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct InstantiateMsg {
-    pub lease_code: Uint64,
+    pub lease_code: external::Code,
     pub lpp: Addr,
     pub profit: Addr,
     pub reserve: Addr,
@@ -78,8 +79,7 @@ pub enum ExecuteMsg {
     /// a continuation key with the same event and the procedure continues until
     /// no key is provided and 'wasm-migrate-leases.status=done'.
     MigrateLeases {
-        // Since this is an external system API we should not use [Code].
-        new_code_id: Uint64,
+        new_code_id: external::Code,
         /// The release ID the new lease code is part of.
         ///
         /// Most of the times this matches the release of the leaser.

--- a/protocol/contracts/leaser/src/tests/mod.rs
+++ b/protocol/contracts/leaser/src/tests/mod.rs
@@ -48,7 +48,7 @@ pub(super) fn lpn_coin_dto(amount: Amount) -> LpnCoinDTO {
 
 fn dummy_instantiate_msg() -> InstantiateMsg {
     InstantiateMsg {
-        lease_code: 10u16.into(),
+        lease_code: 10u64.into(),
         lpp: Addr::unchecked("LPP"),
         profit: Addr::unchecked("Profit"),
         reserve: Addr::unchecked("reserve"),

--- a/protocol/contracts/lpp/src/contract/mod.rs
+++ b/protocol/contracts/lpp/src/contract/mod.rs
@@ -12,9 +12,7 @@ use currencies::{
 };
 use cw_time::IntoInstant;
 
-use platform::{
-    bank, contract::Code, error as platform_error, message::Response as PlatformResponse, response,
-};
+use platform::{bank, error as platform_error, message::Response as PlatformResponse, response};
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
     cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, entry_point},
@@ -66,24 +64,22 @@ pub fn instantiate(
             .map_err(Into::into)
         })?;
 
-    Code::try_new(
-        msg.lease_code.into(),
-        &platform::contract::validator(deps.querier),
-    )
-    .map_err(Into::into)
-    .and_then(|lease_code| {
-        let config = ApiConfig::new(lease_code, msg.borrow_rate, msg.min_utilization);
-        Config::store(&config, deps.storage).map(|()| config)
-    })
-    .and_then(|ref config| {
-        LiquidityPool::<LpnCurrency, _>::new(
-            config,
-            &bank::account_view(&env.contract.address, deps.querier),
-        )
-        .save(deps.storage)
-    })
-    .map(|()| response::empty_response())
-    .inspect_err(platform_error::log(deps.api))
+    msg.lease_code
+        .try_validate(&platform::contract::validator(deps.querier))
+        .map_err(Into::into)
+        .and_then(|lease_code| {
+            let config = ApiConfig::new(lease_code, msg.borrow_rate, msg.min_utilization);
+            Config::store(&config, deps.storage).map(|()| config)
+        })
+        .and_then(|ref config| {
+            LiquidityPool::<LpnCurrency, _>::new(
+                config,
+                &bank::account_view(&env.contract.address, deps.querier),
+            )
+            .save(deps.storage)
+        })
+        .map(|()| response::empty_response())
+        .inspect_err(platform_error::log(deps.api))
 }
 
 #[entry_point]

--- a/protocol/contracts/lpp/src/msg.rs
+++ b/protocol/contracts/lpp/src/msg.rs
@@ -7,8 +7,8 @@ use finance::{
     price::Price,
 };
 use lpp_platform::NLpn;
-use platform::contract::Code;
-use sdk::cosmwasm_std::{Addr, Uint64};
+use platform::contract::{Code, external};
+use sdk::cosmwasm_std::Addr;
 
 use crate::{borrow::InterestRate, config::Config, loan::Loan};
 
@@ -20,8 +20,7 @@ pub struct InstantiateMsg {
     /// and close all deposits.
     /// In the current protocol architecture, it is the leaser contract
     pub protocol_admin: Addr,
-    // Since this is an external system API we should not use [Code].
-    pub lease_code: Uint64,
+    pub lease_code: external::Code,
     pub borrow_rate: InterestRate,
     pub min_utilization: Percent100,
 }

--- a/protocol/contracts/remote_lease/src/api.rs
+++ b/protocol/contracts/remote_lease/src/api.rs
@@ -1,9 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use finance::duration::Duration;
-use platform::contract::{Code, CodeId};
+use platform::contract::{Code, CodeId, external};
 use remote_lease::msg::{CloseLeaseParams, OpenLeaseParams, SwapParams, TransferOutParams};
-use sdk::cosmwasm_std::Uint64;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
@@ -17,8 +16,7 @@ pub struct InstantiateMsg {
     /// channel, in canonical `channel-<N>` form. Proposed to the counterparty in
     /// the lease channel's handshake version (ADR-0002 §3.3).
     pub transfer_channel: String,
-    // External system API — accept `Uint64`; the contract wraps it in `Code` after validation.
-    pub lease_code: Uint64,
+    pub lease_code: external::Code,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -85,7 +83,7 @@ pub struct ConfigResponse {
     pub connection_id: String,
     pub dex_label: String,
     pub transfer_channel: String,
-    pub lease_code_id: Uint64,
+    pub lease_code_id: external::Code,
 }
 
 impl ConfigResponse {
@@ -130,8 +128,10 @@ pub struct ChannelResponse {
 
 #[cfg(test)]
 mod test {
-    use platform::{contract::Code, tests as platform_tests};
-    use sdk::cosmwasm_std::Uint64;
+    use platform::{
+        contract::{Code, external},
+        tests as platform_tests,
+    };
 
     use super::{ConfigResponse, QueryMsg};
 
@@ -154,6 +154,6 @@ mod test {
         assert_eq!("connection-7", response.connection_id);
         assert_eq!("osmosis", response.dex_label);
         assert_eq!("channel-3", response.transfer_channel);
-        assert_eq!(Uint64::new(9), response.lease_code_id);
+        assert_eq!(external::Code::from(9), response.lease_code_id);
     }
 }

--- a/protocol/contracts/remote_lease/src/contract.rs
+++ b/protocol/contracts/remote_lease/src/contract.rs
@@ -4,9 +4,7 @@ use access_control::SingleUserAccess;
 use cosmwasm_std::Storage;
 use cw_time::{IntoInstant as _, IntoTimestamp as _};
 use finance::{duration::Duration, instant::Instant};
-use platform::{
-    contract::Code, error as platform_error, message::Response as PlatformResponse, response,
-};
+use platform::{error as platform_error, message::Response as PlatformResponse, response};
 use remote_lease::{
     envelope::{LeaseAddrOnWire, PacketEnvelope},
     msg::Operation,
@@ -71,11 +69,10 @@ pub fn instantiate(
             .map_err(Into::into)
         })
         .and_then(|()| {
-            Code::try_new(
-                new_controller.lease_code.into(),
-                &platform::contract::validator(deps.querier),
-            )
-            .map_err(Into::into)
+            new_controller
+                .lease_code
+                .try_validate(&platform::contract::validator(deps.querier))
+                .map_err(Into::into)
         })
         .and_then(|lease_code| {
             Config::new(

--- a/protocol/contracts/remote_lease/src/contract/tests/execute_admin.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/execute_admin.rs
@@ -1,8 +1,8 @@
-use platform::contract::{Code, CodeId};
+use platform::contract::{Code, CodeId, external};
 use sdk::{
     cosmos_sdk_proto::prost::Message as _,
     cosmwasm_ext::{CosmosMsg, SubMsg},
-    cosmwasm_std::{AnyMsg, IbcMsg, Uint64, testing},
+    cosmwasm_std::{AnyMsg, IbcMsg, testing},
     ibc_proto::ibc::core::channel::v1::MsgChannelOpenInit,
 };
 
@@ -43,7 +43,10 @@ fn new_lease_code_admin_succeeds() {
     assert_eq!(0, res.messages.len());
 
     let config = query_config(deps.as_ref());
-    assert_eq!(Uint64::from(CodeId::from(new_code)), config.lease_code_id);
+    assert_eq!(
+        external::Code::from(CodeId::from(new_code)),
+        config.lease_code_id
+    );
 }
 
 #[test]
@@ -206,5 +209,5 @@ fn new_lease_code_non_admin_rejected() {
     assert!(matches!(err, Error::Unauthorized(_)), "got {err:?}");
 
     let config = query_config(deps.as_ref());
-    assert_eq!(Uint64::from(LEASE_CODE_ID), config.lease_code_id);
+    assert_eq!(external::Code::from(LEASE_CODE_ID), config.lease_code_id);
 }

--- a/protocol/contracts/remote_lease/src/contract/tests/instantiate.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/instantiate.rs
@@ -1,7 +1,7 @@
-use platform::contract::{Code, CodeId};
+use platform::contract::{Code, CodeId, external};
 use sdk::{
     cosmwasm_std::{
-        OwnedDeps, SystemError, SystemResult, Uint64, WasmQuery,
+        OwnedDeps, SystemError, SystemResult, WasmQuery,
         testing::{self, MockApi, MockQuerier, MockStorage},
     },
     testing as sdk_testing,
@@ -31,7 +31,7 @@ fn proper_initialization() {
     assert_eq!(DEX_LABEL, config.dex_label);
     assert_eq!(TRANSFER_CHANNEL, config.transfer_channel);
     assert_eq!(
-        Uint64::from(CodeId::from(Code::unchecked(LEASE_CODE_ID))),
+        external::Code::from(CodeId::from(Code::unchecked(LEASE_CODE_ID))),
         config.lease_code_id,
     );
 

--- a/protocol/contracts/reserve/src/api.rs
+++ b/protocol/contracts/reserve/src/api.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 pub(crate) use currencies::Lpns as LpnCurrencies;
 use currency::CurrencyDTO;
 use finance::coin::CoinDTO;
-use platform::contract::{Code, CodeId};
-use sdk::cosmwasm_std::{Addr, Uint64};
+use platform::contract::{Code, CodeId, external};
+use sdk::cosmwasm_std::Addr;
 
 pub type LpnCurrencyDTO = CurrencyDTO<LpnCurrencies>;
 pub type LpnCoin = CoinDTO<LpnCurrencies>;
@@ -14,8 +14,7 @@ pub type LpnCoin = CoinDTO<LpnCurrencies>;
 pub struct InstantiateMsg {
     /// Unchecked address of the protocol admin user that can change the lease code Id and dump balances
     pub protocol_admin: String,
-    // Since this is an external system API we should not use [Code].
-    pub lease_code: Uint64,
+    pub lease_code: external::Code,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -53,7 +52,7 @@ pub enum QueryMsg {
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "testing", derive(Debug))]
 pub struct ConfigResponse {
-    lease_code_id: Uint64,
+    lease_code_id: external::Code,
 }
 
 impl ConfigResponse {

--- a/protocol/contracts/reserve/src/contract.rs
+++ b/protocol/contracts/reserve/src/contract.rs
@@ -8,7 +8,7 @@ use finance::coin::Coin;
 use platform::{
     bank::{self, BankAccount, BankAccountView},
     batch::{Emit, Emitter},
-    contract::{self, Code, Validator},
+    contract::{self, Validator},
     error as platform_error,
     message::Response as PlatformResponse,
     response,
@@ -57,11 +57,10 @@ pub fn instantiate(
             .map_err(Into::into)
         })
         .and_then(|()| {
-            Code::try_new(
-                new_reserve.lease_code.into(),
-                &platform::contract::validator(deps.querier),
-            )
-            .map_err(Into::into)
+            new_reserve
+                .lease_code
+                .try_validate(&platform::contract::validator(deps.querier))
+                .map_err(Into::into)
         })
         .and_then(|lease_code| Config::new(lease_code).store(deps.storage))
         .map(|()| response::empty_response())

--- a/tests/src/common/remote_lease_controller_stub.rs
+++ b/tests/src/common/remote_lease_controller_stub.rs
@@ -51,7 +51,7 @@ use serde::{Deserialize, Serialize};
 use currencies::{Lpn, PaymentGroup};
 use currency::{self, CurrencyDef, Group, MemberOf};
 use finance::coin::{Amount, Coin, CoinDTO, WithCoin};
-use platform::contract::{Code, CodeId};
+use platform::contract::{Code, CodeId, external};
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
     msg::{CloseLeaseParams, OpenLeaseParams, SwapParams, TransferOutParams},
@@ -66,7 +66,7 @@ use remote_lease_controller::api::{
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
     cosmwasm_std::{
-        self, Addr, Binary, Deps, Env, MessageInfo, StdError, StdResult, Storage, Uint64, WasmMsg,
+        self, Addr, Binary, Deps, Env, MessageInfo, StdError, StdResult, Storage, WasmMsg,
         to_json_binary,
     },
     cw_storage_plus::{Item, Map},
@@ -262,6 +262,8 @@ pub enum StubError {
     NoPending { op: String },
     #[error("op `{op}` is configured to fail synchronously")]
     SyncFailure { op: String },
+    #[error("platform: {0}")]
+    Platform(#[from] platform::error::Error),
     #[error("std: {0}")]
     Std(#[from] StdError),
 }
@@ -272,7 +274,9 @@ pub fn instantiate(
     _info: MessageInfo,
     msg: ControllerInstantiateMsg,
 ) -> Result<CwResponse, StubError> {
-    let lease_code = Code::unchecked(u64::from(msg.lease_code));
+    let lease_code = msg
+        .lease_code
+        .try_validate(&platform::contract::validator(deps.querier))?;
     let config = StubConfig {
         connection_id: msg.connection_id,
         dex_label: msg.dex_label,
@@ -671,7 +675,7 @@ impl Instantiator {
             connection_id: super::test_case::TestCase::DEX_CONNECTION_ID.into(),
             dex_label: "test-dex".into(),
             transfer_channel: "channel-0".into(),
-            lease_code: Uint64::from(CodeId::from(lease_code)),
+            lease_code: external::Code::from(CodeId::from(lease_code)),
         };
 
         app.instantiate(


### PR DESCRIPTION
Closes #623. Supersedes #620 (the use-site `Code::verify` approach — this delivers the same validate-on-the-boundary guarantee through the type instead).

## What

External contract message APIs exposed code ids as `cosmwasm_std::Uint64`, a primitive with no hook to validate on deserialize. This adds `platform::contract::external::Code` — a `#[serde(transparent)]` wrapper over `Uint64` whose only coercion to a validated `platform::contract::Code` is `try_validate(&Validator)` — and adopts it everywhere a code id crosses an external boundary:

- **leaser** — `InstantiateMsg.lease_code`, `ExecuteMsg::MigrateLeases.new_code_id`
- **lpp / reserve / remote_lease** — `InstantiateMsg.lease_code` and the `ConfigResponse.lease_code_id` query outputs
- **admin** — `ExecuteMsg::Instantiate.code_id`, `QueryMsg::InstantiateAddress.code_id`, `MigrationSpec.code_id` (drops the now-dead `where Uint64: Into<CodeId>` bounds)

No `Uint64` code id remains in any external API.

## Wire compatibility

Zero on-wire change. `Uint64` serializes as a JSON string (`"42"`); `external::Code` is transparent over `Uint64`, so every instantiate / execute / migrate / query-response payload is byte-identical. Unit tests assert the string form and the round-trip; the integration suite passes unchanged.

The internal `platform::contract::Code` is transparent over a bare `u64` and serializes as a *number* — `external::Code` deliberately wraps `Uint64`, not `Code`, to preserve the string form.

## Behavior change

The admin `Instantiate`, `InstantiateAddress` and contract-migration paths previously took the raw `Uint64` and used it without confirming the code id exists on chain. They now route through `try_validate`, which performs a `WasmQuery::CodeInfo` existence check before the code id is used — closing a validate-on-the-boundary gap. The leaser/lpp/reserve/remote_lease paths already validated; they are refactored to the equivalent `try_validate` with no behavior change.

`InstantiateAddress` issues two `CodeInfo` queries (the `try_validate` check plus the existing checksum fetch). This is deliberate — keeping `external::Code`'s single validated-coercion path with no unvalidated extractor is worth one extra read on a read-only query endpoint.

## Verification

- `cargo clippy` / `cargo test` clean on platform, admin and the four protocol contracts
- Full integration suite (`dex-osmosis`): 165 passed
- Production-profile (non-`testing`) contract builds compile
- Independent correctness and security passes run: security came back clean (net improvement — the change adds validation and exposes no escape hatch to an unvalidated code id); a correctness pass caught one production-build break (a missing unconditional `Debug` on the wrapper), now fixed

Three commits, each builds in isolation: platform type → protocol adoption → admin adoption.
