### PR TITLE
refactor(lease): share the baseline-gated drain arrival check

### DIFF
--- a/protocol/contracts/lease/src/contract/endpoins.rs
+++ b/protocol/contracts/lease/src/contract/endpoins.rs
@@ -26,7 +26,7 @@ use crate::{
 
 use super::state::{self, Response, State};
 
-const CONTRACT_STORAGE_VERSION: VersionSegment = 14;
+const CONTRACT_STORAGE_VERSION: VersionSegment = 15;
 const CURRENT_RELEASE: ProtocolPackageRelease = ProtocolPackageRelease::current(
     package_name!(),
     package_version!(),
@@ -103,6 +103,16 @@ pub fn migrate(
     // `OpeningUnwind` a rolled-back v13 binary cannot load it — the enum layout
     // is binary-incompatible — so v14 is not rollback-safe past that point. No
     // live v13 remote-lease population exists, so the refusal stays.
+    //
+    // v15 gives the two sibling home-bound drains — the opened-lease proceeds
+    // drain and the paid-lease asset transfer-out — the same persisted
+    // per-currency `baseline` the v14 `OpeningUnwind` drain carries, so their
+    // arrival check measures every coin against its pre-drain balance instead
+    // of an absolute one. The persisted drain `State` variants gain the field;
+    // the change is forward-only with no data transform. Once any lease
+    // persists mid-drain a rolled-back v14 binary cannot load it — the drain
+    // layout is binary-incompatible — so v15 is not rollback-safe past that
+    // point. No live v14 remote-lease population exists, so the refusal stays.
     Err(ContractError::UnsupportedMigration).inspect_err(platform_error::log(deps.api))
 }
 

--- a/protocol/contracts/lease/src/contract/state/arrival.rs
+++ b/protocol/contracts/lease/src/contract/state/arrival.rs
@@ -1,0 +1,275 @@
+use currency::{CurrencyDef, Group, MemberOf};
+use finance::{
+    coin::{Amount, Coin, CoinDTO, WithCoin},
+    zero::Zero,
+};
+use platform::{bank, error::Error as PlatformError};
+use sdk::cosmwasm_std::{Addr, QuerierWrapper};
+
+/// Snapshot the local-account balance, per drained currency, at drain entry
+///
+/// One entry per unique currency among `expected`, carrying that currency's
+/// balance on `account` at the moment of the call. Taken once at drain
+/// construction, before any coin is drained back, and persisted with the task
+/// so [`arrived_over_baseline`] measures every later poll against the pre-drain
+/// balances. Returns the raw bank error so each caller maps it into its own
+/// error type.
+pub fn snapshot_baseline<G>(
+    expected: &[CoinDTO<G>],
+    account: &Addr,
+    querier: QuerierWrapper<'_>,
+) -> Result<Vec<CoinDTO<G>>, PlatformError>
+where
+    G: Group,
+{
+    unique_currencies(expected.iter().copied())
+        .map(|coin| account_balance(&coin, account, querier))
+        .collect()
+}
+
+/// Have all the drained coins arrived over their entry baseline?
+///
+/// Each currency clears once its measured balance has risen above its entry
+/// baseline by at least the aggregate amount expected in that currency. Two
+/// properties make this safe where an absolute balance check is not. The
+/// baseline is subtracted, so a balance the account already held — including
+/// one an attacker bank-sent to force an early finish — is not mistaken for an
+/// arrival. And coins are grouped by currency and summed, so two legs in the
+/// same currency must both land before the check passes.
+pub fn arrived_over_baseline<G>(
+    expected: &[CoinDTO<G>],
+    baseline: &[CoinDTO<G>],
+    account: &Addr,
+    querier: QuerierWrapper<'_>,
+) -> dex::DexResult<bool>
+where
+    G: Group,
+{
+    debug_assert!(
+        !expected.is_empty(),
+        "a drain always transfers at least one coin, so the arrival check is never vacuous"
+    );
+    unique_currencies(expected.iter().copied()).try_fold(true, |all_received, currency| {
+        let expected_amount = aggregate_amount(expected.iter().copied(), &currency);
+        let baseline_amount = aggregate_amount(baseline.iter().copied(), &currency);
+        account_balance(&currency, account, querier)
+            .map_err(Into::into)
+            .map(|arrived| {
+                all_received && arrived.amount().saturating_sub(baseline_amount) >= expected_amount
+            })
+    })
+}
+
+/// Deduplicate a coin list down to one representative per currency
+///
+/// A drain handles a handful of coins, so the linear scan is trivial; the
+/// representative carries the currency only — its amount is irrelevant to the
+/// per-currency aggregation done by [`aggregate_amount`].
+fn unique_currencies<G, I>(coins: I) -> impl Iterator<Item = CoinDTO<G>>
+where
+    G: Group,
+    I: IntoIterator<Item = CoinDTO<G>>,
+{
+    let mut seen: Vec<CoinDTO<G>> = Vec::new();
+    for coin in coins {
+        if !seen.iter().any(|kept| kept.currency() == coin.currency()) {
+            seen.push(coin);
+        }
+    }
+    seen.into_iter()
+}
+
+/// Sum the amounts of every coin matching `currency`
+fn aggregate_amount<G, I>(coins: I, currency: &CoinDTO<G>) -> Amount
+where
+    G: Group,
+    I: IntoIterator<Item = CoinDTO<G>>,
+{
+    coins
+        .into_iter()
+        .filter(|coin| coin.currency() == currency.currency())
+        .map(|coin| coin.amount())
+        .fold(Amount::ZERO, Amount::saturating_add)
+}
+
+/// Snapshot the local-account balance in `coin`'s currency
+fn account_balance<G>(
+    coin: &CoinDTO<G>,
+    account: &Addr,
+    querier: QuerierWrapper<'_>,
+) -> Result<CoinDTO<G>, PlatformError>
+where
+    G: Group,
+{
+    struct Balance<'account, 'querier> {
+        account: &'account Addr,
+        querier: QuerierWrapper<'querier>,
+    }
+
+    impl<G> WithCoin<G> for Balance<'_, '_>
+    where
+        G: Group,
+    {
+        type Outcome = Result<CoinDTO<G>, PlatformError>;
+
+        fn on<C>(self, _coin: Coin<C>) -> Self::Outcome
+        where
+            C: CurrencyDef,
+            C::Group: MemberOf<G> + MemberOf<G::TopG>,
+        {
+            bank::balance::<C>(self.account, self.querier).map(CoinDTO::from)
+        }
+    }
+
+    coin.with_coin(Balance { account, querier })
+}
+
+#[cfg(all(feature = "internal.test.contract", test))]
+mod tests {
+    use currencies::{
+        Lpn,
+        testing::{PaymentC1, PaymentC2},
+    };
+    use currency::CurrencyDef;
+    use finance::coin::{Amount, Coin, CoinDTO};
+    use sdk::cosmwasm_std::{Addr, Coin as CwCoin, Empty, QuerierWrapper, testing::MockQuerier};
+
+    use crate::api::LeasePaymentCurrencies;
+
+    const ACCOUNT: &str = "account";
+    const DOWNPAYMENT: Amount = 1_000;
+    const PRINCIPAL: Amount = 4_000;
+
+    /// A pre-existing balance in a drained currency is not mistaken for an
+    /// arrival: the entry baseline is subtracted, so the same balance at the
+    /// arrival check leaves nothing received.
+    #[test]
+    fn pre_existing_balance_is_not_an_arrival() {
+        let held = balances(&[(Lpn::dto().definition().bank_symbol, DOWNPAYMENT + PRINCIPAL)]);
+        let baseline = snapshot(&same_currency(), &held);
+
+        assert_eq!(Ok(false), arrived(&same_currency(), &baseline, &held));
+    }
+
+    /// Zero-baseline single-coin arrival is unchanged from an absolute check:
+    /// it completes exactly when the balance reaches the expected amount.
+    #[test]
+    fn zero_baseline_single_coin_arrives_at_the_expected_amount() {
+        let one: [CoinDTO<LeasePaymentCurrencies>; 1] = [Coin::<Lpn>::new(PRINCIPAL).into()];
+        let baseline = snapshot(&one, &balances(&[]));
+
+        let short = balances(&[(Lpn::dto().definition().bank_symbol, PRINCIPAL - 1)]);
+        assert_eq!(Ok(false), arrived(&one, &baseline, &short));
+
+        let exact = balances(&[(Lpn::dto().definition().bank_symbol, PRINCIPAL)]);
+        assert_eq!(Ok(true), arrived(&one, &baseline, &exact));
+    }
+
+    /// Same-currency legs must both arrive: only the downpayment landing over
+    /// the baseline is not enough.
+    #[test]
+    fn same_currency_requires_both_legs() {
+        let baseline = snapshot(&same_currency(), &balances(&[]));
+
+        let half = balances(&[(Lpn::dto().definition().bank_symbol, DOWNPAYMENT)]);
+        assert_eq!(Ok(false), arrived(&same_currency(), &baseline, &half));
+
+        let full = balances(&[(Lpn::dto().definition().bank_symbol, DOWNPAYMENT + PRINCIPAL)]);
+        assert_eq!(Ok(true), arrived(&same_currency(), &baseline, &full));
+    }
+
+    /// Same-currency arrival is measured over the baseline: a pre-existing
+    /// balance plus only one leg is still short.
+    #[test]
+    fn same_currency_arrival_measured_over_baseline() {
+        const PRE_EXISTING: Amount = 500;
+        let baseline = snapshot(
+            &same_currency(),
+            &balances(&[(Lpn::dto().definition().bank_symbol, PRE_EXISTING)]),
+        );
+
+        let one_leg = balances(&[(
+            Lpn::dto().definition().bank_symbol,
+            PRE_EXISTING + DOWNPAYMENT,
+        )]);
+        assert_eq!(Ok(false), arrived(&same_currency(), &baseline, &one_leg));
+
+        let both = balances(&[(
+            Lpn::dto().definition().bank_symbol,
+            PRE_EXISTING + DOWNPAYMENT + PRINCIPAL,
+        )]);
+        assert_eq!(Ok(true), arrived(&same_currency(), &baseline, &both));
+    }
+
+    /// Distinct currencies each clear independently: both must rise over their
+    /// own baseline before the drain completes.
+    #[test]
+    fn distinct_currencies_each_must_arrive() {
+        let baseline = snapshot(&distinct(), &balances(&[]));
+
+        let only_downpayment =
+            balances(&[(PaymentC1::dto().definition().bank_symbol, DOWNPAYMENT)]);
+        assert_eq!(
+            Ok(false),
+            arrived(&distinct(), &baseline, &only_downpayment)
+        );
+
+        let only_principal = balances(&[(Lpn::dto().definition().bank_symbol, PRINCIPAL)]);
+        assert_eq!(Ok(false), arrived(&distinct(), &baseline, &only_principal));
+
+        let both = balances(&[
+            (PaymentC1::dto().definition().bank_symbol, DOWNPAYMENT),
+            (Lpn::dto().definition().bank_symbol, PRINCIPAL),
+        ]);
+        assert_eq!(Ok(true), arrived(&distinct(), &baseline, &both));
+    }
+
+    // PaymentC1 and Lpn are distinct currencies; PaymentC2 aliases Lpn.
+    fn distinct() -> [CoinDTO<LeasePaymentCurrencies>; 2] {
+        [
+            Coin::<PaymentC1>::new(DOWNPAYMENT).into(),
+            Coin::<Lpn>::new(PRINCIPAL).into(),
+        ]
+    }
+
+    fn same_currency() -> [CoinDTO<LeasePaymentCurrencies>; 2] {
+        [
+            Coin::<PaymentC2>::new(DOWNPAYMENT).into(),
+            Coin::<Lpn>::new(PRINCIPAL).into(),
+        ]
+    }
+
+    fn arrived(
+        expected: &[CoinDTO<LeasePaymentCurrencies>],
+        baseline: &[CoinDTO<LeasePaymentCurrencies>],
+        querier: &MockQuerier<Empty>,
+    ) -> Result<bool, String> {
+        super::arrived_over_baseline(
+            expected,
+            baseline,
+            &Addr::unchecked(ACCOUNT),
+            QuerierWrapper::new(querier),
+        )
+        .map_err(|err| err.to_string())
+    }
+
+    fn snapshot(
+        expected: &[CoinDTO<LeasePaymentCurrencies>],
+        querier: &MockQuerier<Empty>,
+    ) -> Vec<CoinDTO<LeasePaymentCurrencies>> {
+        super::snapshot_baseline(
+            expected,
+            &Addr::unchecked(ACCOUNT),
+            QuerierWrapper::new(querier),
+        )
+        .expect("the baseline snapshot succeeds")
+    }
+
+    fn balances(holdings: &[(&str, Amount)]) -> MockQuerier<Empty> {
+        let coins: Vec<CwCoin> = holdings
+            .iter()
+            .map(|(denom, amount)| CwCoin::new(*amount, *denom))
+            .collect();
+        MockQuerier::<Empty>::new(&[(ACCOUNT, &coins)])
+    }
+}

--- a/protocol/contracts/lease/src/contract/state/arrival.rs
+++ b/protocol/contracts/lease/src/contract/state/arrival.rs
@@ -45,17 +45,19 @@ pub fn arrived_over_baseline<G>(
 where
     G: Group,
 {
-    debug_assert!(
-        !expected.is_empty(),
-        "a drain always transfers at least one coin, so the arrival check is never vacuous"
-    );
+    // A drain always carries at least one coin; an empty `expected` would let
+    // the `try_fold` seed report a no-transfer drain as complete, so fail closed
+    // in release rather than rely on a debug-only invariant.
+    if expected.is_empty() {
+        return Ok(false);
+    }
     unique_currencies(expected.iter().copied()).try_fold(true, |all_received, currency| {
         let expected_amount = aggregate_amount(expected.iter().copied(), &currency);
         let baseline_amount = aggregate_amount(baseline.iter().copied(), &currency);
         account_balance(&currency, account, querier)
             .map_err(Into::into)
             .map(|arrived| {
-                all_received && arrived.amount().saturating_sub(baseline_amount) >= expected_amount
+                all_received && expected_amount <= arrived.amount().saturating_sub(baseline_amount)
             })
     })
 }
@@ -79,7 +81,6 @@ where
     seen.into_iter()
 }
 
-/// Sum the amounts of every coin matching `currency`
 fn aggregate_amount<G, I>(coins: I, currency: &CoinDTO<G>) -> Amount
 where
     G: Group,
@@ -92,7 +93,8 @@ where
         .fold(Amount::ZERO, Amount::saturating_add)
 }
 
-/// Snapshot the local-account balance in `coin`'s currency
+/// Returns the raw bank error so each caller maps it into its own type — the
+/// entry snapshot into `ContractError`, the arrival check into `dex::Error`.
 fn account_balance<G>(
     coin: &CoinDTO<G>,
     account: &Addr,
@@ -222,6 +224,14 @@ mod tests {
             (Lpn::dto().definition().bank_symbol, PRINCIPAL),
         ]);
         assert_eq!(Ok(true), arrived(&distinct(), &baseline, &both));
+    }
+
+    /// An empty drain fails closed in release: the gate never reports a
+    /// no-transfer drain as complete, the release-safe replacement for the
+    /// former debug-only non-vacuity assertion.
+    #[test]
+    fn empty_expected_never_completes() {
+        assert_eq!(Ok(false), arrived(&[], &[], &balances(&[])));
     }
 
     // PaymentC1 and Lpn are distinct currencies; PaymentC2 aliases Lpn.

