### PR TITLE
feat(profit): remote-profit IBC wire-contract crate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,7 +244,7 @@ jobs:
             "${image_tag:?}" \
             "${workspace:?}"
   check-remote-lease-wire-msrv:
-    name: "Check remote_lease_wire MSRV (Rust 1.89)"
+    name: "Check wire-crate MSRV (Rust 1.89)"
     runs-on: ["self-hosted", "nolus-ci"]
     steps:
       - name: "Checkout repository"

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -40,9 +40,9 @@ ARG protocol_contracts_count="8"
 ### 1.94.0-alpine3.23
 ARG rust_image_digest="sha256:ef7b340d4201444fa2757dfddfd4c03be9d2bde468de7b7a68b0e9fabb794334"
 
-### 1.89-alpine (pinned MSRV for the `remote_lease_wire` wire crate, consumed by
-### the external `ibc-solray` repo). Bump in lockstep with `rust-version` in
-### `protocol/packages/remote_lease_wire/Cargo.toml`.
+### 1.89-alpine (pinned MSRV for the `remote_lease_wire` and `remote_profit_wire`
+### wire crates, consumed by the external `ibc-solray` repo). Bump in lockstep with
+### `rust-version` in their `Cargo.toml` files.
 ARG msrv_rust_image_digest="sha256:4b800f2e72e04be908e5f634c504c741bd943b763d1d8ad7b096cc340e1b5b46"
 
 ### 1.96.0
@@ -98,7 +98,8 @@ ENTRYPOINT [ \
   "cargo", "check", \
   "--locked", \
   "--all-targets", \
-  "--package", "remote_lease_wire" \
+  "--package", "remote_lease_wire", \
+  "--package", "remote_profit_wire" \
 ]
 
 FROM docker.io/library/rust@${tooling_rust_image_digest:?} AS tooling-rust

