### PR TITLE
fix(dex): remove the unused InspectSpec trait

### DIFF
--- a/protocol/packages/dex/src/impl_/ica_connector.rs
+++ b/protocol/packages/dex/src/impl_/ica_connector.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 #[cfg(feature = "migration")]
-use super::migration::{InspectSpec, MigrateSpec};
+use super::migration::MigrateSpec;
 use cw_time::IntoInstant;
 
 #[derive(Serialize, Deserialize)]
@@ -81,20 +81,6 @@ where
         MigrateFn: FnOnce(SwapTask) -> SwapTaskNew,
     {
         Self::Out::new(self.connectee.migrate_spec(migrate_fn))
-    }
-}
-
-#[cfg(feature = "migration")]
-impl<SwapTask, R, Connectee, SwapResult> InspectSpec<SwapTask, R>
-    for IcaConnector<Connectee, SwapResult>
-where
-    Connectee: InspectSpec<SwapTask, R>,
-{
-    fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R
-    where
-        InspectFn: FnOnce(&SwapTask) -> R,
-    {
-        self.connectee.inspect_spec(inspect_fn)
     }
 }
 

--- a/protocol/packages/dex/src/impl_/migration.rs
+++ b/protocol/packages/dex/src/impl_/migration.rs
@@ -8,9 +8,3 @@ where
     where
         MigrateFn: FnOnce(SwapTask) -> SwapTaskNew;
 }
-
-pub trait InspectSpec<SwapTask, R> {
-    fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R
-    where
-        InspectFn: FnOnce(&SwapTask) -> R;
-}

--- a/protocol/packages/dex/src/impl_/out_local.rs
+++ b/protocol/packages/dex/src/impl_/out_local.rs
@@ -476,7 +476,7 @@ mod impl_display {
 #[cfg(feature = "migration")]
 mod impl_migration {
 
-    use super::{super::migration::InspectSpec, State};
+    use super::State;
     use crate::{
         SwapTask as SwapTaskT,
         impl_::{ForwardToInner, migration::MigrateSpec},
@@ -506,28 +506,6 @@ mod impl_migration {
                 State::TransferInInit(inner) => inner.migrate_spec(migrate_fn).into(),
                 State::TransferInInitRespDelivery(inner) => inner.migrate_spec(migrate_fn).into(),
                 State::TransferInFinish(inner) => inner.migrate_spec(migrate_fn).into(),
-            }
-        }
-    }
-
-    impl<SwapTask, R, SwapClient, ForwardToInnerMsg> InspectSpec<SwapTask, R>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
-    where
-        SwapTask: SwapTaskT,
-        ForwardToInnerMsg: ForwardToInner,
-    {
-        fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R
-        where
-            InspectFn: FnOnce(&SwapTask) -> R,
-        {
-            match self {
-                State::TransferOut(inner) => inner.inspect_spec(inspect_fn),
-                State::TransferOutRespDelivery(inner) => inner.inspect_spec(inspect_fn),
-                State::SwapExactIn(inner) => inner.inspect_spec(inspect_fn),
-                State::SwapExactInRespDelivery(inner) => inner.inspect_spec(inspect_fn),
-                State::TransferInInit(inner) => inner.inspect_spec(inspect_fn),
-                State::TransferInInitRespDelivery(inner) => inner.inspect_spec(inspect_fn),
-                State::TransferInFinish(inner) => inner.inspect_spec(inspect_fn),
             }
         }
     }

--- a/protocol/packages/dex/src/impl_/out_swap.rs
+++ b/protocol/packages/dex/src/impl_/out_swap.rs
@@ -444,7 +444,7 @@ mod impl_display {
 
 #[cfg(feature = "migration")]
 mod impl_migration {
-    use super::{super::migration::InspectSpec, State};
+    use super::State;
     use crate::{
         SwapTask as SwapTaskT,
         impl_::{ForwardToInner, migration::MigrateSpec},
@@ -469,25 +469,6 @@ mod impl_migration {
                 State::TransferOutRespDelivery(inner) => inner.migrate_spec(migrate_fn).into(),
                 State::RemoteSwap(inner) => inner.migrate_spec(migrate_fn).into(),
                 State::SlippageAnomaly(inner) => inner.migrate_spec(migrate_fn).into(),
-            }
-        }
-    }
-
-    impl<SwapTask, R, SwapClient, ForwardToInnerMsg> InspectSpec<SwapTask, R>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
-    where
-        SwapTask: SwapTaskT,
-        ForwardToInnerMsg: ForwardToInner,
-    {
-        fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R
-        where
-            InspectFn: FnOnce(&SwapTask) -> R,
-        {
-            match self {
-                State::TransferOut(inner) => inner.inspect_spec(inspect_fn),
-                State::TransferOutRespDelivery(inner) => inner.inspect_spec(inspect_fn),
-                State::RemoteSwap(inner) => inner.inspect_spec(inspect_fn),
-                State::SlippageAnomaly(inner) => inner.inspect_spec(inspect_fn),
             }
         }
     }

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -65,7 +65,7 @@ use crate::{
 };
 
 #[cfg(feature = "migration")]
-use super::migration::{InspectSpec, MigrateSpec};
+use super::migration::MigrateSpec;
 
 const EVENT_KEY_ABSORBED: &str = "absorbed";
 const EVENT_KEY_ANOMALY: &str = "anomaly";
@@ -685,19 +685,6 @@ where
             self.errors,
             self.in_flight_nonce,
         )
-    }
-}
-
-#[cfg(feature = "migration")]
-impl<SwapTask, R, SEnum> InspectSpec<SwapTask, R> for RemoteSwap<SwapTask, SEnum>
-where
-    SwapTask: SwapTaskT,
-{
-    fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R
-    where
-        InspectFn: FnOnce(&SwapTask) -> R,
-    {
-        inspect_fn(&self.spec)
     }
 }
 