--- a/protocol/contracts/lease/src/contract/state/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/mod.rs
@@ -30,6 +30,7 @@ pub(crate) use self::handler::{Handler, Response};
 use self::{dex::State as DexState, lease::State as LeaseState};
 use finance::instant::Instant;
 
+mod arrival;
 mod closed;
 mod dex;
 mod drain;

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
@@ -1,12 +1,11 @@
 use std::iter;
 
 use currency::Group;
-use cw_time::IntoInstant;
 use oracle::stub::SwapPath;
 use serde::{Deserialize, Serialize};
 
 use dex::{
-    Account, CoinsNb, ContractInRemoteSwap, Enterable, Error as DexError, RemoteSwapClient,
+    Account, CoinsNb, ContractInRemoteSwap, Error as DexError, RemoteSwapClient,
     SlippageCalculator, SlippageEscalation, SwapOutputTask, SwapTask, WithCalculator,
     WithOutputTask,
 };
@@ -35,7 +34,7 @@ use crate::{
     contract::{
         Lease,
         state::{
-            Response, State, SwapResult,
+            State, SwapResult,
             opened::{
                 self,
                 payment::Repayable,
@@ -227,17 +226,7 @@ where
             &env.contract.address,
             querier,
         )
-        .and_then(|drain| {
-            dex::start_drain(drain)
-                .and_then(|start_drain| {
-                    start_drain
-                        .enter(env.block.time.into_instant(), querier)
-                        .map(|drain_msgs| {
-                            Response::from(drain_msgs, DrainState::<RepayableT>::from(start_drain))
-                        })
-                })
-                .map_err(Into::into)
-        })
+        .and_then(|drain| drain.start(env, querier))
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
@@ -220,20 +220,24 @@ where
         env: &Env,
         querier: QuerierWrapper<'_>,
     ) -> <Self as SwapTask>::Result {
-        let drain = RepayDrain::new(
+        RepayDrain::new(
             self.lease,
             amount_out.into(),
             CloseFinish::new(self.repayable),
-        );
-        dex::start_drain(drain)
-            .and_then(|start_drain| {
-                start_drain
-                    .enter(env.block.time.into_instant(), querier)
-                    .map(|drain_msgs| {
-                        Response::from(drain_msgs, DrainState::<RepayableT>::from(start_drain))
-                    })
-            })
-            .map_err(Into::into)
+            &env.contract.address,
+            querier,
+        )
+        .and_then(|drain| {
+            dex::start_drain(drain)
+                .and_then(|start_drain| {
+                    start_drain
+                        .enter(env.block.time.into_instant(), querier)
+                        .map(|drain_msgs| {
+                            Response::from(drain_msgs, DrainState::<RepayableT>::from(start_drain))
+                        })
+                })
+                .map_err(Into::into)
+        })
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opened/proceeds_drain.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/proceeds_drain.rs
@@ -3,7 +3,8 @@ use std::iter;
 use serde::{Deserialize, Serialize};
 
 use access_control::permissions::SingleUserPermission;
-use dex::{DrainStage, Error as DexError, RemoteTransferOutTask};
+use cw_time::IntoInstant;
+use dex::{DrainStage, Enterable, Error as DexError, RemoteTransferOutTask};
 use finance::{coin::CoinDTO, duration::Duration, instant::Instant};
 use platform::batch::Batch;
 use remote_lease::{
@@ -24,7 +25,7 @@ use crate::{
     },
     contract::{
         Lease,
-        state::{SwapResult, arrival, opened},
+        state::{Response, State, SwapResult, arrival, opened},
     },
     error::{ContractError, ContractResult},
     event::Type,
@@ -75,6 +76,24 @@ impl<Finisher> RepayDrain<Finisher> {
                 finisher,
                 baseline,
             })
+    }
+}
+
+impl<Finisher> RepayDrain<Finisher>
+where
+    Finisher: ProceedsFinish,
+    dex::StateDrain<RepayDrain<Finisher>>: Into<State>,
+{
+    pub(in super::super) fn start(self, env: &Env, querier: QuerierWrapper<'_>) -> SwapResult {
+        dex::start_drain(self)
+            .and_then(|start_drain| {
+                start_drain
+                    .enter(env.block.time.into_instant(), querier)
+                    .map(|drain_msgs| {
+                        Response::from(drain_msgs, dex::StateDrain::from(start_drain))
+                    })
+            })
+            .map_err(Into::into)
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opened/proceeds_drain.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/proceeds_drain.rs
@@ -85,14 +85,10 @@ where
     dex::StateDrain<RepayDrain<Finisher>>: Into<State>,
 {
     pub(in super::super) fn start(self, env: &Env, querier: QuerierWrapper<'_>) -> SwapResult {
-        dex::start_drain(self)
-            .and_then(|start_drain| {
-                start_drain
-                    .enter(env.block.time.into_instant(), querier)
-                    .map(|drain_msgs| {
-                        Response::from(drain_msgs, dex::StateDrain::from(start_drain))
-                    })
-            })
+        let start_drain = dex::start_drain(self)?;
+        start_drain
+            .enter(env.block.time.into_instant(), querier)
+            .map(|drain_msgs| Response::from(drain_msgs, dex::StateDrain::from(start_drain)))
             .map_err(Into::into)
     }
 }

--- a/protocol/contracts/lease/src/contract/state/opened/proceeds_drain.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/proceeds_drain.rs
@@ -85,10 +85,8 @@ where
     dex::StateDrain<RepayDrain<Finisher>>: Into<State>,
 {
     pub(in super::super) fn start(self, env: &Env, querier: QuerierWrapper<'_>) -> SwapResult {
-        let start_drain = dex::start_drain(self)?;
-        start_drain
-            .enter(env.block.time.into_instant(), querier)
-            .map(|drain_msgs| Response::from(drain_msgs, dex::StateDrain::from(start_drain)))
+        dex::start_drain(self)
+            .and_then(|start_drain| enter_drain(start_drain, env, querier))
             .map_err(Into::into)
     }
 }
@@ -288,6 +286,20 @@ enum ControllerExecuteMsg {
 }
 
 impl ControllerInnerMessage for ControllerExecuteMsg {}
+
+fn enter_drain<Finisher>(
+    start_drain: dex::StartDrainState<RepayDrain<Finisher>>,
+    env: &Env,
+    querier: QuerierWrapper<'_>,
+) -> dex::DexResult<Response>
+where
+    Finisher: ProceedsFinish,
+    dex::StateDrain<RepayDrain<Finisher>>: Into<State>,
+{
+    start_drain
+        .enter(env.block.time.into_instant(), querier)
+        .map(|drain_msgs| Response::from(drain_msgs, dex::StateDrain::from(start_drain)))
+}
 
 fn transfer_out_msg(controller: &Addr, coin: &CoinDTO<ProceedsGroup>) -> dex::DexResult<Batch> {
     TransferOutParams::new(coin.into_super_group())

--- a/protocol/contracts/lease/src/contract/state/opened/proceeds_drain.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/proceeds_drain.rs
@@ -3,14 +3,9 @@ use std::iter;
 use serde::{Deserialize, Serialize};
 
 use access_control::permissions::SingleUserPermission;
-use currency::CurrencyDef;
 use dex::{DrainStage, Error as DexError, RemoteTransferOutTask};
-use finance::{
-    coin::{Coin, CoinDTO, WithCoin},
-    duration::Duration,
-    instant::Instant,
-};
-use platform::{bank, batch::Batch};
+use finance::{coin::CoinDTO, duration::Duration, instant::Instant};
+use platform::batch::Batch;
 use remote_lease::{
     msg::TransferOutParams,
     response::OperationResponse,
@@ -29,9 +24,9 @@ use crate::{
     },
     contract::{
         Lease,
-        state::{SwapResult, opened},
+        state::{SwapResult, arrival, opened},
     },
-    error::ContractResult,
+    error::{ContractError, ContractResult},
     event::Type,
     finance::{LpnCoinDTO, LpnCurrencies},
 };
@@ -55,15 +50,31 @@ pub(crate) struct RepayDrain<Finisher> {
     lease: Lease,
     proceeds: LpnCoinDTO,
     finisher: Finisher,
+    /// The local-account balance in the proceeds' currency at the moment the
+    /// drain was entered — before any coin had been drained back. The arrival
+    /// check measures against this baseline, never an absolute balance, so a
+    /// balance the lease already held cannot be mistaken for the proceeds
+    /// arriving. Persisted with the task so it survives every callback's serde
+    /// round-trip; captured once at construction and never recomputed.
+    baseline: Vec<LpnCoinDTO>,
 }
 
 impl<Finisher> RepayDrain<Finisher> {
-    pub(in super::super) fn new(lease: Lease, proceeds: LpnCoinDTO, finisher: Finisher) -> Self {
-        Self {
-            lease,
-            proceeds,
-            finisher,
-        }
+    pub(in super::super) fn new(
+        lease: Lease,
+        proceeds: LpnCoinDTO,
+        finisher: Finisher,
+        account: &Addr,
+        querier: QuerierWrapper<'_>,
+    ) -> ContractResult<Self> {
+        arrival::snapshot_baseline(&[proceeds], account, querier)
+            .map_err(ContractError::from)
+            .map(|baseline| Self {
+                lease,
+                proceeds,
+                finisher,
+                baseline,
+            })
     }
 }
 
@@ -112,7 +123,7 @@ where
     }
 
     fn all_received(&self, account: &Addr, querier: QuerierWrapper<'_>) -> dex::DexResult<bool> {
-        received(&self.proceeds, account, querier)
+        arrival::arrived_over_baseline(&[self.proceeds], &self.baseline, account, querier)
     }
 
     fn finish(self, env: &Env, querier: QuerierWrapper<'_>) -> Self::Result {
@@ -288,32 +299,6 @@ fn decode_response(payload: &[u8]) -> dex::DexResult<()> {
         })
 }
 
-fn received(
-    expected: &CoinDTO<ProceedsGroup>,
-    account: &Addr,
-    querier: QuerierWrapper<'_>,
-) -> dex::DexResult<bool> {
-    struct CheckBalance<'account, 'querier> {
-        account: &'account Addr,
-        querier: QuerierWrapper<'querier>,
-    }
-
-    impl WithCoin<ProceedsGroup> for CheckBalance<'_, '_> {
-        type Outcome = dex::DexResult<bool>;
-
-        fn on<C>(self, expected: Coin<C>) -> Self::Outcome
-        where
-            C: CurrencyDef,
-        {
-            bank::balance::<C>(self.account, self.querier)
-                .map_err(Into::into)
-                .map(|ref balance| expected <= *balance)
-        }
-    }
-
-    expected.with_coin(CheckBalance { account, querier })
-}
-
 #[cfg(all(feature = "internal.test.contract", test))]
 mod tests {
     use currencies::testing::LeaseC2;
@@ -390,14 +375,20 @@ mod tests {
         });
     }
 
+    /// The proceeds have arrived only once the balance rises over its entry
+    /// baseline by the full proceeds amount: a pre-existing balance equal to
+    /// the proceeds is not mistaken for an arrival, while the zero-baseline
+    /// case is unchanged from an absolute balance check.
     #[test]
-    fn received_only_when_balance_covers_the_proceeds() {
-        let expected: CoinDTO<LpnCurrencies> = Coin::<LpnCurrency>::new(1000).into();
-        let account = Addr::unchecked(LEASE);
+    fn proceeds_arrival_measured_over_baseline() {
+        const PROCEEDS: u128 = 1_000;
+        let expected: CoinDTO<LpnCurrencies> = Coin::<LpnCurrency>::new(PROCEEDS).into();
 
-        assert_eq!(Ok(false), query_received(&expected, &account, 999));
-        assert_eq!(Ok(true), query_received(&expected, &account, 1000));
-        assert_eq!(Ok(true), query_received(&expected, &account, 1500));
+        assert_eq!(Ok(false), arrived(&expected, 0, PROCEEDS - 1));
+        assert_eq!(Ok(true), arrived(&expected, 0, PROCEEDS));
+
+        assert_eq!(Ok(false), arrived(&expected, PROCEEDS, PROCEEDS));
+        assert_eq!(Ok(true), arrived(&expected, PROCEEDS, PROCEEDS + PROCEEDS));
     }
 
     fn decode(payload: &OperationResponse) -> dex::DexResult<()> {
@@ -406,20 +397,37 @@ mod tests {
             .and_then(|payload| super::decode_response(&payload))
     }
 
-    fn query_received(
+    fn arrived(
         expected: &CoinDTO<LpnCurrencies>,
-        account: &Addr,
-        balance: u128,
+        baseline_balance: u128,
+        arrival_balance: u128,
     ) -> Result<bool, String> {
-        let mock_querier = MockQuerier::<Empty>::new(&[(
+        let account = Addr::unchecked(LEASE);
+        super::arrival::snapshot_baseline(
+            &[*expected],
+            &account,
+            QuerierWrapper::new(&held(baseline_balance)),
+        )
+        .map_err(|err| err.to_string())
+        .and_then(|baseline| {
+            super::arrival::arrived_over_baseline(
+                &[*expected],
+                &baseline,
+                &account,
+                QuerierWrapper::new(&held(arrival_balance)),
+            )
+            .map_err(|err| err.to_string())
+        })
+    }
+
+    fn held(balance: u128) -> MockQuerier<Empty> {
+        MockQuerier::<Empty>::new(&[(
             LEASE,
             &[CwCoin::new(
                 balance,
                 LpnCurrency::dto().definition().bank_symbol,
             )],
-        )]);
-        super::received(expected, account, QuerierWrapper::new(&mock_querier))
-            .map_err(|err| err.to_string())
+        )])
     }
 
     fn remote_lease_id() -> RemoteLeaseId {

--- a/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
@@ -221,18 +221,22 @@ impl SwapOutputTask<Self> for BuyLpn {
         env: &Env,
         querier: QuerierWrapper<'_>,
     ) -> <Self as SwapTask>::Result {
-        let drain = RepayDrain::new(
+        RepayDrain::new(
             self.lease,
             amount_out.into(),
             RepayFinish::new(self.payment),
-        );
-        dex::start_drain(drain)
-            .and_then(|start_drain| {
-                start_drain
-                    .enter(env.block.time.into_instant(), querier)
-                    .map(|drain_msgs| Response::from(drain_msgs, DrainState::from(start_drain)))
-            })
-            .map_err(Into::into)
+            &env.contract.address,
+            querier,
+        )
+        .and_then(|drain| {
+            dex::start_drain(drain)
+                .and_then(|start_drain| {
+                    start_drain
+                        .enter(env.block.time.into_instant(), querier)
+                        .map(|drain_msgs| Response::from(drain_msgs, DrainState::from(start_drain)))
+                })
+                .map_err(Into::into)
+        })
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
@@ -228,15 +228,7 @@ impl SwapOutputTask<Self> for BuyLpn {
             &env.contract.address,
             querier,
         )
-        .and_then(|drain| {
-            dex::start_drain(drain)
-                .and_then(|start_drain| {
-                    start_drain
-                        .enter(env.block.time.into_instant(), querier)
-                        .map(|drain_msgs| Response::from(drain_msgs, DrainState::from(start_drain)))
-                })
-                .map_err(Into::into)
-        })
+        .and_then(|drain| drain.start(env, querier))
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opening/unwind.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/unwind.rs
@@ -1,15 +1,13 @@
 use serde::{Deserialize, Serialize};
 
 use access_control::permissions::SingleUserPermission;
-use currency::{CurrencyDef, Group, MemberOf};
 use dex::{DrainStage, Error as DexError, RemoteTransferOutTask};
 use finance::{
-    coin::{Amount, Coin, CoinDTO, WithCoin},
+    coin::{Coin, CoinDTO},
     duration::Duration,
     instant::Instant,
-    zero::Zero,
 };
-use platform::{bank, batch::Batch, error::Error as PlatformError};
+use platform::batch::Batch;
 use remote_lease::{
     msg::TransferOutParams,
     response::OperationResponse,
@@ -28,7 +26,7 @@ use crate::{
         cmd::OpenLoanRespResult,
         finalize::LeasesRef,
         state::{
-            SwapResult,
+            SwapResult, arrival,
             opening::refund::{OpenFailureRefund, refund_to_open_failed},
         },
     },
@@ -90,20 +88,18 @@ impl OpeningUnwindTask {
     ) -> ContractResult<Self> {
         let (lpp_ref, _oracle, time_alarms, leases_ref) = deps;
         let principal_in = loan.principal.into_super_group::<LeasePaymentCurrencies>();
-        let baseline = unique_currencies([downpayment, principal_in])
-            .map(|coin| account_balance(&coin, lease_addr, querier))
-            .collect::<Result<Vec<_>, PlatformError>>()
-            .map_err(ContractError::from)?;
-        Ok(Self {
-            form,
-            downpayment,
-            loan,
-            lpp_ref,
-            leases_ref,
-            time_alarms,
-            remote_lease_controller,
-            baseline,
-        })
+        arrival::snapshot_baseline(&[downpayment, principal_in], lease_addr, querier)
+            .map_err(ContractError::from)
+            .map(|baseline| Self {
+                form,
+                downpayment,
+                loan,
+                lpp_ref,
+                leases_ref,
+                time_alarms,
+                remote_lease_controller,
+                baseline,
+            })
     }
 
     fn drained(&self) -> [DownpaymentCoin; 2] {
@@ -176,15 +172,7 @@ impl RemoteTransferOutTask for OpeningUnwindTask {
     /// currency and summed, so a downpayment and a principal in the same
     /// currency must BOTH land before the check passes.
     fn all_received(&self, account: &Addr, querier: QuerierWrapper<'_>) -> dex::DexResult<bool> {
-        unique_currencies(self.drained()).try_fold(true, |all_received, expected_currency| {
-            let aggregate = aggregate_amount(self.drained(), &expected_currency);
-            let baseline = aggregate_amount(self.baseline.iter().copied(), &expected_currency);
-            account_balance(&expected_currency, account, querier)
-                .map_err(Into::into)
-                .map(|arrived| {
-                    all_received && arrived.amount().saturating_sub(baseline) >= aggregate
-                })
-        })
+        arrival::arrived_over_baseline(&self.drained(), &self.baseline, account, querier)
     }
 
     fn finish(self, env: &Env, querier: QuerierWrapper<'_>) -> Self::Result {
@@ -224,65 +212,6 @@ impl RemoteTransferOutTask for OpeningUnwindTask {
     ) -> Self::StateResponse {
         self.state_envelope()
     }
-}
-
-/// Deduplicate a coin list down to one representative per currency
-///
-/// The drain handles at most two coins, so the linear scan is trivial; the
-/// representative carries the currency only — its amount is irrelevant to the
-/// per-currency aggregation done by [`aggregate_amount`].
-fn unique_currencies(
-    coins: impl IntoIterator<Item = DownpaymentCoin>,
-) -> impl Iterator<Item = DownpaymentCoin> {
-    let mut seen: Vec<DownpaymentCoin> = Vec::new();
-    for coin in coins {
-        if !seen.iter().any(|kept| kept.currency() == coin.currency()) {
-            seen.push(coin);
-        }
-    }
-    seen.into_iter()
-}
-
-/// Sum the amounts of every coin matching `currency`
-fn aggregate_amount(
-    coins: impl IntoIterator<Item = DownpaymentCoin>,
-    currency: &DownpaymentCoin,
-) -> Amount {
-    coins
-        .into_iter()
-        .filter(|coin| coin.currency() == currency.currency())
-        .map(|coin| coin.amount())
-        .fold(Amount::ZERO, Amount::saturating_add)
-}
-
-/// Snapshot the local-account balance in `coin`'s currency
-///
-/// Returns the raw bank error so each caller maps it into its own error type:
-/// the entry snapshot into `ContractError`, the arrival check into `dex::Error`.
-fn account_balance(
-    coin: &DownpaymentCoin,
-    account: &Addr,
-    querier: QuerierWrapper<'_>,
-) -> Result<DownpaymentCoin, PlatformError> {
-    struct Balance<'account, 'querier> {
-        account: &'account Addr,
-        querier: QuerierWrapper<'querier>,
-    }
-
-    impl WithCoin<LeasePaymentCurrencies> for Balance<'_, '_> {
-        type Outcome = Result<DownpaymentCoin, PlatformError>;
-
-        fn on<C>(self, _coin: Coin<C>) -> Self::Outcome
-        where
-            C: CurrencyDef,
-            C::Group: MemberOf<LeasePaymentCurrencies>
-                + MemberOf<<LeasePaymentCurrencies as Group>::TopG>,
-        {
-            bank::balance::<C>(self.account, self.querier).map(CoinDTO::from)
-        }
-    }
-
-    coin.with_coin(Balance { account, querier })
 }
 
 #[derive(Serialize)]

--- a/protocol/contracts/lease/src/contract/state/paid/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/paid/mod.rs
@@ -18,7 +18,7 @@ pub fn start_close(
     env: &Env,
     querier: QuerierWrapper<'_>,
 ) -> ContractResult<Response> {
-    transfer_out::start(lease).and_then(|start_drain| {
+    transfer_out::start(lease, &env.contract.address, querier).and_then(|start_drain| {
         start_drain
             .enter(env.block.time.into_instant(), querier)
             .map(|drain_msgs| curr_request_response.merge_with(drain_msgs))

--- a/protocol/contracts/lease/src/contract/state/paid/transfer_out.rs
+++ b/protocol/contracts/lease/src/contract/state/paid/transfer_out.rs
@@ -3,13 +3,8 @@ use std::iter;
 use serde::{Deserialize, Serialize};
 
 use access_control::permissions::SingleUserPermission;
-use currency::CurrencyDef;
 use dex::{DrainStage, Error as DexError, RemoteTransferOutTask};
-use finance::{
-    coin::{Coin, CoinDTO, WithCoin},
-    duration::Duration,
-    instant::Instant,
-};
+use finance::{coin::CoinDTO, duration::Duration, instant::Instant};
 use platform::{
     bank,
     batch::{Batch, Emit, Emitter},
@@ -32,9 +27,9 @@ use crate::{
     contract::{
         Lease,
         cmd::Close,
-        state::{SwapResult, paid::remote_close::ClosingRemoteLease},
+        state::{SwapResult, arrival, paid::remote_close::ClosingRemoteLease},
     },
-    error::ContractResult,
+    error::{ContractError, ContractResult},
     event::Type,
     lease::{LeaseDTO, with_lease_paid},
 };
@@ -48,18 +43,32 @@ type AssetGroup = LeaseAssetCurrencies;
 pub(super) type StartState = dex::StartDrainState<TransferOut>;
 pub(in super::super) type DexState = dex::StateDrain<TransferOut>;
 
-pub(super) fn start(lease: Lease) -> ContractResult<StartState> {
-    dex::start_drain(TransferOut::new(lease)).map_err(Into::into)
+pub(super) fn start(
+    lease: Lease,
+    account: &Addr,
+    querier: QuerierWrapper<'_>,
+) -> ContractResult<StartState> {
+    TransferOut::enter(lease, account, querier)
+        .and_then(|task| dex::start_drain(task).map_err(Into::into))
 }
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct TransferOut {
     lease: Lease,
+    /// The local-account balance in the lease asset's currency at the moment
+    /// the close drain was entered — before the asset had been drained back.
+    /// The arrival check measures against this baseline, never an absolute
+    /// balance, so a balance the lease already held cannot be mistaken for the
+    /// asset arriving. Persisted with the task so it survives every callback's
+    /// serde round-trip; captured once at construction and never recomputed.
+    baseline: Vec<CoinDTO<AssetGroup>>,
 }
 
 impl TransferOut {
-    fn new(lease: Lease) -> Self {
-        Self { lease }
+    fn enter(lease: Lease, account: &Addr, querier: QuerierWrapper<'_>) -> ContractResult<Self> {
+        arrival::snapshot_baseline(&[*lease.lease.position.amount()], account, querier)
+            .map_err(ContractError::from)
+            .map(|baseline| Self { lease, baseline })
     }
 
     fn amount(&self) -> &CoinDTO<AssetGroup> {
@@ -116,7 +125,7 @@ impl RemoteTransferOutTask for TransferOut {
     }
 
     fn all_received(&self, account: &Addr, querier: QuerierWrapper<'_>) -> dex::DexResult<bool> {
-        received(self.amount(), account, querier)
+        arrival::arrived_over_baseline(&[*self.amount()], &self.baseline, account, querier)
     }
 
     fn finish(self, env: &Env, querier: QuerierWrapper<'_>) -> Self::Result {
@@ -197,32 +206,6 @@ fn decode_response(payload: &[u8]) -> dex::DexResult<()> {
         })
 }
 
-fn received(
-    expected: &CoinDTO<AssetGroup>,
-    account: &Addr,
-    querier: QuerierWrapper<'_>,
-) -> dex::DexResult<bool> {
-    struct CheckBalance<'account, 'querier> {
-        account: &'account Addr,
-        querier: QuerierWrapper<'querier>,
-    }
-
-    impl WithCoin<AssetGroup> for CheckBalance<'_, '_> {
-        type Outcome = dex::DexResult<bool>;
-
-        fn on<C>(self, expected: Coin<C>) -> Self::Outcome
-        where
-            C: CurrencyDef,
-        {
-            bank::balance::<C>(self.account, self.querier)
-                .map_err(Into::into)
-                .map(|ref balance| expected <= *balance)
-        }
-    }
-
-    expected.with_coin(CheckBalance { account, querier })
-}
-
 #[cfg(all(feature = "internal.test.contract", test))]
 mod tests {
     use currencies::testing::LeaseC2;
@@ -290,14 +273,20 @@ mod tests {
         });
     }
 
+    /// The asset has arrived only once the balance rises over its entry
+    /// baseline by the full position amount: a pre-existing balance equal to
+    /// the amount is not mistaken for an arrival, while the zero-baseline case
+    /// is unchanged from an absolute balance check.
     #[test]
-    fn received_only_when_balance_covers_the_amount() {
-        let expected: CoinDTO<LeaseAssetCurrencies> = Coin::<LeaseC2>::new(1000).into();
-        let account = Addr::unchecked(LEASE);
+    fn asset_arrival_measured_over_baseline() {
+        const AMOUNT: u128 = 1_000;
+        let expected: CoinDTO<LeaseAssetCurrencies> = Coin::<LeaseC2>::new(AMOUNT).into();
 
-        assert_eq!(Ok(false), query_received(&expected, &account, 999));
-        assert_eq!(Ok(true), query_received(&expected, &account, 1000));
-        assert_eq!(Ok(true), query_received(&expected, &account, 1500));
+        assert_eq!(Ok(false), arrived(&expected, 0, AMOUNT - 1));
+        assert_eq!(Ok(true), arrived(&expected, 0, AMOUNT));
+
+        assert_eq!(Ok(false), arrived(&expected, AMOUNT, AMOUNT));
+        assert_eq!(Ok(true), arrived(&expected, AMOUNT, AMOUNT + AMOUNT));
     }
 
     #[test]
@@ -314,20 +303,37 @@ mod tests {
             .and_then(|payload| super::decode_response(&payload))
     }
 
-    fn query_received(
+    fn arrived(
         expected: &CoinDTO<LeaseAssetCurrencies>,
-        account: &Addr,
-        balance: u128,
+        baseline_balance: u128,
+        arrival_balance: u128,
     ) -> Result<bool, String> {
-        let mock_querier = MockQuerier::<Empty>::new(&[(
+        let account = Addr::unchecked(LEASE);
+        super::arrival::snapshot_baseline(
+            &[*expected],
+            &account,
+            QuerierWrapper::new(&held(baseline_balance)),
+        )
+        .map_err(|err| err.to_string())
+        .and_then(|baseline| {
+            super::arrival::arrived_over_baseline(
+                &[*expected],
+                &baseline,
+                &account,
+                QuerierWrapper::new(&held(arrival_balance)),
+            )
+            .map_err(|err| err.to_string())
+        })
+    }
+
+    fn held(balance: u128) -> MockQuerier<Empty> {
+        MockQuerier::<Empty>::new(&[(
             LEASE,
             &[CwCoin::new(
                 balance,
                 LeaseC2::dto().definition().bank_symbol,
             )],
-        )]);
-        super::received(expected, account, QuerierWrapper::new(&mock_querier))
-            .map_err(|err| err.to_string())
+        )])
     }
 
     fn remote_lease_id() -> RemoteLeaseId {


### PR DESCRIPTION
## What

The two sibling "drain" workflows that bring remotely-held funds home — the opened-lease proceeds drain (`RepayDrain`) and the paid-lease asset transfer-out (`TransferOut`) — gated completion on an absolute local-balance check (`expected <= balance`). A balance the lease already held, or one bank-sent to it, could satisfy that check before the drained funds actually arrived, completing the drain (and its payout / loan settlement / lease close) early.

This extracts the baseline-subtracted, aggregate-by-currency arrival check first written for the opening clean-unwind drain (#658) into one shared generic module, `contract::state::arrival` (`snapshot_baseline` / `arrived_over_baseline`, generic over the currency `Group`), and adopts it across all three drains. Each now snapshots a per-currency local-account baseline at drain entry — before any transfer dispatches, against the same account the arrival poll later reads — and requires `arrived − baseline ≥ Σ expected` per currency before completing.

## Why

The arrival check is the sole gate between "remote transfer acknowledged" and the irreversible local step: the transport carries no value cross-check, and an IBC ack proves only that the remote side initiated the transfer, not that the funds landed. Measuring over a pre-drain baseline closes three early-completion paths — a pre-existing balance, an external bank-send, and same-currency multi-leg under-counting.

The two siblings are single-coin today, so this is defense-in-depth plus a single audited implementation across the three drains, not a fix for a live fund-loss bug.

## Storage

Bumps lease storage to **v15** (forward-only; `migrate` refuses with `UnsupportedMigration`, mirroring v13/v14). No live remote-lease state exists, so nothing is stranded; deploy stays gated on the Solana program being live (the existing remote-lease deploy precondition).

## Tests

New unit coverage for the shared check (a pre-existing balance is not an arrival, per-currency aggregation, distinct currencies, zero-baseline single-coin unchanged) plus a per-sibling baseline test; the opening-unwind tests are unchanged and still pass. Full lease gate green (build, fmt, clippy, tests) across the agnostic test combo and a production per-DEX contract build.

Closes #670