--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -1444,6 +1444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "remote_profit_wire"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "reserve"
 version = "0.2.2"
 dependencies = [

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -48,6 +48,7 @@ dex = { path = "packages/dex", default-features = false }
 marketprice = { path = "packages/marketprice", default-features = false }
 remote_lease = { path = "packages/remote_lease", default-features = false }
 remote_lease_wire = { path = "packages/remote_lease_wire", default-features = false }
+remote_profit_wire = { path = "packages/remote_profit_wire", default-features = false }
 swap = { path = "packages/swap", default-features = false }
 
 # Platform Contracts

--- a/protocol/packages/remote_profit_wire/Cargo.toml
+++ b/protocol/packages/remote_profit_wire/Cargo.toml
@@ -1,0 +1,21 @@
+lints = { workspace = true }
+
+[package]
+name = "remote_profit_wire"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version = "1.89"
+
+[package.metadata.cargo-each]
+combinations = [
+    { tags = ["ci", "@agnostic"], include-rest = true },
+]
+
+[dependencies]
+serde = { workspace = true, features = ["derive", "std"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/protocol/packages/remote_profit_wire/src/callback.rs
+++ b/protocol/packages/remote_profit_wire/src/callback.rs
@@ -49,10 +49,7 @@ pub enum RemoteOperationOutcome {
 /// Serialises as a bare JSON string. The counterparty-facing paths —
 /// deserialisation and the fallible [`new`](Self::new) — reject payloads
 /// above [`OPERATION_ERR_MAX_BYTES`], so any string sourced from over the
-/// wire is bounded before it reaches downstream storage. The
-/// [`from_static`](Self::from_static) constructor is the one exception: it
-/// trusts the (compile-time-known) caller and only `debug_assert!`s the
-/// bound, so it must be fed provably-in-range literals.
+/// wire is bounded before it reaches downstream storage.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RemoteErrorMessage(String);
 
@@ -64,7 +61,9 @@ impl RemoteErrorMessage {
         let message: String = message.into();
         let actual = message.len();
         if actual <= OPERATION_ERR_MAX_BYTES {
-            Ok(Self(message))
+            let value = Self(message);
+            debug_assert!(value.invariant_held());
+            Ok(value)
         } else {
             Err(Error::CallbackErrorTooLong {
                 actual,
@@ -73,34 +72,12 @@ impl RemoteErrorMessage {
         }
     }
 
-    /// Construct from a compile-time-known string literal that is statically
-    /// known to be within [`OPERATION_ERR_MAX_BYTES`].
-    ///
-    /// For fixed internal reasons (e.g. `"timeout"`) where threading a
-    /// fallible [`new`](Self::new) through the call site would add error
-    /// plumbing for a value that is provably in range.
-    ///
-    /// Precondition (caller's responsibility): `message` must be a genuine
-    /// literal whose length is verifiable by inspection, never a
-    /// runtime-produced `&'static str` (e.g. a `Box::leak`ed value). The
-    /// length is only `debug_assert!`ed, so an over-cap input that slips past
-    /// review would bypass the bound in release builds — unlike [`new`] and
-    /// deserialisation, which reject it. When the length is not statically
-    /// obvious, use [`new`] instead.
-    ///
-    /// # Panics
-    ///
-    /// In debug builds, panics if `message` exceeds [`OPERATION_ERR_MAX_BYTES`].
-    pub fn from_static(message: &'static str) -> Self {
-        debug_assert!(
-            message.len() <= OPERATION_ERR_MAX_BYTES,
-            "RemoteErrorMessage::from_static exceeds OPERATION_ERR_MAX_BYTES"
-        );
-        Self(message.to_owned())
-    }
-
     pub fn as_str(&self) -> &str {
         self.0.as_str()
+    }
+
+    pub fn invariant_held(&self) -> bool {
+        self.0.len() <= OPERATION_ERR_MAX_BYTES
     }
 }
 

--- a/protocol/packages/remote_profit_wire/src/callback.rs
+++ b/protocol/packages/remote_profit_wire/src/callback.rs
@@ -1,0 +1,166 @@
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+use crate::{error::Error, response::OperationResponse};
+
+/// Maximum byte length of a [`RemoteOperationOutcome::OperationErr`] payload.
+///
+/// Why a cap: the string is authored by the Solana counterparty and consumed
+/// by Nolus storage / event emission. Without a bound, a hostile or
+/// misbehaving counterparty can inflate event sizes and storage rows
+/// arbitrarily. 512 bytes is enough to carry a structured short message
+/// ("dex error: <code> <reason>") but small enough to forbid abuse.
+pub const OPERATION_ERR_MAX_BYTES: usize = 512;
+
+/// A remote operation outcome paired with the nonce of the emission it
+/// resolves.
+///
+/// The controller reads `nonce` back from its own committed outbound packet
+/// on ack/timeout (never from the counterparty's reply) and returns it here,
+/// so the profit instance can credit the outcome to the exact in-flight
+/// emission and reject a duplicate, stale, or heal-superseded callback.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct RemoteProfitCallback {
+    pub nonce: u64,
+    pub outcome: RemoteOperationOutcome,
+}
+
+/// Outcome of a remote operation as reported back to the Nolus controller.
+///
+/// `OperationOk` carries the typed response when Solana confirmed the
+/// requested action. `OperationErr` carries a short error message authored
+/// by the Solana program itself, e.g. a DEX-layer failure or an invariant
+/// rejection in the vault. `OperationTimeout` is emitted by the IBC layer
+/// when the packet was never acknowledged — it is structurally distinct
+/// from `OperationErr` because the recovery path differs (funds may still
+/// be in flight on the Solana side until the channel times out).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum RemoteOperationOutcome {
+    OperationOk(OperationResponse),
+    OperationErr(RemoteErrorMessage),
+    OperationTimeout,
+}
+
+/// Length-capped error string returned by the Solana counterparty.
+///
+/// Serialises as a bare JSON string. The counterparty-facing paths —
+/// deserialisation and the fallible [`new`](Self::new) — reject payloads
+/// above [`OPERATION_ERR_MAX_BYTES`], so any string sourced from over the
+/// wire is bounded before it reaches downstream storage. The
+/// [`from_static`](Self::from_static) constructor is the one exception: it
+/// trusts the (compile-time-known) caller and only `debug_assert!`s the
+/// bound, so it must be fed provably-in-range literals.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RemoteErrorMessage(String);
+
+impl RemoteErrorMessage {
+    pub fn new<S>(message: S) -> Result<Self, Error>
+    where
+        S: Into<String>,
+    {
+        let message: String = message.into();
+        let actual = message.len();
+        if actual <= OPERATION_ERR_MAX_BYTES {
+            Ok(Self(message))
+        } else {
+            Err(Error::CallbackErrorTooLong {
+                actual,
+                max: OPERATION_ERR_MAX_BYTES,
+            })
+        }
+    }
+
+    /// Construct from a compile-time-known string literal that is statically
+    /// known to be within [`OPERATION_ERR_MAX_BYTES`].
+    ///
+    /// For fixed internal reasons (e.g. `"timeout"`) where threading a
+    /// fallible [`new`](Self::new) through the call site would add error
+    /// plumbing for a value that is provably in range.
+    ///
+    /// Precondition (caller's responsibility): `message` must be a genuine
+    /// literal whose length is verifiable by inspection, never a
+    /// runtime-produced `&'static str` (e.g. a `Box::leak`ed value). The
+    /// length is only `debug_assert!`ed, so an over-cap input that slips past
+    /// review would bypass the bound in release builds — unlike [`new`] and
+    /// deserialisation, which reject it. When the length is not statically
+    /// obvious, use [`new`] instead.
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, panics if `message` exceeds [`OPERATION_ERR_MAX_BYTES`].
+    pub fn from_static(message: &'static str) -> Self {
+        debug_assert!(
+            message.len() <= OPERATION_ERR_MAX_BYTES,
+            "RemoteErrorMessage::from_static exceeds OPERATION_ERR_MAX_BYTES"
+        );
+        Self(message.to_owned())
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Serialize for RemoteErrorMessage {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for RemoteErrorMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Rejects payloads above the cap inside the visitor, before any
+        // owned `String` is materialised on our side. With `serde_json`'s
+        // `deserialize_str` the visitor receives a borrowed slice into the
+        // input buffer when no JSON escapes are present, so the over-cap
+        // case allocates nothing beyond the already-bounded IBC packet.
+        deserializer.deserialize_str(RemoteErrorMessageVisitor)
+    }
+}
+
+struct RemoteErrorMessageVisitor;
+
+impl RemoteErrorMessageVisitor {
+    fn take_within_cap<E, F>(&self, len: usize, take: F) -> Result<RemoteErrorMessage, E>
+    where
+        E: de::Error,
+        F: FnOnce() -> String,
+    {
+        (len <= OPERATION_ERR_MAX_BYTES)
+            .then(take)
+            .map(RemoteErrorMessage)
+            .ok_or_else(|| E::invalid_length(len, self))
+    }
+}
+
+impl<'de> de::Visitor<'de> for RemoteErrorMessageVisitor {
+    type Value = RemoteErrorMessage;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "a string of at most {OPERATION_ERR_MAX_BYTES} bytes")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.take_within_cap(value.len(), || value.to_owned())
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let len = value.len();
+        self.take_within_cap(len, || value)
+    }
+}

--- a/protocol/packages/remote_profit_wire/src/coin.rs
+++ b/protocol/packages/remote_profit_wire/src/coin.rs
@@ -1,0 +1,99 @@
+use serde::{Deserialize, Serialize};
+
+use crate::ticker::Ticker;
+
+/// Coin amount as it travels on the wire.
+///
+/// Type-level alias mirroring `finance::coin::Amount` (`u128`). Defined locally
+/// so the wire crate stays free of the `finance` dependency tree — the wire
+/// format is the contract here, not Rust-level identity.
+pub type Amount = u128;
+
+/// Wire encoding of a coin: a `u128` amount + a ticker.
+///
+/// JSON shape matches `finance::CoinDTO<G>`:
+/// `{"amount":"<u128-decimal>","ticker":"<TICKER>"}`. The amount is encoded as
+/// a quoted decimal string (no leading zeros, no sign) so values above `2^53`
+/// survive JSON parsers that materialise numbers as `f64`. Deserialisation
+/// rejects non-canonical encodings (empty, leading-zero, non-digit).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct WireCoin {
+    #[serde(with = "string_amount")]
+    amount: Amount,
+    ticker: Ticker,
+}
+
+impl WireCoin {
+    pub const fn new(amount: Amount, ticker: Ticker) -> Self {
+        Self { amount, ticker }
+    }
+
+    pub const fn amount(&self) -> Amount {
+        self.amount
+    }
+
+    pub const fn ticker(&self) -> &Ticker {
+        &self.ticker
+    }
+
+    pub const fn is_zero(&self) -> bool {
+        self.amount == 0
+    }
+}
+
+mod string_amount {
+    //! Quoted-decimal `u128` serde, byte-compatible with `finance::CoinDTO`.
+    //!
+    //! Rejects non-canonical inputs at deserialise time: empty, leading-zero
+    //! (except the single-character `"0"`), or non-digit. Two byte sequences
+    //! must never decode to the same value — important for any downstream
+    //! consumer that hashes the JSON for canonical signing / replay defence.
+
+    use std::fmt;
+
+    use serde::{Deserializer, Serializer, de};
+
+    use super::Amount;
+
+    pub(super) fn serialize<S>(amount: &Amount, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&amount.to_string())
+    }
+
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Amount, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(AmountVisitor)
+    }
+
+    struct AmountVisitor;
+
+    impl de::Visitor<'_> for AmountVisitor {
+        type Value = Amount;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a canonical decimal u128 in JSON string form")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            canonical(v)
+                .then(|| v.parse::<Amount>().ok())
+                .flatten()
+                .ok_or_else(|| de::Error::invalid_value(de::Unexpected::Str(v), &self))
+        }
+    }
+
+    fn canonical(v: &str) -> bool {
+        if v.is_empty() || !v.bytes().all(|b| b.is_ascii_digit()) {
+            return false;
+        }
+        v == "0" || !v.starts_with('0')
+    }
+}

