### PR TITLE
refactor(ci): retire the per-DEX lease build axis

### DIFF
--- a/protocol/contracts/lease/Cargo.toml
+++ b/protocol/contracts/lease/Cargo.toml
@@ -10,9 +10,9 @@ rust-version.workspace = true
 
 [package.metadata.cargo-each]
 combinations = [
-    { tags = ["build", "$dex"], always-on = ["contract", "$dex"], include-rest = false, generics = { "$dex" = ["dex-astroport_main", "dex-astroport_test", "dex-osmosis"] } },
+    { tags = ["build", "@agnostic"], always-on = ["contract"], include-rest = false },
     { tags = ["ci", "@agnostic"], feature-groups = ["skel"], include-rest = false },
-    { tags = ["ci", "@agnostic"], always-on = ["dex-test_impl"], feature-groups = ["contract"], include-rest = false },
+    { tags = ["ci", "@agnostic"], feature-groups = ["contract"], include-rest = false },
 ]
 feature-groups = { contract = { members = ["contract", "contract_testing", "internal.test.contract"], at-least-one = true, mutually-exclusive = true }, skel = { members = ["skel", "skel_testing", "internal.test.skel"], at-least-one = false, mutually-exclusive = true } }
 
@@ -20,18 +20,6 @@ feature-groups = { contract = { members = ["contract", "contract_testing", "inte
 crate-type = ["cdylib", "rlib"]
 
 [features]
-# Swaps now execute remotely on the remote-lease controller (#647), so the lease
-# no longer pulls the DEX-specific `swap` client and these per-DEX selectors are
-# no-ops. The lease still carries the DEX `ConnectionParams` at runtime to address
-# the ICS-20 transfer channel it funds the lease over, so it is not fully
-# DEX-agnostic. The selectors are kept so the per-DEX build matrix and the
-# downstream `lease/dex-*` forwarding (tests, etc.) still resolve; the whole axis
-# can be dropped when the per-DEX lease build is retired.
-dex-astroport_main = []
-dex-astroport_test = []
-dex-osmosis = []
-dex-test_impl = []
-
 contract = [
     "cosmwasm-std/exports",
     "skel",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -33,9 +33,9 @@ warnings = "deny"
 ### [SYNC WITH OTHER WORKSPACES : END]
 
 [features]
-dex-astroport_test = ["lease/dex-astroport_test", "profit/dex-astroport_test"]
-dex-astroport_main = ["lease/dex-astroport_main", "profit/dex-astroport_main"]
-dex-osmosis = ["lease/dex-osmosis", "profit/dex-osmosis"]
+dex-astroport_test = ["profit/dex-astroport_test"]
+dex-astroport_main = ["profit/dex-astroport_main"]
+dex-osmosis = ["profit/dex-osmosis"]
 
 [dev-dependencies]
 admin_contract = { path = "../platform/contracts/admin", features = ["contract"], default-features = false }


### PR DESCRIPTION
## Summary

Retire the redundant per-DEX build axis on the lease. Since the lease's swaps moved to the remote-lease controller (#647), its `dex-*` features are no-ops, so building and checking it three times across the DEX axis adds no coverage. Profit still does local DEX swaps, so its per-DEX axis is preserved unchanged.

Addresses parts 1 and 3 of #674. Part 2 (running the DEX-agnostic integration tests once instead of three times) needs a test-crate split and is tracked in #678.

## Changes

- `protocol/contracts/lease/Cargo.toml`: the `build` combination moves from the per-DEX axis to the agnostic pass (`["build", "@agnostic"]`, `always-on = ["contract"]`); the CI `contract` combination drops its no-op `dex-test_impl` selector; the four no-op `dex-*` feature definitions (and their explanatory comment) are removed.
- `tests/Cargo.toml`: the `dex-*` features no longer forward to the (no-op) `lease/dex-*`; they keep forwarding to `profit/dex-*`.

## Verification

- `cargo each --tag build --tag @agnostic list` (from `protocol/`): the lease now builds in the agnostic pass (`contract`).
- `cargo each --tag build --tag dex-osmosis list` (from `protocol/`): the lease is gone from the per-DEX pass; profit still builds `contract,dex-osmosis`.
- Protocol contract count stays 8 (`ci/Containerfile` `protocol_contracts_count`) — the lease moved passes (agnostic 6→7, per-DEX 2→1), it was not dropped.
- `cargo each --tag ci list` resolves for the lease and the integration tests with no dangling feature references.
- `cargo check` passes for the lease (`contract`) and the integration tests (`dex-osmosis`).

## Follow-ups

- #678: run the DEX-agnostic integration tests once instead of per-DEX (needs a test-crate split + a shared test-support crate).
