### PR TITLE
feat(dex): per-emission nonce on the remote transfer-out transport

### DIFF
--- a/protocol/contracts/lease/src/contract/state/opened/proceeds_drain.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/proceeds_drain.rs
@@ -127,8 +127,8 @@ where
         iter::once(self.proceeds)
     }
 
-    fn schedule_transfer_out(&self, coin: &CoinDTO<Self::G>) -> dex::DexResult<Batch> {
-        transfer_out_msg(&self.lease.lease.remote_lease_controller, coin)
+    fn schedule_transfer_out(&self, coin: &CoinDTO<Self::G>, nonce: u64) -> dex::DexResult<Batch> {
+        transfer_out_msg(&self.lease.lease.remote_lease_controller, coin, nonce)
     }
 
     fn decode_response(&self, payload: &[u8]) -> dex::DexResult<()> {
@@ -282,6 +282,7 @@ enum ControllerExecuteMsg {
     TransferOut {
         params: TransferOutParams,
         timeout: Duration,
+        nonce: u64,
     },
 }
 
@@ -301,13 +302,21 @@ where
         .map(|drain_msgs| Response::from(drain_msgs, dex::StateDrain::from(start_drain)))
 }
 
-fn transfer_out_msg(controller: &Addr, coin: &CoinDTO<ProceedsGroup>) -> dex::DexResult<Batch> {
+fn transfer_out_msg(
+    controller: &Addr,
+    coin: &CoinDTO<ProceedsGroup>,
+    nonce: u64,
+) -> dex::DexResult<Batch> {
     TransferOutParams::new(coin.into_super_group())
         .map_err(DexError::remote_swap_client)
         .and_then(|params| {
             ControllerLease::new(controller)
                 .transfer_out(params, TransferOutParams::TIMEOUT, |params, timeout| {
-                    ControllerExecuteMsg::TransferOut { params, timeout }
+                    ControllerExecuteMsg::TransferOut {
+                        params,
+                        timeout,
+                        nonce,
+                    }
                 })
                 .map_err(Into::into)
         })
@@ -349,19 +358,22 @@ mod tests {
 
     #[test]
     fn transfer_out_msg_shape_matches_the_controller_wire() {
+        const NONCE: u64 = 7;
         let proceeds: CoinDTO<LpnCurrencies> = Coin::<LpnCurrency>::new(1000).into();
         let params =
             TransferOutParams::new(proceeds.into_super_group()).expect("a non-zero amount");
         let msg = super::ControllerExecuteMsg::TransferOut {
             params: params.clone(),
             timeout: TransferOutParams::TIMEOUT,
+            nonce: NONCE,
         };
 
         let expected = format!(
-            r#"{{"transfer_out":{{"params":{},"timeout":{}}}}}"#,
+            r#"{{"transfer_out":{{"params":{},"timeout":{},"nonce":{}}}}}"#,
             cosmwasm_std::to_json_string(&params).expect("the params should serialize"),
             cosmwasm_std::to_json_string(&TransferOutParams::TIMEOUT)
                 .expect("the timeout should serialize"),
+            NONCE,
         );
         assert_eq!(
             expected,
@@ -372,7 +384,7 @@ mod tests {
     #[test]
     fn transfer_out_msg_targets_the_controller() {
         let coin: CoinDTO<LpnCurrencies> = Coin::<LpnCurrency>::new(1000).into();
-        let batch = super::transfer_out_msg(&Addr::unchecked(CONTROLLER), &coin)
+        let batch = super::transfer_out_msg(&Addr::unchecked(CONTROLLER), &coin, 7)
             .expect("a valid transfer-out message");
         assert_eq!(1, batch.len());
     }

--- a/protocol/contracts/lease/src/contract/state/opening/unwind.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/unwind.rs
@@ -155,8 +155,8 @@ impl RemoteTransferOutTask for OpeningUnwindTask {
         self.drained()
     }
 
-    fn schedule_transfer_out(&self, coin: &CoinDTO<Self::G>) -> dex::DexResult<Batch> {
-        transfer_out_msg(&self.remote_lease_controller, coin)
+    fn schedule_transfer_out(&self, coin: &CoinDTO<Self::G>, nonce: u64) -> dex::DexResult<Batch> {
+        transfer_out_msg(&self.remote_lease_controller, coin, nonce)
     }
 
     fn decode_response(&self, payload: &[u8]) -> dex::DexResult<()> {
@@ -220,6 +220,7 @@ enum ControllerExecuteMsg {
     TransferOut {
         params: TransferOutParams,
         timeout: Duration,
+        nonce: u64,
     },
 }
 
@@ -228,13 +229,18 @@ impl ControllerInnerMessage for ControllerExecuteMsg {}
 fn transfer_out_msg(
     controller: &Addr,
     coin: &CoinDTO<LeasePaymentCurrencies>,
+    nonce: u64,
 ) -> dex::DexResult<Batch> {
     TransferOutParams::new(*coin)
         .map_err(DexError::remote_swap_client)
         .and_then(|params| {
             ControllerLease::new(controller)
                 .transfer_out(params, TransferOutParams::TIMEOUT, |params, timeout| {
-                    ControllerExecuteMsg::TransferOut { params, timeout }
+                    ControllerExecuteMsg::TransferOut {
+                        params,
+                        timeout,
+                        nonce,
+                    }
                 })
                 .map_err(Into::into)
         })

--- a/protocol/contracts/lease/src/contract/state/paid/remote_close.rs
+++ b/protocol/contracts/lease/src/contract/state/paid/remote_close.rs
@@ -200,9 +200,10 @@ impl Handler for ClosingRemoteLease {
         _querier: QuerierWrapper<'_>,
         env: Env,
     ) -> ContractResult<Response> {
-        // CloseLease/TransferOut over this transport are not yet
-        // nonce-correlated (they convert in a later phase), so the callback
-        // nonce is not consulted here.
+        // CloseLease is a single-packet operation that rides a zero nonce - no
+        // duplicate-callback window to close - so the callback nonce is not
+        // consulted here; a stray transfer-out ack landing after the drain is
+        // absorbed below as an unexpected variant.
         self.authz_callback(&info)
             .and_then(|()| match callback.outcome {
                 RemoteOperationOutcome::OperationOk(WireOperationResponse::CloseLease(

--- a/protocol/contracts/lease/src/contract/state/paid/transfer_out.rs
+++ b/protocol/contracts/lease/src/contract/state/paid/transfer_out.rs
@@ -116,8 +116,8 @@ impl RemoteTransferOutTask for TransferOut {
         iter::once(*self.amount())
     }
 
-    fn schedule_transfer_out(&self, coin: &CoinDTO<Self::G>) -> dex::DexResult<Batch> {
-        transfer_out_msg(&self.lease.lease.remote_lease_controller, coin)
+    fn schedule_transfer_out(&self, coin: &CoinDTO<Self::G>, nonce: u64) -> dex::DexResult<Batch> {
+        transfer_out_msg(&self.lease.lease.remote_lease_controller, coin, nonce)
     }
 
     fn decode_response(&self, payload: &[u8]) -> dex::DexResult<()> {
@@ -176,18 +176,27 @@ enum ControllerExecuteMsg {
     TransferOut {
         params: TransferOutParams,
         timeout: Duration,
+        nonce: u64,
     },
 }
 
 impl ControllerInnerMessage for ControllerExecuteMsg {}
 
-fn transfer_out_msg(controller: &Addr, coin: &CoinDTO<AssetGroup>) -> dex::DexResult<Batch> {
+fn transfer_out_msg(
+    controller: &Addr,
+    coin: &CoinDTO<AssetGroup>,
+    nonce: u64,
+) -> dex::DexResult<Batch> {
     TransferOutParams::new(coin.into_super_group())
         .map_err(DexError::remote_swap_client)
         .and_then(|params| {
             ControllerLease::new(controller)
                 .transfer_out(params, TransferOutParams::TIMEOUT, |params, timeout| {
-                    ControllerExecuteMsg::TransferOut { params, timeout }
+                    ControllerExecuteMsg::TransferOut {
+                        params,
+                        timeout,
+                        nonce,
+                    }
                 })
                 .map_err(Into::into)
         })
@@ -229,18 +238,21 @@ mod tests {
 
     #[test]
     fn transfer_out_msg_shape_matches_the_controller_wire() {
+        const NONCE: u64 = 7;
         let amount: CoinDTO<LeasePaymentCurrencies> = Coin::<LeaseC2>::new(1000).into();
         let params = TransferOutParams::new(amount).expect("a non-zero amount");
         let msg = super::ControllerExecuteMsg::TransferOut {
             params: params.clone(),
             timeout: TransferOutParams::TIMEOUT,
+            nonce: NONCE,
         };
 
         let expected = format!(
-            r#"{{"transfer_out":{{"params":{},"timeout":{}}}}}"#,
+            r#"{{"transfer_out":{{"params":{},"timeout":{},"nonce":{}}}}}"#,
             cosmwasm_std::to_json_string(&params).expect("the params should serialize"),
             cosmwasm_std::to_json_string(&TransferOutParams::TIMEOUT)
                 .expect("the timeout should serialize"),
+            NONCE,
         );
         assert_eq!(
             expected,
@@ -292,7 +304,7 @@ mod tests {
     #[test]
     fn transfer_out_msg_targets_the_controller() {
         let coin: CoinDTO<LeaseAssetCurrencies> = Coin::<LeaseC2>::new(1000).into();
-        let batch = super::transfer_out_msg(&Addr::unchecked(CONTROLLER), &coin)
+        let batch = super::transfer_out_msg(&Addr::unchecked(CONTROLLER), &coin, 7)
             .expect("a valid transfer-out message");
         assert_eq!(1, batch.len());
     }

--- a/protocol/contracts/remote_lease/src/api.rs
+++ b/protocol/contracts/remote_lease/src/api.rs
@@ -59,9 +59,16 @@ pub enum ExecuteMsg {
         nonce: u64,
     },
     /// Outbound `TransferOut` packet. See [`ExecuteMsg::OpenLease`] for `timeout` semantics.
+    ///
+    /// `nonce` is the lease's per-emission correlation identifier; it rides the
+    /// packet envelope and is returned in the callback so the lease can match
+    /// the acknowledgment to the exact in-flight transfer. `#[serde(default)]`
+    /// keeps it optional at decode for callers that predate the field.
     TransferOut {
         params: TransferOutParams,
         timeout: Duration,
+        #[serde(default)]
+        nonce: u64,
     },
 }
 

--- a/protocol/contracts/remote_lease/src/contract.rs
+++ b/protocol/contracts/remote_lease/src/contract.rs
@@ -31,12 +31,13 @@ use crate::{
 
 const CONTRACT_STORAGE_VERSION: VersionSegment = 0;
 
-/// Envelope nonce for operations that are not yet callback-correlated.
+/// Envelope nonce for the single-packet operations that have no duplicate-
+/// callback window to close.
 ///
-/// Only the `Swap` operation carries a per-emission nonce today (issue #636);
-/// the single-packet `OpenLease`/`CloseLease`/`TransferOut` flows have no
-/// duplicate-callback exposure to close, so they ride a zero nonce until they
-/// convert in the remaining ibc-solray#142 phases.
+/// `OpenLease`/`CloseLease` solicit exactly one callback, so a superseded-packet
+/// race cannot arise and they ride a zero nonce. `Swap` (#636) and the multi-leg
+/// `TransferOut` drain (#671) instead carry a real per-emission nonce the lease
+/// assigns, so a packet superseded by a re-emission or heal is rejected.
 const NO_NONCE: u64 = 0;
 const CURRENT_RELEASE: ProtocolPackageRelease = ProtocolPackageRelease::current(
     package_name!(),
@@ -151,13 +152,17 @@ pub fn execute(
             timeout,
             nonce,
         ),
-        ExecuteMsg::TransferOut { params, timeout } => send_operation(
+        ExecuteMsg::TransferOut {
+            params,
+            timeout,
+            nonce,
+        } => send_operation(
             deps,
             &env,
             info.sender,
             Operation::TransferOut(params),
             timeout,
-            NO_NONCE,
+            nonce,
         ),
     }
     .map(response::response_only_messages)

--- a/protocol/contracts/remote_lease/src/contract/tests/execute_outbound.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/execute_outbound.rs
@@ -84,6 +84,8 @@ fn swap_emits_send_packet() {
 
 #[test]
 fn transfer_out_emits_send_packet() {
+    const TRANSFER_OUT_NONCE: u64 = 5;
+
     let mut deps = deps_with_lease();
     instantiate_default(deps.as_mut());
     store_open_channel(deps.as_mut());
@@ -96,10 +98,15 @@ fn transfer_out_emits_send_packet() {
         ExecuteMsg::TransferOut {
             params: params.clone(),
             timeout: PACKET_TIMEOUT,
+            nonce: TRANSFER_OUT_NONCE,
         },
     )
     .unwrap();
-    assert_send_packet(&Operation::TransferOut(params), 0, &res.messages);
+    assert_send_packet(
+        &Operation::TransferOut(params),
+        TRANSFER_OUT_NONCE,
+        &res.messages,
+    );
 }
 
 #[test]

--- a/protocol/packages/dex/src/impl_/remote_transfer_out.rs
+++ b/protocol/packages/dex/src/impl_/remote_transfer_out.rs
@@ -222,10 +222,16 @@ where
     /// Advance the in-flight nonce ahead of a same-transfer re-emission, so the
     /// superseded packet's late callback no longer matches and is absorbed.
     fn with_bumped_nonce(self) -> Self {
+        let prev_nonce = self.in_flight_nonce;
         let ret = Self {
-            in_flight_nonce: self.in_flight_nonce.saturating_add(1),
+            in_flight_nonce: prev_nonce.saturating_add(1),
             ..self
         };
+        // The module doc's strict-monotonicity pillar, made executable: a bump
+        // must strictly increase the nonce or the mismatch guard would credit a
+        // superseded packet's late callback. Trips in debug/test if a refactor
+        // (or the unreachable u64::MAX saturation) ever breaks it.
+        debug_assert!(prev_nonce < ret.in_flight_nonce);
         debug_assert!(ret.invariant_held());
         ret
     }
@@ -285,7 +291,9 @@ where
                 .try_complete(querier, env)
                 .map_into(),
             Some(acks_left) => {
-                Self::internal_new(self.spec, acks_left, self.in_flight_nonce.saturating_add(1))
+                let next_nonce = self.in_flight_nonce.saturating_add(1);
+                debug_assert!(self.in_flight_nonce < next_nonce);
+                Self::internal_new(self.spec, acks_left, next_nonce)
                     .schedule_and_continue()
                     .into()
             }

--- a/protocol/packages/dex/src/impl_/remote_transfer_out.rs
+++ b/protocol/packages/dex/src/impl_/remote_transfer_out.rs
@@ -1,15 +1,31 @@
 //! # Acknowledgment-to-transfer correlation trust model
 //!
-//! `OperationResponse::TransferOut` carries no payload at all, so
-//! acknowledgments correlate to transfers purely positionally: each one is
-//! credited to the single in-flight transfer the `acks_left` countdown
-//! tracks. This is a strictly weaker correlation than the swap leg's -
-//! there is not even a `min_out`-style cross-check on the credited value.
-//! The wire contract is frozen; a per-operation nonce is a cross-repo
-//! follow-up. The positional assumption rests on the same pillars as
-//! [`RemoteSwap`][super::remote_swap::RemoteSwap]: authorization of the
-//! callback sender, the controller's exactly-one-packet delivery, and the
-//! sequential one-in-flight emission.
+//! `OperationResponse::TransferOut` carries no payload at all, so an
+//! acknowledgment cannot identify its transfer from content - there is not
+//! even a `min_out`-style cross-check on a credited value. Each emission
+//! instead rides a per-emission `nonce` on the packet envelope. The controller
+//! reads it back from the original outbound packet on ack/timeout and returns
+//! it in the callback, so an acknowledgment is credited to the exact emission
+//! that solicited it: a callback whose nonce differs from the in-flight one is
+//! absorbed (`nonce-mismatch`) without touching progress. The node still tracks
+//! the in-flight transfer positionally through the `acks_left` countdown; the
+//! nonce disambiguates *which emission* of that transfer a callback belongs to.
+//! Correctness rests on the same pillars as
+//! [`RemoteSwap`][super::remote_swap::RemoteSwap]:
+//!
+//! - authorization - only the remote-lease controller passes
+//!   [`Handler::authz_remote_callback`], so callbacks cannot be forged;
+//! - the controller's delivery semantics - every emitted transfer becomes
+//!   exactly one IBC packet addressed back to this contract, its ack and
+//!   timeout paths mutually exclusive and at-most-once;
+//! - the strictly-monotonic `in_flight_nonce` - every emission, including each
+//!   re-emission and operator [`Handler::heal`], bumps it, so a packet
+//!   superseded by a later emission carries a smaller nonce and its late
+//!   callback is rejected. This closes the duplicate-acknowledgment window that
+//!   a `heal` issued while the original packet is still resolvable would
+//!   otherwise open: the original's late ack no longer matches the in-flight
+//!   emission and is absorbed instead of positionally mis-credited to a
+//!   consecutive transfer.
 //!
 //! # Acknowledgment does not mean arrival
 //!
@@ -64,6 +80,10 @@ const EVENT_VALUE_REEMIT: &str = "re-emit";
 const ABSORB_UNDECODABLE: &str = "undecodable-response";
 const ABSORB_UNEXPECTED_VARIANT: &str = "unexpected-response-variant";
 const ABSORB_REMOTE_ERROR: &str = "remote-error";
+const ABSORB_NONCE_MISMATCH: &str = "nonce-mismatch";
+/// Predecessor nonce for the very first emission of a node: nothing has been
+/// emitted yet, so the first transfer opens at `NO_PRIOR_NONCE + 1`.
+const NO_PRIOR_NONCE: u64 = 0;
 
 /// Specification of a remote-account drain
 ///
@@ -95,8 +115,11 @@ where
     /// Schedule a transfer of `coin` out of the remote account
     ///
     /// The transport guarantees a single response, error, or timeout
-    /// per scheduled transfer.
-    fn schedule_transfer_out(&self, coin: &CoinDTO<Self::G>) -> Result<Batch>;
+    /// per scheduled transfer. `nonce` is the per-emission correlation
+    /// identifier the node assigns; it must ride the packet envelope so the
+    /// controller can return it in the callback and the node can match the
+    /// acknowledgment to this emission.
+    fn schedule_transfer_out(&self, coin: &CoinDTO<Self::G>, nonce: u64) -> Result<Batch>;
 
     /// Validate a transfer response payload
     ///
@@ -153,6 +176,12 @@ where
 {
     spec: Task,
     acks_left: CoinsNb,
+    /// Strictly-monotonic per-emission correlation nonce; bumped on every
+    /// emission and re-emission, matched against the callback. `#[serde(default)]`
+    /// lets a node persisted before the nonce existed load with a zero nonce,
+    /// matching the zero an old, nonce-less in-flight packet decodes to.
+    #[serde(default)]
+    in_flight_nonce: u64,
     #[serde(skip)]
     _state_enum: PhantomData<SEnum>,
 }
@@ -170,16 +199,32 @@ where
                 if acks_left == 0 {
                     Err(Error::MissingTransferOutLeg)
                 } else {
-                    Ok(Self::internal_new(spec, acks_left))
+                    Ok(Self::internal_new(
+                        spec,
+                        acks_left,
+                        NO_PRIOR_NONCE.saturating_add(1),
+                    ))
                 }
             })
     }
 
-    fn internal_new(spec: Task, acks_left: CoinsNb) -> Self {
+    fn internal_new(spec: Task, acks_left: CoinsNb, in_flight_nonce: u64) -> Self {
         let ret = Self {
             spec,
             acks_left,
+            in_flight_nonce,
             _state_enum: PhantomData,
+        };
+        debug_assert!(ret.invariant_held());
+        ret
+    }
+
+    /// Advance the in-flight nonce ahead of a same-transfer re-emission, so the
+    /// superseded packet's late callback no longer matches and is absorbed.
+    fn with_bumped_nonce(self) -> Self {
+        let ret = Self {
+            in_flight_nonce: self.in_flight_nonce.saturating_add(1),
+            ..self
         };
         debug_assert!(ret.invariant_held());
         ret
@@ -208,7 +253,7 @@ where
     /// recovery paths idempotent.
     fn schedule(&self) -> Result<Batch> {
         self.in_flight_transfer()
-            .and_then(|coin| self.spec.schedule_transfer_out(&coin))
+            .and_then(|coin| self.spec.schedule_transfer_out(&coin, self.in_flight_nonce))
     }
 
     fn emit_acks_left(&self) -> Emitter {
@@ -239,9 +284,11 @@ where
             Some(0) => FundsArrival::new(self.spec)
                 .try_complete(querier, env)
                 .map_into(),
-            Some(acks_left) => Self::internal_new(self.spec, acks_left)
-                .schedule_and_continue()
-                .into(),
+            Some(acks_left) => {
+                Self::internal_new(self.spec, acks_left, self.in_flight_nonce.saturating_add(1))
+                    .schedule_and_continue()
+                    .into()
+            }
         }
     }
 
@@ -292,10 +339,13 @@ where
     fn on_remote_response(
         self,
         data: Binary,
-        _nonce: u64,
+        nonce: u64,
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> HandlerResult<Self> {
+        if nonce != self.in_flight_nonce {
+            return self.absorb(ABSORB_NONCE_MISMATCH).into();
+        }
         match self.spec.decode_response(data.as_slice()) {
             Ok(()) => self.deliver_ack(querier, env),
             Err(Error::UnexpectedResponseVariant(_details)) => {
@@ -309,45 +359,50 @@ where
     fn on_remote_error(
         self,
         _response: ICAErrorResponse,
-        _nonce: u64,
+        nonce: u64,
         _querier: QuerierWrapper<'_>,
         _env: Env,
     ) -> HandlerResult<Self> {
+        if nonce != self.in_flight_nonce {
+            return self.absorb(ABSORB_NONCE_MISMATCH).into();
+        }
         self.absorb(ABSORB_REMOTE_ERROR).into()
     }
 
     fn on_remote_timeout(
         self,
-        _nonce: u64,
+        nonce: u64,
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> HandlerResult<Self> {
-        let state_label = self.spec.label();
-        timeout::on_timeout_retry(self, state_label, querier, env).into()
+        if nonce != self.in_flight_nonce {
+            return self.absorb(ABSORB_NONCE_MISMATCH).into();
+        }
+        let node = self.with_bumped_nonce();
+        let state_label = node.spec.label();
+        timeout::on_timeout_retry(node, state_label, querier, env).into()
     }
 
     /// Re-emit the in-flight transfer verbatim
     ///
-    /// The operator recovery for both an unresolvable packet and an
-    /// absorbed error acknowledgment. See the module doc of
-    /// [`RemoteSwap`][super::remote_swap::RemoteSwap] for the
-    /// duplicate-acknowledgment risk a heal issued while the original
-    /// operation is still resolvable creates. `RemoteSwap` now closes that
-    /// window with a per-emission nonce; this payload-less transport does
-    /// not yet carry one - its adoption is deferred to the remaining
-    /// ibc-solray#142 phases - so it stays credulous to the risk by
-    /// construction until it does.
+    /// The operator recovery for both an unresolvable packet and an absorbed
+    /// error acknowledgment. The re-emission carries a fresh nonce (via
+    /// [`RemoteTransferOut::with_bumped_nonce`]) so the original packet's late
+    /// callback is absorbed as `nonce-mismatch` rather than positionally
+    /// mis-credited - the heal is idempotent regardless of operator timing
+    /// (see the module doc).
     fn heal(
         self,
         _querier: QuerierWrapper<'_>,
         _env: Env,
         _info: &MessageInfo,
     ) -> HandlerResult<Self> {
-        self.schedule()
+        let node = self.with_bumped_nonce();
+        node.schedule()
             .and_then(|batch| {
                 response::res_continue::<_, _, Self>(
-                    MessageResponse::messages_with_event(batch, self.emit_heal()),
-                    self,
+                    MessageResponse::messages_with_event(batch, node.emit_heal()),
+                    node,
                 )
             })
             .into()
@@ -475,7 +530,13 @@ pub(super) mod mock {
             self.coins.clone()
         }
 
-        fn schedule_transfer_out(&self, coin: &CoinDTO<SuperGroup>) -> Result<Batch> {
+        // The mock ignores the nonce in the emitted batch — the production
+        // controller puts it on the packet envelope, but the mock's
+        // `TransferOutRequest` payload keeps the pre-nonce coin shape so the
+        // existing transfer/timeout response assertions stay byte-identical. The
+        // nonce is exercised through the node's callback-matching, not the
+        // emitted batch.
+        fn schedule_transfer_out(&self, coin: &CoinDTO<SuperGroup>, _nonce: u64) -> Result<Batch> {
             transfer_request(coin)
         }
 
@@ -585,10 +646,13 @@ mod tests {
         let mock_querier = MockQuerier::default();
         let querier = QuerierWrapper::new(&mock_querier);
 
+        let node = started();
+        let nonce = node.in_flight_nonce;
         let (response, node) =
-            continued(started().on_remote_response(ok_payload(), 0, querier, testing::mock_env()));
+            continued(node.on_remote_response(ok_payload(), nonce, querier, testing::mock_env()));
         assert_eq!(transfer_response(&coin2(70), 1), response);
         assert_acks_left(1, &node);
+        assert_eq!(2, node.in_flight_nonce);
     }
 
     #[test]
@@ -598,7 +662,8 @@ mod tests {
         let env = testing::mock_env();
 
         let node = after_first_ack(querier);
-        let resp = match node.on_remote_response(ok_payload(), 0, querier, env.clone()) {
+        let nonce = node.in_flight_nonce;
+        let resp = match node.on_remote_response(ok_payload(), nonce, querier, env.clone()) {
             HandlerResult::Continue(Ok(resp)) => resp,
             HandlerResult::Continue(Err(err)) => panic!("expected a continuation, got {err}"),
             HandlerResult::Finished(_result) => panic!("expected a continuation, got a finish"),
@@ -614,9 +679,10 @@ mod tests {
 
         let mut node = after_first_ack(querier);
         node.spec.set_received(true);
+        let nonce = node.in_flight_nonce;
         assert_eq!(
             mock::FINISH_RESULT,
-            finished(node.on_remote_response(ok_payload(), 0, querier, testing::mock_env()))
+            finished(node.on_remote_response(ok_payload(), nonce, querier, testing::mock_env()))
         );
     }
 
@@ -627,9 +693,11 @@ mod tests {
         let mock_querier = MockQuerier::default();
         let querier = QuerierWrapper::new(&mock_querier);
 
-        let (response, node) = continued(started().on_remote_error(
+        let node = started();
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_error(
             ICAErrorResponse::from(String::from("transfer failed")),
-            0,
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -643,9 +711,12 @@ mod tests {
         let querier = QuerierWrapper::new(&mock_querier);
         let env = testing::mock_env();
 
-        let (response, node) = continued(started().on_remote_timeout(0, querier, env.clone()));
+        let node = started();
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_timeout(nonce, querier, env.clone()));
         assert_eq!(timeout_response(&coin1(100), &env), response);
         assert_acks_left(2, &node);
+        assert_eq!(2, node.in_flight_nonce);
     }
 
     #[test]
@@ -653,9 +724,11 @@ mod tests {
         let mock_querier = MockQuerier::default();
         let querier = QuerierWrapper::new(&mock_querier);
 
-        let (response, node) = continued(started().on_remote_response(
+        let node = started();
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_response(
             Binary::from(b"garbage".as_slice()),
-            0,
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -668,9 +741,11 @@ mod tests {
         let mock_querier = MockQuerier::default();
         let querier = QuerierWrapper::new(&mock_querier);
 
-        let (response, node) = continued(started().on_remote_response(
+        let node = started();
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_response(
             Binary::from(mock::WRONG_VARIANT_PAYLOAD),
-            0,
+            nonce,
             querier,
             testing::mock_env(),
         ));
@@ -697,6 +772,77 @@ mod tests {
             response
         );
         assert_acks_left(1, &node);
+        assert_eq!(3, node.in_flight_nonce);
+    }
+
+    #[test]
+    fn stale_response_nonce_absorbed() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let node = started();
+        let stale = node.in_flight_nonce.saturating_sub(1);
+        let (response, node) =
+            continued(node.on_remote_response(ok_payload(), stale, querier, testing::mock_env()));
+        assert_eq!(absorb_response("nonce-mismatch"), response);
+        assert_acks_left(2, &node);
+        assert_eq!(1, node.in_flight_nonce);
+    }
+
+    #[test]
+    fn stale_error_nonce_absorbed() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let node = started();
+        let stale = node.in_flight_nonce.saturating_sub(1);
+        let (response, node) = continued(node.on_remote_error(
+            ICAErrorResponse::from(String::from("transfer failed")),
+            stale,
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(absorb_response("nonce-mismatch"), response);
+        assert_acks_left(2, &node);
+    }
+
+    #[test]
+    fn stale_timeout_nonce_absorbed() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let node = started();
+        let stale = node.in_flight_nonce.saturating_sub(1);
+        let (response, node) =
+            continued(node.on_remote_timeout(stale, querier, testing::mock_env()));
+        assert_eq!(absorb_response("nonce-mismatch"), response);
+        assert_acks_left(2, &node);
+        assert_eq!(1, node.in_flight_nonce);
+    }
+
+    /// A heal bumps the nonce, so the original packet's late acknowledgment no
+    /// longer matches the in-flight emission - it is absorbed instead of
+    /// advancing the countdown, closing the duplicate-acknowledgment window.
+    #[test]
+    fn heal_supersedes_the_original_packet_ack() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let node = started();
+        let original_nonce = node.in_flight_nonce;
+        let info = MessageInfo {
+            sender: Addr::unchecked(mock::CONTROLLER),
+            funds: vec![],
+        };
+        let (_response, node) = continued(node.heal(querier, testing::mock_env(), &info));
+        let (response, node) = continued(node.on_remote_response(
+            ok_payload(),
+            original_nonce,
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(absorb_response("nonce-mismatch"), response);
+        assert_acks_left(2, &node);
     }
 
     #[test]
@@ -709,6 +855,7 @@ mod tests {
         let restored: Node =
             sdk::cosmwasm_std::from_json(&serialized).expect("the state should round-trip");
         assert_acks_left(node.acks_left, &restored);
+        assert_eq!(node.in_flight_nonce, restored.in_flight_nonce);
         assert_eq!(
             serialized,
             sdk::cosmwasm_std::to_json_vec(&restored).expect("a serializable state")
@@ -736,8 +883,10 @@ mod tests {
     }
 
     fn after_first_ack(querier: QuerierWrapper<'_>) -> Node {
+        let node = started();
+        let nonce = node.in_flight_nonce;
         let (_response, node) =
-            continued(started().on_remote_response(ok_payload(), 0, querier, testing::mock_env()));
+            continued(node.on_remote_response(ok_payload(), nonce, querier, testing::mock_env()));
         node
     }
 

--- a/tests/src/common/remote_lease_controller_stub.rs
+++ b/tests/src/common/remote_lease_controller_stub.rs
@@ -141,9 +141,14 @@ pub enum StubExecuteMsg {
         #[serde(default)]
         nonce: u64,
     },
+    // #671: `TransferOut` carries the per-emission `nonce` the same way `Swap`
+    // does; the stand-in echoes it into the synthesised callback exactly as the
+    // production controller forwards `envelope.nonce`.
     TransferOut {
         params: TransferOutParams,
         timeout: finance::duration::Duration,
+        #[serde(default)]
+        nonce: u64,
     },
     /// Test-only: configure the stand-in's reply for a given op tag.
     SetResponseMode {
@@ -325,9 +330,9 @@ pub fn execute(
                 }))
             })
         }
-        StubExecuteMsg::TransferOut { params, .. } => {
+        StubExecuteMsg::TransferOut { params, nonce, .. } => {
             record_transfer_out(deps.storage, &info.sender, &params)?;
-            handle_outbound(deps, info, op_tag::TRANSFER_OUT, 0, |_storage| {
+            handle_outbound(deps, info, op_tag::TRANSFER_OUT, nonce, |_storage| {
                 Ok(OperationResponse::TransferOut(TransferOutResponse {}))
             })
         }
@@ -345,8 +350,8 @@ pub fn execute(
             // current in-flight nonce so a live swap leg matches it (the leg
             // absorbs any other nonce as `nonce-mismatch`). Stamp the last
             // recorded swap nonce for `to` over the caller's placeholder; if the
-            // lease has emitted no swap yet (open/close/transfer-out flows that
-            // ignore the nonce), fall back to the caller's value.
+            // lease has emitted no swap yet (open/close flows that ignore the
+            // nonce), fall back to the caller's value.
             let nonce = last_recorded_swap_nonce(deps.storage, &to)?.unwrap_or(callback.nonce);
             Ok(CwResponse::new().add_message(callback_msg(
                 to,

--- a/tests/src/common/remote_lease_controller_stub.rs
+++ b/tests/src/common/remote_lease_controller_stub.rs
@@ -233,6 +233,10 @@ const RECORDED_SWAPS: Map<&Addr, Vec<SwapParams>> = Map::new("stub_recorded_swap
 /// [`RECORDED_SWAPS`]. Lets a driver replay the in-flight nonce (matching) or
 /// the superseded one after a heal (stale).
 const RECORDED_SWAP_NONCES: Map<&Addr, Vec<u64>> = Map::new("stub_recorded_swap_nonces");
+/// The last nonce the lease emitted on any nonce-bearing operation (swap or
+/// transfer-out) — its current in-flight nonce regardless of which transport is
+/// active, so an injected callback can be stamped to match whatever leg is live.
+const LAST_INFLIGHT_NONCE: Map<&Addr, u64> = Map::new("stub_last_inflight_nonce");
 const RECORDED_TRANSFER_OUTS: Map<&Addr, Vec<TransferOutParams>> =
     Map::new("stub_recorded_transfer_outs");
 const RECORDED_CLOSES: Map<&Addr, u32> = Map::new("stub_recorded_closes");
@@ -324,6 +328,7 @@ pub fn execute(
         StubExecuteMsg::Swap { params, nonce, .. } => {
             record_swap(deps.storage, &info.sender, &params)?;
             record_swap_nonce(deps.storage, &info.sender, nonce)?;
+            record_inflight_nonce(deps.storage, &info.sender, nonce)?;
             handle_outbound(deps, info, op_tag::SWAP, nonce, |storage| {
                 Ok(OperationResponse::Swap(SwapResponse {
                     amount_out: next_swap_output(storage, &params)?,
@@ -332,6 +337,7 @@ pub fn execute(
         }
         StubExecuteMsg::TransferOut { params, nonce, .. } => {
             record_transfer_out(deps.storage, &info.sender, &params)?;
+            record_inflight_nonce(deps.storage, &info.sender, nonce)?;
             handle_outbound(deps, info, op_tag::TRANSFER_OUT, nonce, |_storage| {
                 Ok(OperationResponse::TransferOut(TransferOutResponse {}))
             })
@@ -346,13 +352,15 @@ pub fn execute(
         }
         StubExecuteMsg::DeliverPending { op } => deliver_pending(deps.storage, op.as_str()),
         StubExecuteMsg::InjectCallback { to, callback } => {
-            // #636: a manually-injected "valid" callback must carry the lease's
-            // current in-flight nonce so a live swap leg matches it (the leg
-            // absorbs any other nonce as `nonce-mismatch`). Stamp the last
-            // recorded swap nonce for `to` over the caller's placeholder; if the
-            // lease has emitted no swap yet (open/close flows that ignore the
-            // nonce), fall back to the caller's value.
-            let nonce = last_recorded_swap_nonce(deps.storage, &to)?.unwrap_or(callback.nonce);
+            // A manually-injected "valid" callback must carry the lease's current
+            // in-flight nonce so a live leg matches it (any other nonce is
+            // absorbed as `nonce-mismatch`). Stamp the last nonce the lease
+            // emitted on any nonce-bearing op — swap or transfer-out — over the
+            // caller's placeholder; fall back to the caller's value when the
+            // lease has emitted none yet (a bare open/close flow).
+            let nonce = LAST_INFLIGHT_NONCE
+                .may_load(deps.storage, &to)?
+                .unwrap_or(callback.nonce);
             Ok(CwResponse::new().add_message(callback_msg(
                 to,
                 RemoteLeaseCallback {
@@ -580,13 +588,14 @@ fn record_swap_nonce(
         .map_err(Into::into)
 }
 
-/// #636: the last `nonce` the given lease emitted a swap with, i.e. its
-/// current in-flight swap nonce. `None` when the lease has emitted no swap
-/// yet (open/close/transfer-out flows that ignore the nonce).
-fn last_recorded_swap_nonce(storage: &dyn Storage, lease: &Addr) -> Result<Option<u64>, StubError> {
-    Ok(RECORDED_SWAP_NONCES
-        .may_load(storage, lease)?
-        .and_then(|nonces| nonces.last().copied()))
+fn record_inflight_nonce(
+    storage: &mut dyn Storage,
+    sender: &Addr,
+    nonce: u64,
+) -> Result<(), StubError> {
+    LAST_INFLIGHT_NONCE
+        .save(storage, sender, &nonce)
+        .map_err(Into::into)
 }
 
 fn record_close(storage: &mut dyn Storage, sender: &Addr) -> Result<(), StubError> {

--- a/tests/src/lease/remote_lease_transfer_out.rs
+++ b/tests/src/lease/remote_lease_transfer_out.rs
@@ -28,6 +28,11 @@
 //!   error-bound re-emission has no packet-lifetime cadence);
 //!   `ExecuteMsg::Heal` re-emits the in-flight transfer verbatim and the
 //!   close completes.
+//! - `transfer_out_heal_supersedes_original_ack` — a heal re-emits the
+//!   in-flight transfer with a fresh nonce; the original packet's late
+//!   acknowledgment (the superseded nonce) is then absorbed as
+//!   `nonce-mismatch` instead of advancing the drain, and the healed
+//!   re-emission's acknowledgment completes the close.
 //! - `late_ack_on_closed_absorbed` / `late_ack_from_stranger_rejected` —
 //!   the `Closed` terminal absorbs a late `TransferOut` acknowledgment
 //!   from the controller pinned at lease open (late-ack event, no state
@@ -190,6 +195,75 @@ fn transfer_out_error_ack_absorbed_until_heal() {
         3,
         stub::recorded_transfer_outs(&test_case.app, &controller, &lease).len()
     );
+    assert_closing(
+        expected_funds,
+        ClosingTrx::TransferInFinish,
+        &test_case,
+        &lease,
+    );
+
+    super::settle_arrival(&mut test_case, &lease, expected_funds);
+    let _arrival = repay::deliver_funds_arrival_alarm(&mut test_case, lease.clone());
+    assert_eq!(
+        StateResponse::Closed(),
+        super::state_query(&test_case, lease)
+    );
+}
+
+// A heal bumps the in-flight nonce, so the original packet's late acknowledgment
+// no longer matches and is absorbed instead of advancing the drain; the healed
+// re-emission's ack then completes the close. End-to-end proof that the
+// duplicate-acknowledgment window is closed.
+#[test]
+fn transfer_out_heal_supersedes_original_ack() {
+    // The close-leg drain is a fresh single-coin transfer-out, so its first
+    // emission carries nonce 1; the heal below re-emits with nonce 2.
+    const ORIGINAL_NONCE: u64 = 1;
+
+    let mut test_case = super::create_test_case::<PaymentCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+
+    // Hold only the close-leg transfer-out in flight: the repay-proceeds drain
+    // has already acked when the hook runs.
+    let (lease, expected_funds, _repay_response) = {
+        let controller = controller.clone();
+        super::open_and_repay_fully_then(&mut test_case, move |app| {
+            stub::set_response_mode(
+                app,
+                &controller,
+                op_tag::TRANSFER_OUT,
+                ResponseMode::Delayed,
+            );
+        })
+    };
+    assert_closing(expected_funds, ClosingTrx::TransferOut, &test_case, &lease);
+
+    // The operator heals the still-in-flight transfer, re-emitting it with a
+    // fresh nonce that supersedes the original packet.
+    let heal_response = super::heal(&mut test_case, lease.clone());
+    heal_response
+        .assert_event(&Event::new(CLOSING_TRANSFER_OUT_EVENT).add_attribute("heal", "re-emit"));
+
+    // The original packet's late ack carries the now-superseded nonce: it is
+    // absorbed, not credited, and the drain stays in transfer-out.
+    let stale = stub::inject_callback_with_nonce(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        ORIGINAL_NONCE,
+        RemoteOperationOutcome::OperationOk(WireOperationResponse::TransferOut(
+            TransferOutResponse {},
+        )),
+    );
+    stale.assert_event(
+        &Event::new(CLOSING_TRANSFER_OUT_EVENT).add_attribute("absorbed", "nonce-mismatch"),
+    );
+    assert_closing(expected_funds, ClosingTrx::TransferOut, &test_case, &lease);
+
+    // The healed re-emission's ack (the fresh nonce the stand-in holds pending)
+    // matches the in-flight transfer and completes the drain.
+    let _delivery =
+        stub::deliver_pending_callback(&mut test_case.app, &controller, op_tag::TRANSFER_OUT);
     assert_closing(
         expected_funds,
         ClosingTrx::TransferInFinish,


### PR DESCRIPTION
## What

`RemoteTransferOut` previously credited acknowledgments positionally — the only thing identifying an in-flight transfer was the `acks_left` countdown, because a transfer-out ack carries no payload. A duplicate, redelivered, reordered, or heal-superseded acknowledgment could therefore advance the countdown early or credit the wrong leg.

This applies the per-emission nonce discipline `RemoteSwap` already uses to the payload-less transfer-out transport:

- The lease assigns a strictly-monotonic nonce per emission and stamps it on each outbound `TransferOut`.
- The controller carries it on the packet envelope and reads it back from its own committed packet on ack/timeout, returning it in the callback. Correlation is entirely Nolus-side; the counterparty never inspects or echoes the nonce. (The envelope field itself already landed with the swap work.)
- The node bumps the nonce on every emission — new leg, timeout retry, operator heal — and absorbs a non-matching callback as `nonce-mismatch`, leaving state byte-identical. The countdown only advances on the matching emission.

## Worst case before / after

Not exploitable for fund loss where a balance-gated completion check exists (the opening-unwind drain gates its refund on the on-chain balance over a pre-drain snapshot; the single-coin drains have one leg) — the worst case was recoverable stranding, resolved by an operator `heal`. This makes the countdown nonce-correct so the transport is robust independent of the consumer's completion check.

## Storage

No storage-version bump. The persisted `RemoteTransferOut` layout change folds into the still-unreleased v10 remote-lease step (nothing has ever persisted at v10; `migrate()` refuses unconditionally). The new fields are `#[serde(default)]`.

## Scope

Transfer-out only. `OpenLease`/`CloseLease` remain single-packet, single-callback flows with no duplicate-callback window and continue to ride a zero nonce.

Closes #671.