--- a/protocol/packages/remote_profit_wire/src/envelope.rs
+++ b/protocol/packages/remote_profit_wire/src/envelope.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{msg::Operation, version::ProtocolVersion};
+
+/// IBC packet payload exchanged between the Nolus controller and the Solana
+/// passive vault.
+///
+/// `version` pins the protocol identifier on the wire so that a mismatched
+/// counterparty is rejected at deserialisation, never by business code.
+///
+/// Unlike the remote-lease protocol, there is no on-wire identity field: the
+/// remote profit is a SINGLETON selected by port / domain / channel, so there
+/// is nothing to disambiguate. The envelope therefore carries only the
+/// operation, the version pin, and the nonce.
+///
+/// `nonce` is a per-emission identifier the Nolus profit instance chooses; the
+/// controller reads it back from its own committed outbound packet on
+/// ack/timeout and returns it in the callback, letting the instance reject a
+/// callback that does not match the in-flight emission. `#[serde(default)]`
+/// keeps the field optional at decode so an envelope authored before the
+/// field existed (nonce absent) decodes to `0`; the counterparty neither
+/// inspects nor echoes it.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PacketEnvelope {
+    pub operation: Operation,
+    pub version: ProtocolVersion,
+    #[serde(default)]
+    pub nonce: u64,
+}

--- a/protocol/packages/remote_profit_wire/src/error.rs
+++ b/protocol/packages/remote_profit_wire/src/error.rs
@@ -1,0 +1,31 @@
+use thiserror::Error;
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum Error {
+    #[error("swap input and output currencies must differ")]
+    SameSwapCurrency,
+
+    #[error("swap input amount and minimum output must be greater than zero")]
+    ZeroSwapAmount,
+
+    #[error("transfer-out amount must be greater than zero")]
+    ZeroTransferAmount,
+
+    #[error("callback error message exceeds the {max}-byte cap (was {actual})")]
+    CallbackErrorTooLong { actual: usize, max: usize },
+
+    #[error("remote-profit-id must not be empty")]
+    RemoteProfitIdEmpty,
+
+    #[error("remote-profit-id exceeds the {max}-byte cap (was {actual})")]
+    RemoteProfitIdTooLong { actual: usize, max: usize },
+
+    #[error("remote-profit-id contains a non-base58 byte 0x{byte:02x}")]
+    RemoteProfitIdInvalidCharacter { byte: u8 },
+
+    #[error("protocol version mismatch: expected {expected}, got {actual}")]
+    ProtocolVersionMismatch {
+        expected: &'static str,
+        actual: String,
+    },
+}

--- a/protocol/packages/remote_profit_wire/src/error.rs
+++ b/protocol/packages/remote_profit_wire/src/error.rs
@@ -22,10 +22,4 @@ pub enum Error {
 
     #[error("remote-profit-id contains a non-base58 byte 0x{byte:02x}")]
     RemoteProfitIdInvalidCharacter { byte: u8 },
-
-    #[error("protocol version mismatch: expected {expected}, got {actual}")]
-    ProtocolVersionMismatch {
-        expected: &'static str,
-        actual: String,
-    },
 }

--- a/protocol/packages/remote_profit_wire/src/lib.rs
+++ b/protocol/packages/remote_profit_wire/src/lib.rs
@@ -1,0 +1,26 @@
+//! Wire-format types for the Nolus ↔ Solana remote-profit protocol.
+//!
+//! This crate has no monorepo-internal dependencies and is intended to be
+//! consumed from outside the workspace (`git = "…"` or `path = "…"`). The
+//! Nolus side reuses the same JSON byte sequences via the typed `remote_profit`
+//! crate, which has wider deps for compile-time ticker enforcement.
+
+pub mod callback;
+pub mod coin;
+pub mod envelope;
+pub mod error;
+pub mod msg;
+pub mod profit_id;
+pub mod response;
+pub mod ticker;
+pub mod version;
+
+#[cfg(test)]
+mod tests;
+
+pub const VERSION: &str = "nls-remote-profit.v1";
+pub const PORT_PREFIX: &str = "nls-remote-profit.";
+
+pub fn port_id_for(dex: &str) -> String {
+    format!("{PORT_PREFIX}{dex}")
+}