--- a/protocol/packages/dex/src/impl_/resp_delivery/mod.rs
+++ b/protocol/packages/dex/src/impl_/resp_delivery/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 #[cfg(feature = "migration")]
-use super::migration::{InspectSpec, MigrateSpec};
+use super::migration::MigrateSpec;
 
 use self::adapter::{DeliveryAdapter, ICAOpenDeliveryAdapter, ResponseDeliveryAdapter};
 use cw_time::IntoInstant;
@@ -85,20 +85,6 @@ where
         MigrateFn: FnOnce(SwapTask) -> SwapTaskNew,
     {
         Self::Out::new(self.handler.migrate_spec(migrate_fn), self.response)
-    }
-}
-
-#[cfg(feature = "migration")]
-impl<SwapTask, RInspect, H, ForwardToInnerMsg, R, Delivery> InspectSpec<SwapTask, RInspect>
-    for ResponseDeliveryImpl<H, ForwardToInnerMsg, R, Delivery>
-where
-    H: InspectSpec<SwapTask, RInspect>,
-{
-    fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> RInspect
-    where
-        InspectFn: FnOnce(&SwapTask) -> RInspect,
-    {
-        self.handler.inspect_spec(inspect_fn)
     }
 }
 

--- a/protocol/packages/dex/src/impl_/slippage_anomaly.rs
+++ b/protocol/packages/dex/src/impl_/slippage_anomaly.rs
@@ -42,7 +42,7 @@ use crate::{
 };
 
 #[cfg(feature = "migration")]
-use super::migration::{InspectSpec, MigrateSpec};
+use super::migration::MigrateSpec;
 
 const EVENT_KEY_ANOMALY: &str = "anomaly";
 const EVENT_KEY_ABSORBED: &str = "absorbed";
@@ -374,18 +374,5 @@ where
             self.in_flight_min_out,
             self.in_flight_nonce,
         )
-    }
-}
-
-#[cfg(feature = "migration")]
-impl<SwapTask, R, SEnum> InspectSpec<SwapTask, R> for SlippageAnomaly<SwapTask, SEnum>
-where
-    SwapTask: SwapTaskT,
-{
-    fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R
-    where
-        InspectFn: FnOnce(&SwapTask) -> R,
-    {
-        inspect_fn(&self.spec)
     }
 }

--- a/protocol/packages/dex/src/impl_/swap_exact_in/mod.rs
+++ b/protocol/packages/dex/src/impl_/swap_exact_in/mod.rs
@@ -38,7 +38,7 @@ use crate::{
 };
 
 #[cfg(feature = "migration")]
-use super::migration::{InspectSpec, MigrateSpec};
+use super::migration::MigrateSpec;
 use cw_time::IntoInstant;
 
 mod decode_resp;
@@ -246,18 +246,6 @@ where
         MigrateFn: FnOnce(SwapTask) -> SwapTaskNew,
     {
         Self::Out::new(migrate_fn(self.spec))
-    }
-}
-
-#[cfg(feature = "migration")]
-impl<SwapTask, R, SEnum, SwapClient> InspectSpec<SwapTask, R>
-    for SwapExactIn<SwapTask, SEnum, SwapClient>
-{
-    fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R
-    where
-        InspectFn: FnOnce(&SwapTask) -> R,
-    {
-        inspect_fn(&self.spec)
     }
 }
 

