### PR TITLE
refactor(ci): run the DEX-agnostic integration tests once instead of per-DEX

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.94"
 
 [package.metadata.cargo-each]
 combinations = [
+    { tags = ["ci", "@agnostic"], always-on = ["dex-test_impl"], include-rest = false },
     { tags = ["ci", "$dex"], always-on = ["$dex"], include-rest = false, generics = { "$dex" = ["dex-astroport_test", "dex-astroport_main", "dex-osmosis"] } },
 ]
 
@@ -36,6 +37,7 @@ warnings = "deny"
 dex-astroport_test = ["profit/dex-astroport_test"]
 dex-astroport_main = ["profit/dex-astroport_main"]
 dex-osmosis = ["profit/dex-osmosis"]
+dex-test_impl = ["profit/dex-test_impl"]
 
 [dev-dependencies]
 admin_contract = { path = "../platform/contracts/admin", features = ["contract"], default-features = false }

--- a/tests/src/common/mod.rs
+++ b/tests/src/common/mod.rs
@@ -40,6 +40,7 @@ pub mod profit;
 pub mod protocols;
 pub mod remote_lease_controller_stub;
 pub mod reserve;
+#[cfg(not(feature = "dex-test_impl"))]
 pub mod swap;
 pub mod test_case;
 pub mod timealarms;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,19 +1,38 @@
 #![cfg(all(test, not(target_arch = "wasm32")))]
 #![allow(clippy::unwrap_used)]
+// The suite is feature-partitioned across the DEX axis (see the module gating
+// below): each build compiles the whole shared `common` harness but runs only
+// one half of the suites, so the other half's harness helpers are unused in any
+// single build even though the union of both DEX configurations exercises them.
+#![allow(dead_code)]
 
 use common::test_case::TestCase;
 use cw_time::IntoInstant;
 use finance::instant::Instant;
 
 mod common;
+
+// The DEX-agnostic suites swap exclusively through the remote-lease controller
+// stand-in, so they are compiled and run once under the placeholder DEX. Only
+// `profit_tests` drives the real per-DEX swap client, so it alone crosses the
+// per-DEX matrix (every real `dex-*` feature implies `not(dex-test_impl)`).
+#[cfg(feature = "dex-test_impl")]
 mod lease;
+#[cfg(feature = "dex-test_impl")]
 mod leaser;
+#[cfg(feature = "dex-test_impl")]
 mod lpp_tests;
+#[cfg(feature = "dex-test_impl")]
 mod oracle_tests;
-mod profit_tests;
+#[cfg(feature = "dex-test_impl")]
 mod reserve;
+#[cfg(feature = "dex-test_impl")]
 mod timealarms_tests;
+#[cfg(feature = "dex-test_impl")]
 mod treasury_tests;
+
+#[cfg(not(feature = "dex-test_impl"))]
+mod profit_tests;
 
 fn block_time<ProtocolsRegistry, Treasury, Profit, Reserve, Leaser, Lpp, Oracle, TimeAlarms>(
     test_case: &TestCase<


### PR DESCRIPTION
## What

The integration-test suite ran its entire set three times — once per real DEX (`astroport_test` / `astroport_main` / `osmosis`) — but only `profit_tests` drives the real per-DEX swap client and asserts per-DEX denoms. The other ~169 suites swap through the remote-lease controller stand-in and are DEX-independent, so two of the three runs added no coverage.

This adds a DEX-agnostic test combination pinned to the mock DEX selector (`dex-test_impl`) so the agnostic suites run **once**, and gates the suite modules on that selector so `profit_tests` alone keeps the per-DEX axis.

## Result

- Agnostic suites: 169 tests, run **once** (was 3×).
- `profit_tests`: 9 tests, still run per-DEX (3×).
- Test executions per CI test job: **534 → 196**. No behaviour change; same 178 distinct tests.

## Approach note

The earlier framing assumed this needed a crate-level split, on the grounds that the build-matrix tool only varies features, not test targets. In fact Cargo's own per-module `#[cfg(feature = …)]` lets one crate compile a different suite set per feature combination — so this is a 3-file in-crate change, with no new crate or lockfile.

## Verification

Full quality gate green across all four feature combinations (`fmt --check`, `lint`, `lint-all`, `run-test`): agnostic `168 passed; 0 failed; 1 ignored`, each DEX `9 passed; 0 failed`. An independent zero-context review confirmed no coverage loss and no double-run — the two partitions' test sets are disjoint and their union equals the prior single-run set (178 tests).

Closes #678

Closes #674