--- a/protocol/packages/remote_profit_wire/src/msg.rs
+++ b/protocol/packages/remote_profit_wire/src/msg.rs
@@ -1,0 +1,141 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{coin::WireCoin, error::Error};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum Operation {
+    OpenProfit(OpenProfitParams),
+    Swap(SwapParams),
+    TransferOut(TransferOutParams),
+    CloseProfit(CloseProfitParams),
+}
+
+/// Singleton-establishment payload for the remote profit.
+///
+/// Unlike the multi-instance remote-lease open, the profit is a singleton
+/// selected by port / domain / channel, so there are no per-customer or
+/// per-currency establishment fields (no downpayment / lpn / asset tickers).
+///
+/// `expected_instance_ordinal` is the ADR-0006 replay guard, mirroring the
+/// lease ordinal: the Nolus side stamps the ordinal it expects the remote
+/// singleton to be established as, so a stale or replayed open against a
+/// superseded instance is rejected.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct OpenProfitParams {
+    expected_instance_ordinal: u16,
+}
+
+impl OpenProfitParams {
+    pub const fn new(expected_instance_ordinal: u16) -> Self {
+        Self {
+            expected_instance_ordinal,
+        }
+    }
+
+    pub const fn expected_instance_ordinal(&self) -> u16 {
+        self.expected_instance_ordinal
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct CloseProfitParams {}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(
+    deny_unknown_fields,
+    rename_all = "snake_case",
+    try_from = "SwapParamsRaw"
+)]
+pub struct SwapParams {
+    coin_in: WireCoin,
+    min_out: WireCoin,
+}
+
+impl SwapParams {
+    pub fn new(coin_in: WireCoin, min_out: WireCoin) -> Result<Self, Error> {
+        if coin_in.is_zero() || min_out.is_zero() {
+            return Err(Error::ZeroSwapAmount);
+        }
+        let params = Self { coin_in, min_out };
+        params
+            .invariant_held()
+            .then_some(params)
+            .ok_or(Error::SameSwapCurrency)
+            .inspect(|p| debug_assert!(p.invariant_held()))
+    }
+
+    pub const fn coin_in(&self) -> &WireCoin {
+        &self.coin_in
+    }
+
+    pub const fn min_out(&self) -> &WireCoin {
+        &self.min_out
+    }
+
+    pub fn invariant_held(&self) -> bool {
+        !self.coin_in.is_zero()
+            && !self.min_out.is_zero()
+            && self.coin_in.ticker() != self.min_out.ticker()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+struct SwapParamsRaw {
+    coin_in: WireCoin,
+    min_out: WireCoin,
+}
+
+impl TryFrom<SwapParamsRaw> for SwapParams {
+    type Error = Error;
+
+    fn try_from(raw: SwapParamsRaw) -> Result<Self, Self::Error> {
+        SwapParams::new(raw.coin_in, raw.min_out)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(
+    deny_unknown_fields,
+    rename_all = "snake_case",
+    try_from = "TransferOutParamsRaw"
+)]
+pub struct TransferOutParams {
+    amount: WireCoin,
+}
+
+impl TransferOutParams {
+    pub fn new(amount: WireCoin) -> Result<Self, Error> {
+        let params = Self { amount };
+        params
+            .invariant_held()
+            .then_some(params)
+            .ok_or(Error::ZeroTransferAmount)
+            .inspect(|p| debug_assert!(p.invariant_held()))
+    }
+
+    pub const fn amount(&self) -> &WireCoin {
+        &self.amount
+    }
+
+    pub fn invariant_held(&self) -> bool {
+        !self.amount.is_zero()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+struct TransferOutParamsRaw {
+    amount: WireCoin,
+}
+
+impl TryFrom<TransferOutParamsRaw> for TransferOutParams {
+    type Error = Error;
+
+    fn try_from(raw: TransferOutParamsRaw) -> Result<Self, Self::Error> {
+        TransferOutParams::new(raw.amount)
+    }
+}

--- a/protocol/packages/remote_profit_wire/src/profit_id.rs
+++ b/protocol/packages/remote_profit_wire/src/profit_id.rs
@@ -1,0 +1,110 @@
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+use crate::error::Error;
+
+/// Maximum byte length of a [`RemoteProfitId`] payload.
+///
+/// Base58-encoded Solana addresses are 32-44 ASCII characters in practice; the
+/// 64-byte cap leaves headroom while bounding event and storage size from a
+/// possibly-misbehaving counterparty.
+pub const REMOTE_PROFIT_ID_MAX_BYTES: usize = 64;
+
+const BASE58_ALPHABET: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+/// Typed wrapper around the Solana profit authority address travelling on the
+/// wire.
+///
+/// Serialises as a bare JSON string (`#[serde(transparent)]`-equivalent through
+/// the manual impls below) so existing off-chain consumers that read the field
+/// as a string see no shape change. Validation lives inside the constructor:
+/// non-empty, at most [`REMOTE_PROFIT_ID_MAX_BYTES`] bytes, base58 character
+/// set. Deserialisation enforces the same invariants — a packet with an
+/// invalid id is rejected at parse time, never observed by business code.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct RemoteProfitId(String);
+
+impl RemoteProfitId {
+    pub fn new<S>(value: S) -> Result<Self, Error>
+    where
+        S: Into<String>,
+    {
+        let value: String = value.into();
+        validate(&value).map(|()| Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl fmt::Display for RemoteProfitId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl AsRef<str> for RemoteProfitId {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+fn validate(value: &str) -> Result<(), Error> {
+    if value.is_empty() {
+        return Err(Error::RemoteProfitIdEmpty);
+    }
+    let len = value.len();
+    if REMOTE_PROFIT_ID_MAX_BYTES < len {
+        return Err(Error::RemoteProfitIdTooLong {
+            actual: len,
+            max: REMOTE_PROFIT_ID_MAX_BYTES,
+        });
+    }
+    value
+        .as_bytes()
+        .iter()
+        .find(|byte| !BASE58_ALPHABET.contains(byte))
+        .map_or(Ok(()), |byte| {
+            Err(Error::RemoteProfitIdInvalidCharacter { byte: *byte })
+        })
+}
+
+impl Serialize for RemoteProfitId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for RemoteProfitId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(RemoteProfitIdVisitor)
+    }
+}
+
+struct RemoteProfitIdVisitor;
+
+impl de::Visitor<'_> for RemoteProfitIdVisitor {
+    type Value = RemoteProfitId;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "a non-empty base58 string of at most {REMOTE_PROFIT_ID_MAX_BYTES} bytes"
+        )
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        RemoteProfitId::new(value).map_err(|err| E::custom(err.to_string()))
+    }
+}

--- a/protocol/packages/remote_profit_wire/src/profit_id.rs
+++ b/protocol/packages/remote_profit_wire/src/profit_id.rs
@@ -31,11 +31,17 @@ impl RemoteProfitId {
         S: Into<String>,
     {
         let value: String = value.into();
-        validate(&value).map(|()| Self(value))
+        validate(&value)
+            .map(|()| Self(value))
+            .inspect(|id| debug_assert!(id.invariant_held()))
     }
 
     pub fn as_str(&self) -> &str {
         self.0.as_str()
+    }
+
+    pub fn invariant_held(&self) -> bool {
+        validate(&self.0).is_ok()
     }
 }
 

--- a/protocol/packages/remote_profit_wire/src/response.rs
+++ b/protocol/packages/remote_profit_wire/src/response.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{coin::WireCoin, profit_id::RemoteProfitId};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum OperationResponse {
+    OpenProfit(OpenProfitResponse),
+    Swap(SwapResponse),
+    TransferOut(TransferOutResponse),
+    CloseProfit(CloseProfitResponse),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct OpenProfitResponse {
+    pub remote_profit_id: RemoteProfitId,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct SwapResponse {
+    pub amount_out: WireCoin,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct TransferOutResponse {}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct CloseProfitResponse {}

--- a/protocol/packages/remote_profit_wire/src/tests.rs
+++ b/protocol/packages/remote_profit_wire/src/tests.rs
@@ -155,27 +155,6 @@ fn callback_error_message_deserialize_over_cap_rejected() {
         .expect_err("over-cap payload must fail deserialization");
 }
 
-#[test]
-fn callback_error_message_from_static_accepted() {
-    let value = RemoteErrorMessage::from_static("timeout");
-    assert_eq!("timeout", value.as_str());
-    assert_round_trip_eq(
-        r#"{"operation_err":"timeout"}"#,
-        &RemoteOperationOutcome::OperationErr(value),
-    );
-}
-
-// `from_static` only `debug_assert!`s its length contract, so the panic is
-// observable solely in debug builds — the test is gated to match.
-#[cfg(debug_assertions)]
-#[test]
-#[should_panic(expected = "OPERATION_ERR_MAX_BYTES")]
-fn callback_error_message_from_static_over_cap_panics_in_debug() {
-    let over_cap: &'static str =
-        Box::leak("x".repeat(OPERATION_ERR_MAX_BYTES + 1).into_boxed_str());
-    let _ = RemoteErrorMessage::from_static(over_cap);
-}
-
 // The callback wraps a per-emission `nonce` alongside the outcome, so the
 // controller can correlate an acknowledgment to the exact packet that
 // solicited it; the nonce is the FIRST field and round-trips on the wire.

--- a/protocol/packages/remote_profit_wire/src/tests.rs
+++ b/protocol/packages/remote_profit_wire/src/tests.rs
@@ -1,0 +1,564 @@
+//! Wire-format byte-pin tests for the cross-chain `remote_profit` protocol.
+//!
+//! Every literal-JSON pin below locks the wire encoding so the Solana side can
+//! rely on a stable surface — **any edit to a literal pin is a breaking
+//! protocol change and MUST bump [`crate::VERSION`]**, with one exception: an
+//! additive field marked `#[serde(default)]` (e.g. `nonce`) extends the wire
+//! without a version bump, because updated consumers decode both the old and
+//! new shapes and the rollout is coordinated consumer-first rather than
+//! signalled by the version.
+
+use std::fmt::Debug;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::{
+    PORT_PREFIX, VERSION,
+    callback::{
+        OPERATION_ERR_MAX_BYTES, RemoteErrorMessage, RemoteOperationOutcome, RemoteProfitCallback,
+    },
+    coin::WireCoin,
+    envelope::PacketEnvelope,
+    error::Error,
+    msg::{CloseProfitParams, OpenProfitParams, Operation, SwapParams, TransferOutParams},
+    port_id_for,
+    profit_id::{REMOTE_PROFIT_ID_MAX_BYTES, RemoteProfitId},
+    response::{
+        CloseProfitResponse, OpenProfitResponse, OperationResponse, SwapResponse,
+        TransferOutResponse,
+    },
+    ticker::Ticker,
+    version::ProtocolVersion,
+};
+
+// ---------------------------------------------------------------------------
+// 1. Operation variants — round-trip + literal JSON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn open_profit_msg_serde() {
+    let value = Operation::OpenProfit(sample_open_profit_params());
+    assert_round_trip_eq(r#"{"open_profit":{"expected_instance_ordinal":7}}"#, &value);
+}
+
+#[test]
+fn swap_msg_serde() {
+    let value = Operation::Swap(sample_swap_params());
+    assert_round_trip_eq(
+        r#"{"swap":{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}"#,
+        &value,
+    );
+}
+
+#[test]
+fn transfer_out_msg_serde() {
+    let value = Operation::TransferOut(sample_transfer_out_params());
+    assert_round_trip_eq(
+        r#"{"transfer_out":{"amount":{"amount":"1000","ticker":"LC1"}}}"#,
+        &value,
+    );
+}
+
+#[test]
+fn close_profit_msg_serde() {
+    let value = Operation::CloseProfit(CloseProfitParams {});
+    assert_round_trip_eq(r#"{"close_profit":{}}"#, &value);
+}
+
+// ---------------------------------------------------------------------------
+// 2. OperationResponse variants — round-trip + literal JSON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn open_profit_response_serde() {
+    let value = OperationResponse::OpenProfit(OpenProfitResponse {
+        remote_profit_id: RemoteProfitId::new("So1RayProfit").expect("base58 profit id"),
+    });
+    assert_round_trip_eq(
+        r#"{"open_profit":{"remote_profit_id":"So1RayProfit"}}"#,
+        &value,
+    );
+}
+
+#[test]
+fn swap_response_serde() {
+    let value = OperationResponse::Swap(SwapResponse {
+        amount_out: WireCoin::new(42, Ticker::new("LPN")),
+    });
+    assert_round_trip_eq(
+        r#"{"swap":{"amount_out":{"amount":"42","ticker":"LPN"}}}"#,
+        &value,
+    );
+}
+
+#[test]
+fn transfer_out_response_serde() {
+    let value = OperationResponse::TransferOut(TransferOutResponse {});
+    assert_round_trip_eq(r#"{"transfer_out":{}}"#, &value);
+}
+
+#[test]
+fn close_profit_response_serde() {
+    let value = OperationResponse::CloseProfit(CloseProfitResponse {});
+    assert_round_trip_eq(r#"{"close_profit":{}}"#, &value);
+}
+
+// ---------------------------------------------------------------------------
+// 3. RemoteProfitCallback variants — round-trip + literal JSON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn callback_operation_ok_serde() {
+    let value =
+        RemoteOperationOutcome::OperationOk(OperationResponse::CloseProfit(CloseProfitResponse {}));
+    assert_round_trip_eq(r#"{"operation_ok":{"close_profit":{}}}"#, &value);
+}
+
+#[test]
+fn callback_operation_err_serde() {
+    let value = RemoteOperationOutcome::OperationErr(
+        RemoteErrorMessage::new("dex pool drained").expect("short message must be accepted"),
+    );
+    assert_round_trip_eq(r#"{"operation_err":"dex pool drained"}"#, &value);
+}
+
+#[test]
+fn callback_operation_timeout_serde() {
+    let value = RemoteOperationOutcome::OperationTimeout;
+    assert_round_trip_eq(r#""operation_timeout""#, &value);
+}
+
+#[test]
+fn callback_error_message_at_cap_accepted() {
+    let payload = "x".repeat(OPERATION_ERR_MAX_BYTES);
+    RemoteErrorMessage::new(payload).expect("payload at the cap must be accepted");
+}
+
+#[test]
+fn callback_error_message_over_cap_rejected() {
+    let payload = "x".repeat(OPERATION_ERR_MAX_BYTES + 1);
+    assert!(matches!(
+        RemoteErrorMessage::new(payload),
+        Err(Error::CallbackErrorTooLong {
+            actual,
+            max: OPERATION_ERR_MAX_BYTES,
+        }) if actual == OPERATION_ERR_MAX_BYTES + 1,
+    ));
+}
+
+#[test]
+fn callback_error_message_deserialize_over_cap_rejected() {
+    let payload = "x".repeat(OPERATION_ERR_MAX_BYTES + 1);
+    let bad_wire = format!(r#""{payload}""#);
+    serde_json::from_str::<RemoteErrorMessage>(&bad_wire)
+        .expect_err("over-cap payload must fail deserialization");
+}
+
+#[test]
+fn callback_error_message_from_static_accepted() {
+    let value = RemoteErrorMessage::from_static("timeout");
+    assert_eq!("timeout", value.as_str());
+    assert_round_trip_eq(
+        r#"{"operation_err":"timeout"}"#,
+        &RemoteOperationOutcome::OperationErr(value),
+    );
+}
+
+// `from_static` only `debug_assert!`s its length contract, so the panic is
+// observable solely in debug builds — the test is gated to match.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "OPERATION_ERR_MAX_BYTES")]
+fn callback_error_message_from_static_over_cap_panics_in_debug() {
+    let over_cap: &'static str =
+        Box::leak("x".repeat(OPERATION_ERR_MAX_BYTES + 1).into_boxed_str());
+    let _ = RemoteErrorMessage::from_static(over_cap);
+}
+
+// The callback wraps a per-emission `nonce` alongside the outcome, so the
+// controller can correlate an acknowledgment to the exact packet that
+// solicited it; the nonce is the FIRST field and round-trips on the wire.
+#[test]
+fn callback_round_trips_with_nonce() {
+    let value = RemoteProfitCallback {
+        nonce: 7,
+        outcome: RemoteOperationOutcome::OperationOk(OperationResponse::CloseProfit(
+            CloseProfitResponse {},
+        )),
+    };
+    assert_round_trip_eq(
+        r#"{"nonce":7,"outcome":{"operation_ok":{"close_profit":{}}}}"#,
+        &value,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. PacketEnvelope — round-trip + literal JSON (Option A: no identity field)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn packet_envelope_serde() {
+    let value = PacketEnvelope {
+        operation: Operation::CloseProfit(CloseProfitParams {}),
+        version: ProtocolVersion,
+        nonce: 0,
+    };
+    assert_round_trip_eq(
+        r#"{"operation":{"close_profit":{}},"version":"nls-remote-profit.v1","nonce":0}"#,
+        &value,
+    );
+}
+
+#[test]
+fn packet_envelope_version_mismatch_rejected() {
+    let bad_wire = r#"{"operation":{"close_profit":{}},"version":"nls-remote-profit.v2"}"#;
+    serde_json::from_str::<PacketEnvelope>(bad_wire)
+        .expect_err("mismatched protocol version must fail deserialization");
+}
+
+#[test]
+fn packet_envelope_missing_version_rejected() {
+    let bad_wire = r#"{"operation":{"close_profit":{}}}"#;
+    serde_json::from_str::<PacketEnvelope>(bad_wire)
+        .expect_err("missing version field must fail deserialization");
+}
+
+// The envelope carries a per-emission `nonce` as its last field (after
+// `version`); a non-zero nonce round-trips byte-identically so the Solana side
+// can echo it back unchanged on the acknowledgment.
+#[test]
+fn packet_envelope_round_trips_with_nonce() {
+    let value = PacketEnvelope {
+        operation: Operation::CloseProfit(CloseProfitParams {}),
+        version: ProtocolVersion,
+        nonce: 7,
+    };
+    assert_round_trip_eq(
+        r#"{"operation":{"close_profit":{}},"version":"nls-remote-profit.v1","nonce":7}"#,
+        &value,
+    );
+}
+
+// `nonce` is `#[serde(default)]`, so a payload that predates the field — a
+// legacy packet from a counterparty that has not yet upgraded — decodes with
+// `nonce == 0` rather than being rejected.
+#[test]
+fn packet_envelope_decodes_without_nonce_to_zero() {
+    let wire = r#"{"operation":{"close_profit":{}},"version":"nls-remote-profit.v1"}"#;
+    let envelope: PacketEnvelope =
+        serde_json::from_str(wire).expect("a payload without nonce must default it to zero");
+    assert_eq!(0, envelope.nonce);
+}
+
+// ---------------------------------------------------------------------------
+// 5. OpenProfitParams — minimal singleton-establishment payload
+// ---------------------------------------------------------------------------
+
+#[test]
+fn open_profit_params_round_trip() {
+    let value = OpenProfitParams::new(7);
+    assert_round_trip_eq(r#"{"expected_instance_ordinal":7}"#, &value);
+    assert_eq!(7, value.expected_instance_ordinal());
+}
+
+#[test]
+fn open_profit_params_max_ordinal_accepted() {
+    let params = OpenProfitParams::new(u16::MAX);
+    assert_eq!(u16::MAX, params.expected_instance_ordinal());
+}
+
+#[test]
+fn open_profit_params_deserialize_above_u16_rejected() {
+    let bad_wire = r#"{"expected_instance_ordinal":65536}"#;
+    serde_json::from_str::<OpenProfitParams>(bad_wire)
+        .expect_err("ordinal above u16 range must fail deserialization");
+}
+
+#[test]
+fn open_profit_params_deserialize_unknown_field_rejected() {
+    let bad_wire = r#"{"expected_instance_ordinal":7,"lpn_currency":"LPN"}"#;
+    serde_json::from_str::<OpenProfitParams>(bad_wire)
+        .expect_err("an unknown field must fail deserialization");
+}
+
+// ---------------------------------------------------------------------------
+// 6. SwapParams invariant: coin_in and min_out currencies differ, both > 0
+// ---------------------------------------------------------------------------
+
+#[test]
+fn swap_params_distinct_currencies_ok() {
+    let params = SwapParams::new(
+        WireCoin::new(1000, Ticker::new("NLS")),
+        WireCoin::new(42, Ticker::new("LPN")),
+    )
+    .expect("distinct non-zero amounts must be accepted");
+    assert!(params.invariant_held());
+}
+
+#[test]
+fn swap_params_same_currency_rejected() {
+    let res = SwapParams::new(
+        WireCoin::new(1000, Ticker::new("NLS")),
+        WireCoin::new(42, Ticker::new("NLS")),
+    );
+    assert!(matches!(res, Err(Error::SameSwapCurrency)));
+}
+
+#[test]
+fn swap_params_zero_coin_in_rejected() {
+    let res = SwapParams::new(
+        WireCoin::new(0, Ticker::new("NLS")),
+        WireCoin::new(42, Ticker::new("LPN")),
+    );
+    assert!(matches!(res, Err(Error::ZeroSwapAmount)));
+}
+
+#[test]
+fn swap_params_zero_min_out_rejected() {
+    let res = SwapParams::new(
+        WireCoin::new(1000, Ticker::new("NLS")),
+        WireCoin::new(0, Ticker::new("LPN")),
+    );
+    assert!(matches!(res, Err(Error::ZeroSwapAmount)));
+}
+
+#[test]
+fn swap_params_deserialize_invariant_violation_rejected() {
+    let bad_wire =
+        r#"{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"NLS"}}"#;
+    serde_json::from_str::<SwapParams>(bad_wire)
+        .expect_err("invariant violation must fail deserialization");
+}
+
+#[test]
+fn swap_params_deserialize_zero_amount_rejected() {
+    let bad_wire =
+        r#"{"coin_in":{"amount":"0","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}"#;
+    serde_json::from_str::<SwapParams>(bad_wire)
+        .expect_err("zero coin_in must fail deserialization");
+}
+
+// ---------------------------------------------------------------------------
+// 6b. RemoteProfitId — round-trip + validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn remote_profit_id_round_trip_is_bare_string() {
+    let id = RemoteProfitId::new("So1RayProfit").expect("base58 profit id");
+    assert_round_trip_eq(r#""So1RayProfit""#, &id);
+}
+
+#[test]
+fn remote_profit_id_accessors_expose_the_payload() {
+    let id = RemoteProfitId::new("So1RayProfit").expect("base58 profit id");
+    assert_eq!("So1RayProfit", id.as_str());
+    assert_eq!("So1RayProfit", AsRef::<str>::as_ref(&id));
+    assert_eq!("So1RayProfit", id.to_string());
+}
+
+#[test]
+fn remote_profit_id_empty_rejected() {
+    let res = RemoteProfitId::new("");
+    assert!(matches!(res, Err(Error::RemoteProfitIdEmpty)));
+}
+
+#[test]
+fn remote_profit_id_at_cap_accepted() {
+    let payload = "a".repeat(REMOTE_PROFIT_ID_MAX_BYTES);
+    RemoteProfitId::new(payload).expect("payload at the cap must be accepted");
+}
+
+#[test]
+fn remote_profit_id_over_cap_rejected() {
+    let payload = "a".repeat(REMOTE_PROFIT_ID_MAX_BYTES + 1);
+    let res = RemoteProfitId::new(payload);
+    assert!(matches!(
+        res,
+        Err(Error::RemoteProfitIdTooLong {
+            actual,
+            max: REMOTE_PROFIT_ID_MAX_BYTES,
+        }) if actual == REMOTE_PROFIT_ID_MAX_BYTES + 1,
+    ));
+}
+
+#[test]
+fn remote_profit_id_non_base58_rejected() {
+    // The base58 alphabet excludes 0, O, I, l.
+    for &bad in &[
+        "0badId",
+        "OBadId",
+        "IbadId",
+        "lbadId",
+        "with-hyphen",
+        "with space",
+    ] {
+        let res = RemoteProfitId::new(bad);
+        assert!(
+            matches!(res, Err(Error::RemoteProfitIdInvalidCharacter { .. })),
+            "expected rejection for {bad:?}, got {res:?}",
+        );
+    }
+}
+
+#[test]
+fn remote_profit_id_deserialize_empty_rejected() {
+    serde_json::from_str::<RemoteProfitId>(r#""""#)
+        .expect_err("empty profit id must fail deserialization");
+}
+
+#[test]
+fn remote_profit_id_deserialize_non_base58_rejected() {
+    serde_json::from_str::<RemoteProfitId>(r#""bad-id""#)
+        .expect_err("non-base58 character must fail deserialization");
+}
+
+#[test]
+fn remote_profit_id_deserialize_over_cap_rejected() {
+    let payload = "a".repeat(REMOTE_PROFIT_ID_MAX_BYTES + 1);
+    let bad_wire = format!(r#""{payload}""#);
+    serde_json::from_str::<RemoteProfitId>(&bad_wire)
+        .expect_err("over-cap profit id must fail deserialization");
+}
+
+// ---------------------------------------------------------------------------
+// 7. TransferOutParams invariant: amount > 0
+// ---------------------------------------------------------------------------
+
+#[test]
+fn transfer_out_params_non_zero_ok() {
+    let params = TransferOutParams::new(WireCoin::new(1000, Ticker::new("LC1")))
+        .expect("non-zero amount must be accepted");
+    assert!(params.invariant_held());
+}
+
+#[test]
+fn transfer_out_params_zero_rejected() {
+    let res = TransferOutParams::new(WireCoin::new(0, Ticker::new("LC1")));
+    assert!(matches!(res, Err(Error::ZeroTransferAmount)));
+}
+
+#[test]
+fn transfer_out_params_deserialize_zero_rejected() {
+    let bad_wire = r#"{"amount":{"amount":"0","ticker":"LC1"}}"#;
+    serde_json::from_str::<TransferOutParams>(bad_wire)
+        .expect_err("zero amount must fail deserialization");
+}
+
+// ---------------------------------------------------------------------------
+// 8. WireCoin amount validation at deserialise time
+// ---------------------------------------------------------------------------
+
+#[test]
+fn wire_coin_deserialize_empty_amount_rejected() {
+    let bad_wire = r#"{"amount":"","ticker":"NLS"}"#;
+    serde_json::from_str::<WireCoin>(bad_wire).expect_err("empty amount must fail deserialization");
+}
+
+#[test]
+fn wire_coin_deserialize_non_digit_amount_rejected() {
+    let bad_wire = r#"{"amount":"12a","ticker":"NLS"}"#;
+    serde_json::from_str::<WireCoin>(bad_wire)
+        .expect_err("non-digit amount must fail deserialization");
+}
+
+#[test]
+fn wire_coin_deserialize_signed_amount_rejected() {
+    let bad_wire = r#"{"amount":"-1","ticker":"NLS"}"#;
+    serde_json::from_str::<WireCoin>(bad_wire)
+        .expect_err("signed amount must fail deserialization");
+}
+
+#[test]
+fn wire_coin_deserialize_leading_zero_rejected() {
+    let bad_wire = r#"{"amount":"00","ticker":"NLS"}"#;
+    serde_json::from_str::<WireCoin>(bad_wire)
+        .expect_err("leading-zero amount must fail deserialization");
+}
+
+#[test]
+fn wire_coin_deserialize_canonical_zero_accepted() {
+    let wire = r#"{"amount":"0","ticker":"NLS"}"#;
+    let coin: WireCoin = serde_json::from_str(wire).expect("canonical zero must deserialize");
+    assert!(coin.is_zero());
+}
+
+#[test]
+fn wire_coin_large_amount_canonical_round_trip() {
+    let value = WireCoin::new(u128::MAX, Ticker::new("NLS"));
+    let expected = format!(r#"{{"amount":"{}","ticker":"NLS"}}"#, u128::MAX);
+    assert_round_trip_eq(&expected, &value);
+}
+
+// ---------------------------------------------------------------------------
+// 9. ProtocolVersion cross-protocol isolation guard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn protocol_version_round_trip_pinned() {
+    assert_round_trip_eq(r#""nls-remote-profit.v1""#, &ProtocolVersion);
+}
+
+#[test]
+fn protocol_version_rejects_sibling_protocol() {
+    serde_json::from_str::<ProtocolVersion>(r#""nls-remote-lease.v1""#)
+        .expect_err("the sibling remote-lease version must be rejected");
+}
+
+#[test]
+fn protocol_version_rejects_arbitrary_string() {
+    serde_json::from_str::<ProtocolVersion>(r#""whatever.v9""#)
+        .expect_err("an arbitrary version string must be rejected");
+}
+
+// ---------------------------------------------------------------------------
+// 10. Wire-protocol constants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_constant_pinned() {
+    assert_eq!("nls-remote-profit.v1", VERSION);
+}
+
+#[test]
+fn port_prefix_constant_pinned() {
+    assert_eq!("nls-remote-profit.", PORT_PREFIX);
+}
+
+#[test]
+fn port_id_for_dex_concatenates_prefix() {
+    assert_eq!("nls-remote-profit.astroport", port_id_for("astroport"));
+}
+
+// ---------------------------------------------------------------------------
+// helpers — expected value first per project rule 17
+// ---------------------------------------------------------------------------
+
+fn assert_round_trip_eq<T>(expected_json: &str, value: &T)
+where
+    T: Serialize + DeserializeOwned + PartialEq + Debug,
+{
+    let encoded = serde_json::to_string(value).expect("serialization must succeed");
+    assert_eq!(expected_json, encoded.as_str());
+
+    let decoded: T =
+        serde_json::from_str(&encoded).expect("decoding the freshly-encoded value must succeed");
+    assert_eq!(value, &decoded);
+}
+
+fn sample_open_profit_params() -> OpenProfitParams {
+    OpenProfitParams::new(7)
+}
+
+fn sample_swap_params() -> SwapParams {
+    SwapParams::new(
+        WireCoin::new(1000, Ticker::new("NLS")),
+        WireCoin::new(42, Ticker::new("LPN")),
+    )
+    .expect("sample uses two distinct non-zero amounts")
+}
+
+fn sample_transfer_out_params() -> TransferOutParams {
+    TransferOutParams::new(WireCoin::new(1000, Ticker::new("LC1")))
+        .expect("sample uses a non-zero amount")
+}

--- a/protocol/packages/remote_profit_wire/src/ticker.rs
+++ b/protocol/packages/remote_profit_wire/src/ticker.rs
@@ -1,0 +1,31 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Bare-string currency ticker as it travels on the wire.
+///
+/// Serialises transparently as a JSON string. The wire crate does not validate
+/// the value against any group; Nolus-side consumers convert into the typed
+/// [`currency::CurrencyDTO`] surface, which enforces the compile-time registry.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct Ticker(String);
+
+impl Ticker {
+    pub fn new<S>(value: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl fmt::Display for Ticker {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/protocol/packages/remote_profit_wire/src/version.rs
+++ b/protocol/packages/remote_profit_wire/src/version.rs
@@ -1,0 +1,50 @@
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+use crate::VERSION;
+
+/// Zero-sized wire-format marker that always serialises as [`crate::VERSION`]
+/// and rejects any other value at deserialisation time.
+///
+/// Why a ZST: every packet on the wire carries the protocol version explicitly,
+/// but the value is fixed at compile time. A mismatched-version packet from
+/// a future counterparty MUST be rejected at the deserialiser, not in the
+/// consumer's business code, so that no callback dispatch can ever observe a
+/// `PacketEnvelope` whose `version` field does not equal the current
+/// `VERSION` constant. Bumping the protocol therefore forces a code change
+/// here — exactly the desired invariant.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ProtocolVersion;
+
+impl fmt::Display for ProtocolVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(VERSION)
+    }
+}
+
+impl Serialize for ProtocolVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(VERSION)
+    }
+}
+
+impl<'de> Deserialize<'de> for ProtocolVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        <&str>::deserialize(deserializer).and_then(|actual| {
+            if actual == VERSION {
+                Ok(Self)
+            } else {
+                Err(de::Error::custom(format!(
+                    "protocol version mismatch: expected {VERSION}, got {actual}",
+                )))
+            }
+        })
+    }
+}


### PR DESCRIPTION
First deliverable of #652 (Remote Profit Protocol): the standalone wire-contract crate `remote_profit_wire`, mirroring `remote_lease_wire`.

This crate defines the IBC packet and ack contract between the Nolus profit contract and its Solana counterpart. It is intentionally dependency-light (serde + thiserror only, no workspace-internal deps) and pinned to rust 1.89 so the counterparty can build it outside this workspace.

## Shape

- Envelope `{ operation, version, nonce }`. The profit instance is a singleton, selected by port / domain / channel, so the envelope carries no per-instance identity field (unlike the lease wire's lease address).
- Operations: `open_profit`, `swap`, `transfer_out`, `close_profit`.
- `open_profit` establishes the singleton; its ack returns the counterparty authority address (`remote_profit_id`). `transfer_out` is amount-only (recipient derived on this side). `swap` mirrors the lease swap.
- Version string `nls-remote-profit.v1` and port prefix `nls-remote-profit.`. The version type rejects any other protocol's string at decode, isolating the two protocols on a shared connection.

## Counterparty coordination (the contract the Solana side builds to)

- `open_profit` params = `{ expected_instance_ordinal: u16 }`.
- `open_profit` ack = `{ remote_profit_id: <base58, ≤ 64 bytes> }`.
- No on-wire instance identifier; the `transfer_out` recipient is derived, not carried.

No behaviour change to existing crates. Part of #652; does not close it.