--- a/protocol/packages/dex/src/impl_/transfer_in_finish.rs
+++ b/protocol/packages/dex/src/impl_/transfer_in_finish.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 #[cfg(feature = "migration")]
-use super::migration::{InspectSpec, MigrateSpec};
+use super::migration::MigrateSpec;
 use super::{
     response::{self, Handler as HandlerT, Result as HandlerResult},
     transfer_in,
@@ -83,19 +83,6 @@ where
         MigrateFn: FnOnce(SwapTask) -> SwapTaskNew,
     {
         Self::Out::new(migrate_fn(self.spec), self.amount_in, self.timeout)
-    }
-}
-
-#[cfg(feature = "migration")]
-impl<SwapTask, R, SEnum> InspectSpec<SwapTask, R> for TransferInFinish<SwapTask, SEnum>
-where
-    SwapTask: SwapTaskT,
-{
-    fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R
-    where
-        InspectFn: FnOnce(&SwapTask) -> R,
-    {
-        inspect_fn(&self.spec)
     }
 }
 

--- a/protocol/packages/dex/src/impl_/transfer_in_init.rs
+++ b/protocol/packages/dex/src/impl_/transfer_in_init.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[cfg(feature = "migration")]
-use super::migration::{InspectSpec, MigrateSpec};
+use super::migration::MigrateSpec;
 use super::{
     SwapTask as SwapTaskT,
     response::{ContinueResult, Handler, Result as HandlerResult},
@@ -65,19 +65,6 @@ where
         MigrateFn: FnOnce(SwapTask) -> SwapTaskNew,
     {
         Self::Out::new(migrate_fn(self.spec), self.amount_in)
-    }
-}
-
-#[cfg(feature = "migration")]
-impl<SwapTask, R, SEnum> InspectSpec<SwapTask, R> for TransferInInit<SwapTask, SEnum>
-where
-    SwapTask: SwapTaskT,
-{
-    fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R
-    where
-        InspectFn: FnOnce(&SwapTask) -> R,
-    {
-        inspect_fn(&self.spec)
     }
 }
 

--- a/protocol/packages/dex/src/impl_/transfer_out/mod.rs
+++ b/protocol/packages/dex/src/impl_/transfer_out/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 #[cfg(feature = "migration")]
-use super::migration::{InspectSpec, MigrateSpec};
+use super::migration::MigrateSpec;
 use super::{
     next_leg::NextLeg as NextLegT,
     response::{self, ContinueResult, Handler, Result as HandlerResult},
@@ -249,18 +249,6 @@ where
         MigrateFn: FnOnce(SwapTask) -> SwapTaskNew,
     {
         Self::Out::new(migrate_fn(self.spec))
-    }
-}
-
-#[cfg(feature = "migration")]
-impl<SwapTask, R, SEnum, SwapClient, NextLeg> InspectSpec<SwapTask, R>
-    for TransferOut<SwapTask, SEnum, SwapClient, NextLeg>
-{
-    fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R
-    where
-        InspectFn: FnOnce(&SwapTask) -> R,
-    {
-        inspect_fn(&self.spec)
     }
 }
 


### PR DESCRIPTION
## Summary

`dex`'s `InspectSpec` trait (`protocol/packages/dex/src/impl_/migration.rs`) was implemented across every dex state node but never invoked by any consumer. Under `unused = "deny"` this made the crate fail to build with the `migration` feature (`error: trait InspectSpec is never used`), so `dex --features impl,migration` could not be built or tested standalone — its migration-gated unit tests were only runnable with `--cap-lints=warn`.

This deletes the dead `InspectSpec` trait and its nine impls. The sibling `MigrateSpec` trait — the one actually wired into the migration state machine and the admin contract's lease migration — is untouched.

## Verification

- `cargo +1.94.0 build -p dex --features impl,migration` — now clean (was the failing repro in the issue).
- `cargo +1.94.0 test -p dex --features impl,migration` — 70 tests pass; the migration-gated tests now run without `--cap-lints`.
- Full workspace gate (`lint`, `lint-all`, `run-test`) green; 1395 tests pass across feature combos.
- Reviewed for correctness and security — pure dead-code removal, no behavior change, zero remaining references.

## Follow-up (not in this PR)

`dex`'s `cargo-each` CI matrix is `impl-or-testing` and never builds the `migration` combo, which is why this dead code never surfaced in dex's own CI. Adding a `migration` combo to dex's matrix so its migration-gated tests run in CI is a separate, maintainer-owned change.

Closes #663
