### PR TITLE
feat(profit): typed remote-profit package and controller stub

### DIFF
--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -1444,6 +1444,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "remote_profit"
+version = "0.1.0"
+dependencies = [
+ "currencies",
+ "currency",
+ "finance",
+ "platform",
+ "remote_profit_wire",
+ "sdk",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "remote_profit_wire"
 version = "0.1.0"
 dependencies = [

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -48,6 +48,7 @@ dex = { path = "packages/dex", default-features = false }
 marketprice = { path = "packages/marketprice", default-features = false }
 remote_lease = { path = "packages/remote_lease", default-features = false }
 remote_lease_wire = { path = "packages/remote_lease_wire", default-features = false }
+remote_profit = { path = "packages/remote_profit", default-features = false }
 remote_profit_wire = { path = "packages/remote_profit_wire", default-features = false }
 swap = { path = "packages/swap", default-features = false }
 

--- a/protocol/packages/remote_profit/Cargo.toml
+++ b/protocol/packages/remote_profit/Cargo.toml
@@ -1,0 +1,34 @@
+lints = { workspace = true }
+
+[package]
+name = "remote_profit"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[package.metadata.cargo-each]
+combinations = [
+    { tags = ["ci", "@agnostic"], include-rest = true },
+]
+
+[features]
+stub = ["dep:platform", "dep:sdk"]
+
+[dependencies]
+currencies = { workspace = true }
+currency = { workspace = true }
+finance = { workspace = true }
+remote_profit_wire = { workspace = true }
+sdk = { workspace = true, optional = true, features = ["contract"] }
+platform = { workspace = true, optional = true }
+
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+currencies = { workspace = true, features = ["testing"] }
+currency = { workspace = true, features = ["testing"] }
+finance = { workspace = true, features = ["testing"] }
+serde_json = { workspace = true }

--- a/protocol/packages/remote_profit/src/callback.rs
+++ b/protocol/packages/remote_profit/src/callback.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+
+pub use remote_profit_wire::callback::{OPERATION_ERR_MAX_BYTES, RemoteErrorMessage};
+
+use crate::response::WireOperationResponse;
+
+/// A remote operation outcome paired with the nonce of the emission it
+/// resolves.
+///
+/// The controller reads `nonce` back from its own committed outbound packet
+/// on ack/timeout (never from the counterparty's reply) and returns it here,
+/// so the addressee profit instance can credit the outcome to the exact
+/// in-flight emission and reject a duplicate, stale, or heal-superseded
+/// callback.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct RemoteProfitCallback {
+    pub nonce: u64,
+    pub outcome: RemoteOperationOutcome,
+}
+
+/// Outcome of a remote operation as reported back to the Nolus controller.
+///
+/// `OperationOk` carries the wire-shaped response verbatim when Solana
+/// confirmed the requested action: the controller validates only that the
+/// payload is a well-formed response, while content validation (the currency
+/// registry) belongs to the addressee profit instance, whose callback handlers
+/// absorb failures instead of erring (ADR 0001 §3.7.2). `OperationErr` carries
+/// a short error message authored by the Solana program itself, e.g. a
+/// DEX-layer failure or an invariant rejection in the vault.
+/// `OperationTimeout` is emitted by the IBC layer when the packet was never
+/// acknowledged — it is structurally distinct from `OperationErr` because
+/// the recovery path differs (funds may still be in flight on the Solana
+/// side until the channel times out).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum RemoteOperationOutcome {
+    OperationOk(WireOperationResponse),
+    OperationErr(RemoteErrorMessage),
+    OperationTimeout,
+}

--- a/protocol/packages/remote_profit/src/envelope.rs
+++ b/protocol/packages/remote_profit/src/envelope.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+
+use remote_profit_wire::version::ProtocolVersion;
+
+use crate::msg::Operation;
+
+/// IBC packet payload exchanged between the Nolus controller and the Solana
+/// passive vault.
+///
+/// `version` pins the protocol identifier on the wire so that a mismatched
+/// counterparty is rejected at deserialisation, never by business code.
+///
+/// Unlike the remote-lease protocol, there is no on-wire identity field: the
+/// remote profit is a SINGLETON selected by port / domain / channel, so there
+/// is nothing to disambiguate. The envelope therefore carries only the
+/// operation, the version pin, and the nonce.
+///
+/// `nonce` is a per-emission identifier the Nolus profit instance chooses; the
+/// controller reads it back from its own committed outbound packet on
+/// ack/timeout and returns it in the callback, letting the instance reject a
+/// callback that does not match the in-flight emission. `#[serde(default)]`
+/// keeps it optional at decode so a packet authored before the field existed
+/// decodes to `0`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PacketEnvelope {
+    pub operation: Operation,
+    pub version: ProtocolVersion,
+    #[serde(default)]
+    pub nonce: u64,
+}

--- a/protocol/packages/remote_profit/src/error.rs
+++ b/protocol/packages/remote_profit/src/error.rs
@@ -1,0 +1,1 @@
+pub use remote_profit_wire::error::Error;

--- a/protocol/packages/remote_profit/src/lib.rs
+++ b/protocol/packages/remote_profit/src/lib.rs
@@ -1,0 +1,17 @@
+pub mod callback;
+pub mod envelope;
+pub mod error;
+pub mod msg;
+pub mod response;
+
+pub mod version {
+    pub use remote_profit_wire::version::ProtocolVersion;
+}
+
+#[cfg(feature = "stub")]
+pub mod stub;
+
+#[cfg(test)]
+mod tests;
+
+pub use remote_profit_wire::{PORT_PREFIX, VERSION, port_id_for};

--- a/protocol/packages/remote_profit/src/msg.rs
+++ b/protocol/packages/remote_profit/src/msg.rs
@@ -1,0 +1,209 @@
+use serde::{Deserialize, Serialize};
+
+use currencies::PaymentGroup;
+use currency::CurrencyDTO;
+use finance::{coin::CoinDTO, duration::Duration};
+
+use crate::error::Error;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum Operation {
+    OpenProfit(OpenProfitParams),
+    Swap(SwapParams),
+    TransferOut(TransferOutParams),
+    CloseProfit(CloseProfitParams),
+}
+
+/// Singleton-establishment payload for the remote profit.
+///
+/// Unlike the multi-instance remote-lease open, the profit is a singleton
+/// selected by port / domain / channel, so there are no per-customer or
+/// per-currency establishment fields (no downpayment / lpn / asset tickers).
+///
+/// `expected_instance_ordinal` is the ADR-0006 replay guard, mirroring the
+/// lease ordinal: the Nolus side stamps the ordinal it expects the remote
+/// singleton to be established as, so a stale or replayed open against a
+/// superseded instance is rejected.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct OpenProfitParams {
+    expected_instance_ordinal: u16,
+}
+
+impl OpenProfitParams {
+    pub const TIMEOUT: Duration = Duration::from_secs(60);
+
+    pub const fn new(expected_instance_ordinal: u16) -> Self {
+        Self {
+            expected_instance_ordinal,
+        }
+    }
+
+    pub const fn expected_instance_ordinal(&self) -> u16 {
+        self.expected_instance_ordinal
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct CloseProfitParams {}
+
+impl CloseProfitParams {
+    pub const TIMEOUT: Duration = Duration::from_secs(60);
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(
+    deny_unknown_fields,
+    rename_all = "snake_case",
+    try_from = "SwapParamsRaw"
+)]
+pub struct SwapParams {
+    coin_in: CoinDTO<PaymentGroup>,
+    min_out: CoinDTO<PaymentGroup>,
+}
+
+impl SwapParams {
+    pub const TIMEOUT: Duration = Duration::from_secs(300);
+
+    pub fn new(
+        coin_in: CoinDTO<PaymentGroup>,
+        min_out: CoinDTO<PaymentGroup>,
+    ) -> Result<Self, Error> {
+        if coin_in.is_zero() || min_out.is_zero() {
+            return Err(Error::ZeroSwapAmount);
+        }
+        let params = Self { coin_in, min_out };
+        params
+            .invariant_held()
+            .then_some(params)
+            .ok_or(Error::SameSwapCurrency)
+            .inspect(|p| debug_assert!(p.invariant_held()))
+    }
+
+    pub const fn coin_in(&self) -> &CoinDTO<PaymentGroup> {
+        &self.coin_in
+    }
+
+    pub const fn min_out(&self) -> &CoinDTO<PaymentGroup> {
+        &self.min_out
+    }
+
+    pub fn invariant_held(&self) -> bool {
+        !self.coin_in.is_zero()
+            && !self.min_out.is_zero()
+            && self.coin_in.currency() != self.min_out.currency()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+struct SwapParamsRaw {
+    coin_in: CoinDTO<PaymentGroup>,
+    min_out: CoinDTO<PaymentGroup>,
+}
+
+impl TryFrom<SwapParamsRaw> for SwapParams {
+    type Error = Error;
+
+    fn try_from(raw: SwapParamsRaw) -> Result<Self, Self::Error> {
+        SwapParams::new(raw.coin_in, raw.min_out)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(
+    deny_unknown_fields,
+    rename_all = "snake_case",
+    try_from = "TransferOutParamsRaw"
+)]
+pub struct TransferOutParams {
+    amount: CoinDTO<PaymentGroup>,
+}
+
+impl TransferOutParams {
+    pub const TIMEOUT: Duration = Duration::from_secs(120);
+
+    pub fn new(amount: CoinDTO<PaymentGroup>) -> Result<Self, Error> {
+        let params = Self { amount };
+        params
+            .invariant_held()
+            .then_some(params)
+            .ok_or(Error::ZeroTransferAmount)
+            .inspect(|p| debug_assert!(p.invariant_held()))
+    }
+
+    pub const fn amount(&self) -> &CoinDTO<PaymentGroup> {
+        &self.amount
+    }
+
+    pub fn invariant_held(&self) -> bool {
+        !self.amount.is_zero()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+struct TransferOutParamsRaw {
+    amount: CoinDTO<PaymentGroup>,
+}
+
+impl TryFrom<TransferOutParamsRaw> for TransferOutParams {
+    type Error = Error;
+
+    fn try_from(raw: TransferOutParamsRaw) -> Result<Self, Self::Error> {
+        TransferOutParams::new(raw.amount)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Typed → wire conversions.
+//
+// These are infallible because the typed surface enforces the same invariants
+// the wire surface enforces (distinct currencies, non-zero amounts), so the
+// stringly-typed wire constructors cannot fail given a valid typed input.
+// The cross-surface integration test verifies byte-identical JSON for each
+// variant.
+// ---------------------------------------------------------------------------
+
+fn wire_ticker(currency: &CurrencyDTO<PaymentGroup>) -> remote_profit_wire::ticker::Ticker {
+    remote_profit_wire::ticker::Ticker::new(currency.to_string())
+}
+
+fn wire_coin(coin: &CoinDTO<PaymentGroup>) -> remote_profit_wire::coin::WireCoin {
+    remote_profit_wire::coin::WireCoin::new(coin.amount(), wire_ticker(&coin.currency()))
+}
+
+impl From<&OpenProfitParams> for remote_profit_wire::msg::OpenProfitParams {
+    fn from(typed: &OpenProfitParams) -> Self {
+        Self::new(typed.expected_instance_ordinal())
+    }
+}
+
+impl From<&SwapParams> for remote_profit_wire::msg::SwapParams {
+    fn from(typed: &SwapParams) -> Self {
+        Self::new(wire_coin(typed.coin_in()), wire_coin(typed.min_out()))
+            .expect("typed SwapParams already upholds the non-zero distinct-currency invariant")
+    }
+}
+
+impl From<&TransferOutParams> for remote_profit_wire::msg::TransferOutParams {
+    fn from(typed: &TransferOutParams) -> Self {
+        Self::new(wire_coin(typed.amount()))
+            .expect("typed TransferOutParams already upholds the non-zero invariant")
+    }
+}
+
+impl From<&Operation> for remote_profit_wire::msg::Operation {
+    fn from(typed: &Operation) -> Self {
+        match typed {
+            Operation::OpenProfit(p) => Self::OpenProfit(p.into()),
+            Operation::Swap(p) => Self::Swap(p.into()),
+            Operation::TransferOut(p) => Self::TransferOut(p.into()),
+            Operation::CloseProfit(CloseProfitParams {}) => {
+                Self::CloseProfit(remote_profit_wire::msg::CloseProfitParams {})
+            }
+        }
+    }
+}

--- a/protocol/packages/remote_profit/src/response.rs
+++ b/protocol/packages/remote_profit/src/response.rs
@@ -1,0 +1,58 @@
+use serde::{Deserialize, Serialize};
+
+use currencies::PaymentGroup;
+use finance::coin::CoinDTO;
+
+pub use remote_profit_wire::{
+    coin::WireCoin,
+    profit_id::RemoteProfitId,
+    response::{
+        CloseProfitResponse, OpenProfitResponse, OperationResponse as WireOperationResponse,
+        SwapResponse as WireSwapResponse, TransferOutResponse,
+    },
+    ticker::Ticker,
+};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum OperationResponse {
+    OpenProfit(OpenProfitResponse),
+    Swap(SwapResponse),
+    TransferOut(TransferOutResponse),
+    CloseProfit(CloseProfitResponse),
+}
+
+/// The only response that diverges from its wire twin: it carries a typed
+/// `CoinDTO<PaymentGroup>` rather than the stringly-typed `WireCoin`. The other
+/// three responses are re-exported verbatim from `remote_profit_wire`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct SwapResponse {
+    pub amount_out: CoinDTO<PaymentGroup>,
+}
+
+// ---------------------------------------------------------------------------
+// Typed → wire conversions. See `msg.rs` for the rationale.
+// ---------------------------------------------------------------------------
+
+impl From<SwapResponse> for WireSwapResponse {
+    fn from(typed: SwapResponse) -> Self {
+        Self {
+            amount_out: WireCoin::new(
+                typed.amount_out.amount(),
+                Ticker::new(typed.amount_out.currency().to_string()),
+            ),
+        }
+    }
+}
+
+impl From<OperationResponse> for WireOperationResponse {
+    fn from(typed: OperationResponse) -> Self {
+        match typed {
+            OperationResponse::OpenProfit(r) => Self::OpenProfit(r),
+            OperationResponse::Swap(r) => Self::Swap(r.into()),
+            OperationResponse::TransferOut(r) => Self::TransferOut(r),
+            OperationResponse::CloseProfit(r) => Self::CloseProfit(r),
+        }
+    }
+}

--- a/protocol/packages/remote_profit/src/stub.rs
+++ b/protocol/packages/remote_profit/src/stub.rs
@@ -1,0 +1,235 @@
+use serde::Serialize;
+
+use finance::duration::Duration;
+use platform::{
+    batch::{Batch, ReplyId},
+    result::Result as PlatformResult,
+};
+use sdk::cosmwasm_std::Addr;
+
+use crate::msg::{CloseProfitParams, OpenProfitParams, SwapParams, TransferOutParams};
+
+/// Marker trait the consuming controller must implement on its own
+/// `ExecuteMsg` (or whichever outer enum carries the per-operation
+/// `{ params, timeout }` variants).
+///
+/// Why a marker: the stub builders accept a `msg` closure that wraps the
+/// typed `*Params` and the `Duration` into the controller's outer message
+/// before it goes onto the wire. Without this bound, any `Serialize` value
+/// would work — including raw `*Params` — which would let the controller
+/// (or a contributor) accidentally emit a flat-embedded params payload that
+/// bypasses the controller's own authorisation layer. By requiring the
+/// closure's output to implement `ControllerInnerMessage` the crate forces
+/// a deliberate one-line opt-in on the consumer side; the orphan rule
+/// prevents the consumer from implementing it on the `*Params` types.
+pub trait ControllerInnerMessage: Serialize {}
+
+pub struct Factory<'controller> {
+    controller: &'controller Addr,
+}
+
+impl<'controller> Factory<'controller> {
+    pub const fn new(controller: &'controller Addr) -> Self {
+        Self { controller }
+    }
+
+    pub fn open<F, M>(
+        &self,
+        params: OpenProfitParams,
+        timeout: Duration,
+        msg: F,
+    ) -> PlatformResult<Batch>
+    where
+        F: FnOnce(OpenProfitParams, Duration) -> M,
+        M: ControllerInnerMessage,
+    {
+        schedule(self.controller, &msg(params, timeout))
+    }
+}
+
+pub struct Profit<'controller> {
+    controller: &'controller Addr,
+}
+
+impl<'controller> Profit<'controller> {
+    pub const fn new(controller: &'controller Addr) -> Self {
+        Self { controller }
+    }
+
+    pub fn swap<F, M>(&self, params: SwapParams, timeout: Duration, msg: F) -> PlatformResult<Batch>
+    where
+        F: FnOnce(SwapParams, Duration) -> M,
+        M: ControllerInnerMessage,
+    {
+        schedule(self.controller, &msg(params, timeout))
+    }
+
+    pub fn transfer_out<F, M>(
+        &self,
+        params: TransferOutParams,
+        timeout: Duration,
+        msg: F,
+    ) -> PlatformResult<Batch>
+    where
+        F: FnOnce(TransferOutParams, Duration) -> M,
+        M: ControllerInnerMessage,
+    {
+        schedule(self.controller, &msg(params, timeout))
+    }
+
+    /// Schedule a `CloseProfit` as a reply-on-error sub-message
+    ///
+    /// The close is best-effort by design: it rides the same transaction
+    /// as the customer payout, and a synchronous controller failure (for
+    /// example, a non-operational channel) must not revert that payout.
+    /// The caller absorbs the failure in its `reply` handler instead.
+    pub fn close<F, M>(
+        &self,
+        params: CloseProfitParams,
+        timeout: Duration,
+        reply_id: ReplyId,
+        msg: F,
+    ) -> PlatformResult<Batch>
+    where
+        F: FnOnce(CloseProfitParams, Duration) -> M,
+        M: ControllerInnerMessage,
+    {
+        schedule_reply_on_error(self.controller, &msg(params, timeout), reply_id)
+    }
+}
+
+fn schedule<M>(controller: &Addr, msg: &M) -> PlatformResult<Batch>
+where
+    M: Serialize + ?Sized,
+{
+    let mut batch = Batch::default();
+    batch
+        .schedule_execute_wasm_no_reply_no_funds(controller.clone(), msg)
+        .map(|()| batch)
+}
+
+fn schedule_reply_on_error<M>(
+    controller: &Addr,
+    msg: &M,
+    reply_id: ReplyId,
+) -> PlatformResult<Batch>
+where
+    M: Serialize + ?Sized,
+{
+    let mut batch = Batch::default();
+    batch
+        .schedule_execute_wasm_reply_on_error_no_funds(controller.clone(), msg, reply_id)
+        .map(|()| batch)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+
+    use currencies::testing::{PaymentC1, PaymentC2, PaymentC3};
+    use finance::{coin::Coin, duration::Duration};
+    use sdk::cosmwasm_std::Addr;
+
+    use crate::msg::{CloseProfitParams, OpenProfitParams, SwapParams, TransferOutParams};
+
+    use super::{ControllerInnerMessage, Factory, Profit};
+
+    /// Mirrors the production controller's `ExecuteMsg` per-variant struct
+    /// shape (`protocol/contracts/remote_profit/src/api.rs`).
+    #[derive(Serialize)]
+    #[serde(rename_all = "snake_case")]
+    enum OuterExecuteMsg {
+        OpenProfit {
+            params: OpenProfitParams,
+            timeout: Duration,
+        },
+        CloseProfit {
+            params: CloseProfitParams,
+            timeout: Duration,
+        },
+        Swap {
+            params: SwapParams,
+            timeout: Duration,
+        },
+        TransferOut {
+            params: TransferOutParams,
+            timeout: Duration,
+        },
+    }
+
+    impl ControllerInnerMessage for OuterExecuteMsg {}
+
+    #[test]
+    fn factory_open_schedules_one_message() {
+        let controller = Addr::unchecked("controller");
+        let factory = Factory::new(&controller);
+        let batch = factory
+            .open(
+                sample_open_profit_params(),
+                OpenProfitParams::TIMEOUT,
+                |params, timeout| OuterExecuteMsg::OpenProfit { params, timeout },
+            )
+            .expect("scheduling must succeed");
+        assert_eq!(1, batch.len());
+    }
+
+    #[test]
+    fn profit_close_schedules_one_message() {
+        let controller = Addr::unchecked("controller");
+        let profit = Profit::new(&controller);
+        let batch = profit
+            .close(
+                CloseProfitParams {},
+                CloseProfitParams::TIMEOUT,
+                1,
+                |params, timeout| OuterExecuteMsg::CloseProfit { params, timeout },
+            )
+            .expect("scheduling must succeed");
+        assert_eq!(1, batch.len());
+    }
+
+    #[test]
+    fn profit_swap_schedules_one_message() {
+        let controller = Addr::unchecked("controller");
+        let profit = Profit::new(&controller);
+        let batch = profit
+            .swap(
+                sample_swap_params(),
+                SwapParams::TIMEOUT,
+                |params, timeout| OuterExecuteMsg::Swap { params, timeout },
+            )
+            .expect("scheduling must succeed");
+        assert_eq!(1, batch.len());
+    }
+
+    #[test]
+    fn profit_transfer_out_schedules_one_message() {
+        let controller = Addr::unchecked("controller");
+        let profit = Profit::new(&controller);
+        let batch = profit
+            .transfer_out(
+                sample_transfer_out_params(),
+                TransferOutParams::TIMEOUT,
+                |params, timeout| OuterExecuteMsg::TransferOut { params, timeout },
+            )
+            .expect("scheduling must succeed");
+        assert_eq!(1, batch.len());
+    }
+
+    fn sample_open_profit_params() -> OpenProfitParams {
+        OpenProfitParams::new(7)
+    }
+
+    fn sample_swap_params() -> SwapParams {
+        SwapParams::new(
+            Coin::<PaymentC1>::new(1000).into(),
+            Coin::<PaymentC2>::new(42).into(),
+        )
+        .expect("sample uses two distinct non-zero amounts")
+    }
+
+    fn sample_transfer_out_params() -> TransferOutParams {
+        TransferOutParams::new(Coin::<PaymentC3>::new(1000).into())
+            .expect("sample uses a non-zero amount")
+    }
+}

--- a/protocol/packages/remote_profit/src/tests.rs
+++ b/protocol/packages/remote_profit/src/tests.rs
@@ -1,0 +1,389 @@
+//! Wire-format and invariant tests for the cross-chain `remote_profit`
+//! protocol.
+//!
+//! Acceptance criterion (ibc-solray#134): round-trip serde tests for every
+//! variant against `cosmwasm_std::to_json_binary` output. The Solana-side
+//! consumer is a foreign codebase, so every literal-JSON pin below is part of
+//! the wire contract — **any edit to a literal pin is a breaking protocol
+//! change and MUST bump [`crate::VERSION`]**, with one exception: an additive
+//! field marked `#[serde(default)]` (e.g. `nonce`, #636) extends the wire
+//! without a version bump, because updated consumers decode both the old and
+//! new shapes and the rollout is coordinated consumer-first rather than
+//! signalled by the version.
+
+use std::fmt::Debug;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use currencies::testing::{PaymentC1, PaymentC2, PaymentC3};
+use finance::coin::Coin;
+
+use crate::{
+    PORT_PREFIX, VERSION,
+    callback::{
+        OPERATION_ERR_MAX_BYTES, RemoteErrorMessage, RemoteOperationOutcome, RemoteProfitCallback,
+    },
+    envelope::PacketEnvelope,
+    error::Error,
+    msg::{CloseProfitParams, OpenProfitParams, Operation, SwapParams, TransferOutParams},
+    port_id_for,
+    response::{
+        CloseProfitResponse, OpenProfitResponse, OperationResponse, RemoteProfitId, SwapResponse,
+        TransferOutResponse, WireOperationResponse,
+    },
+    version::ProtocolVersion,
+};
+
+// ---------------------------------------------------------------------------
+// 1. Operation variants — round-trip + literal JSON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn open_profit_msg_serde() {
+    let value = Operation::OpenProfit(sample_open_profit_params());
+    assert_round_trip_eq(r#"{"open_profit":{"expected_instance_ordinal":7}}"#, &value);
+}
+
+#[test]
+fn close_profit_msg_serde() {
+    let value = Operation::CloseProfit(CloseProfitParams {});
+    assert_round_trip_eq(r#"{"close_profit":{}}"#, &value);
+}
+
+#[test]
+fn swap_msg_serde() {
+    let value = Operation::Swap(sample_swap_params());
+    assert_round_trip_eq(
+        r#"{"swap":{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}"#,
+        &value,
+    );
+}
+
+#[test]
+fn transfer_out_msg_serde() {
+    let value = Operation::TransferOut(sample_transfer_out_params());
+    assert_round_trip_eq(
+        r#"{"transfer_out":{"amount":{"amount":"1000","ticker":"LC1"}}}"#,
+        &value,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. OperationResponse variants — round-trip + literal JSON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn open_profit_response_serde() {
+    let value = OperationResponse::OpenProfit(OpenProfitResponse {
+        remote_profit_id: RemoteProfitId::new("So1RayProfit").expect("base58 profit id"),
+    });
+    assert_round_trip_eq(
+        r#"{"open_profit":{"remote_profit_id":"So1RayProfit"}}"#,
+        &value,
+    );
+}
+
+#[test]
+fn close_profit_response_serde() {
+    let value = OperationResponse::CloseProfit(CloseProfitResponse {});
+    assert_round_trip_eq(r#"{"close_profit":{}}"#, &value);
+}
+
+#[test]
+fn swap_response_serde() {
+    let value = OperationResponse::Swap(SwapResponse {
+        amount_out: Coin::<PaymentC2>::new(42).into(),
+    });
+    assert_round_trip_eq(
+        r#"{"swap":{"amount_out":{"amount":"42","ticker":"LPN"}}}"#,
+        &value,
+    );
+}
+
+#[test]
+fn transfer_out_response_serde() {
+    let value = OperationResponse::TransferOut(TransferOutResponse {});
+    assert_round_trip_eq(r#"{"transfer_out":{}}"#, &value);
+}
+
+// ---------------------------------------------------------------------------
+// 3. RemoteProfitCallback variants — round-trip + literal JSON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn callback_operation_ok_serde() {
+    let value = RemoteOperationOutcome::OperationOk(WireOperationResponse::CloseProfit(
+        CloseProfitResponse {},
+    ));
+    assert_round_trip_eq(r#"{"operation_ok":{"close_profit":{}}}"#, &value);
+}
+
+#[test]
+fn callback_operation_err_serde() {
+    let value = RemoteOperationOutcome::OperationErr(
+        RemoteErrorMessage::new("dex pool drained").expect("short message must be accepted"),
+    );
+    assert_round_trip_eq(r#"{"operation_err":"dex pool drained"}"#, &value);
+}
+
+#[test]
+fn callback_operation_timeout_serde() {
+    let value = RemoteOperationOutcome::OperationTimeout;
+    assert_round_trip_eq(r#""operation_timeout""#, &value);
+}
+
+#[test]
+fn callback_error_message_at_cap_accepted() {
+    let payload = "x".repeat(OPERATION_ERR_MAX_BYTES);
+    RemoteErrorMessage::new(payload).expect("payload at the cap must be accepted");
+}
+
+#[test]
+fn callback_error_message_over_cap_rejected() {
+    let payload = "x".repeat(OPERATION_ERR_MAX_BYTES + 1);
+    assert!(matches!(
+        RemoteErrorMessage::new(payload),
+        Err(Error::CallbackErrorTooLong {
+            actual,
+            max: OPERATION_ERR_MAX_BYTES,
+        }) if actual == OPERATION_ERR_MAX_BYTES + 1,
+    ));
+}
+
+#[test]
+fn callback_error_message_deserialize_over_cap_rejected() {
+    let payload = "x".repeat(OPERATION_ERR_MAX_BYTES + 1);
+    let bad_wire = format!(r#""{payload}""#);
+    serde_json::from_str::<RemoteErrorMessage>(&bad_wire)
+        .expect_err("over-cap payload must fail deserialization");
+}
+
+// AC (#636): the typed callback carries the per-emission `nonce` alongside the
+// outcome and round-trips byte-identically to the wire shape the controller
+// dispatches into the profit instance.
+#[test]
+fn callback_round_trips_with_nonce() {
+    let value = RemoteProfitCallback {
+        nonce: 7,
+        outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::CloseProfit(
+            CloseProfitResponse {},
+        )),
+    };
+    assert_round_trip_eq(
+        r#"{"nonce":7,"outcome":{"operation_ok":{"close_profit":{}}}}"#,
+        &value,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. PacketEnvelope — round-trip + literal JSON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn packet_envelope_serde() {
+    let value = PacketEnvelope {
+        operation: Operation::CloseProfit(CloseProfitParams {}),
+        version: ProtocolVersion,
+        nonce: 0,
+    };
+    assert_round_trip_eq(
+        r#"{"operation":{"close_profit":{}},"version":"nls-remote-profit.v1","nonce":0}"#,
+        &value,
+    );
+}
+
+#[test]
+fn packet_envelope_version_mismatch_rejected() {
+    let bad_wire = r#"{"operation":{"close_profit":{}},"version":"nls-remote-profit.v2"}"#;
+    serde_json::from_str::<PacketEnvelope>(bad_wire)
+        .expect_err("mismatched protocol version must fail deserialization");
+}
+
+#[test]
+fn packet_envelope_missing_version_rejected() {
+    let bad_wire = r#"{"operation":{"close_profit":{}}}"#;
+    serde_json::from_str::<PacketEnvelope>(bad_wire)
+        .expect_err("missing version field must fail deserialization");
+}
+
+// AC (#636): the typed envelope carries `nonce` as its last field (after
+// `version`) and a non-zero nonce round-trips byte-identically to the wire
+// JSON the Solana side consumes.
+#[test]
+fn packet_envelope_round_trips_with_nonce() {
+    let value = PacketEnvelope {
+        operation: Operation::CloseProfit(CloseProfitParams {}),
+        version: ProtocolVersion,
+        nonce: 7,
+    };
+    assert_round_trip_eq(
+        r#"{"operation":{"close_profit":{}},"version":"nls-remote-profit.v1","nonce":7}"#,
+        &value,
+    );
+}
+
+// AC (#636): `nonce` is `#[serde(default)]`, so a packet that predates the
+// field decodes with `nonce == 0` instead of being rejected.
+#[test]
+fn packet_envelope_decodes_without_nonce_to_zero() {
+    let wire = r#"{"operation":{"close_profit":{}},"version":"nls-remote-profit.v1"}"#;
+    let envelope: PacketEnvelope =
+        serde_json::from_str(wire).expect("a payload without nonce must default it to zero");
+    assert_eq!(0, envelope.nonce);
+}
+
+// ---------------------------------------------------------------------------
+// 5. OpenProfitParams: singleton establishment, ordinal replay guard only
+// ---------------------------------------------------------------------------
+
+#[test]
+fn open_profit_params_max_ordinal_accepted() {
+    let params = OpenProfitParams::new(u16::MAX);
+    assert_eq!(u16::MAX, params.expected_instance_ordinal());
+}
+
+#[test]
+fn open_profit_params_deserialize_above_u16_rejected() {
+    let bad_wire = r#"{"expected_instance_ordinal":65536}"#;
+    serde_json::from_str::<OpenProfitParams>(bad_wire)
+        .expect_err("ordinal above u16 range must fail deserialization");
+}
+
+// ---------------------------------------------------------------------------
+// 6. SwapParams invariant: coin_in and min_out currencies differ, both > 0
+// ---------------------------------------------------------------------------
+
+#[test]
+fn swap_params_distinct_currencies_ok() {
+    let params = SwapParams::new(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    )
+    .expect("distinct non-zero amounts must be accepted");
+    assert!(params.invariant_held());
+}
+
+#[test]
+fn swap_params_same_currency_rejected() {
+    let res = SwapParams::new(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC1>::new(42).into(),
+    );
+    assert!(matches!(res, Err(Error::SameSwapCurrency)));
+}
+
+#[test]
+fn swap_params_zero_coin_in_rejected() {
+    let res = SwapParams::new(
+        Coin::<PaymentC1>::new(0).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    );
+    assert!(matches!(res, Err(Error::ZeroSwapAmount)));
+}
+
+#[test]
+fn swap_params_zero_min_out_rejected() {
+    let res = SwapParams::new(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC2>::new(0).into(),
+    );
+    assert!(matches!(res, Err(Error::ZeroSwapAmount)));
+}
+
+#[test]
+fn swap_params_deserialize_invariant_violation_rejected() {
+    let bad_wire =
+        r#"{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"NLS"}}"#;
+    serde_json::from_str::<SwapParams>(bad_wire)
+        .expect_err("invariant violation must fail deserialization");
+}
+
+#[test]
+fn swap_params_deserialize_zero_amount_rejected() {
+    let bad_wire =
+        r#"{"coin_in":{"amount":"0","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}"#;
+    serde_json::from_str::<SwapParams>(bad_wire)
+        .expect_err("zero coin_in must fail deserialization");
+}
+
+// ---------------------------------------------------------------------------
+// 7. TransferOutParams invariant: amount > 0
+// ---------------------------------------------------------------------------
+
+#[test]
+fn transfer_out_params_non_zero_ok() {
+    let params = TransferOutParams::new(Coin::<PaymentC3>::new(1000).into())
+        .expect("non-zero amount must be accepted");
+    assert!(params.invariant_held());
+}
+
+#[test]
+fn transfer_out_params_zero_rejected() {
+    let res = TransferOutParams::new(Coin::<PaymentC3>::new(0).into());
+    assert!(matches!(res, Err(Error::ZeroTransferAmount)));
+}
+
+#[test]
+fn transfer_out_params_deserialize_zero_rejected() {
+    let bad_wire = r#"{"amount":{"amount":"0","ticker":"LC1"}}"#;
+    serde_json::from_str::<TransferOutParams>(bad_wire)
+        .expect_err("zero amount must fail deserialization");
+}
+
+// ---------------------------------------------------------------------------
+// 8. Wire-protocol constants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_constant_pinned() {
+    assert_eq!("nls-remote-profit.v1", VERSION);
+}
+
+#[test]
+fn port_prefix_constant_pinned() {
+    assert_eq!("nls-remote-profit.", PORT_PREFIX);
+}
+
+#[test]
+fn port_id_for_dex_concatenates_prefix() {
+    assert_eq!("nls-remote-profit.astroport", port_id_for("astroport"));
+}
+
+#[test]
+fn protocol_version_round_trip_pinned() {
+    assert_round_trip_eq(r#""nls-remote-profit.v1""#, &ProtocolVersion);
+}
+
+// ---------------------------------------------------------------------------
+// helpers — expected value first per project rule 17
+// ---------------------------------------------------------------------------
+
+fn assert_round_trip_eq<T>(expected_json: &str, value: &T)
+where
+    T: Serialize + DeserializeOwned + PartialEq + Debug,
+{
+    let encoded = serde_json::to_string(value).expect("serialization must succeed");
+    assert_eq!(expected_json, encoded.as_str());
+
+    let decoded: T =
+        serde_json::from_str(&encoded).expect("decoding the freshly-encoded value must succeed");
+    assert_eq!(value, &decoded);
+}
+
+fn sample_open_profit_params() -> OpenProfitParams {
+    OpenProfitParams::new(7)
+}
+
+fn sample_swap_params() -> SwapParams {
+    SwapParams::new(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    )
+    .expect("sample uses two distinct non-zero amounts")
+}
+
+fn sample_transfer_out_params() -> TransferOutParams {
+    TransferOutParams::new(Coin::<PaymentC3>::new(1000).into())
+        .expect("sample uses a non-zero amount")
+}

--- a/protocol/packages/remote_profit/tests/cross_surface.rs
+++ b/protocol/packages/remote_profit/tests/cross_surface.rs
@@ -1,0 +1,163 @@
+//! Cross-surface byte-equivalence test (GH #626 acceptance criterion).
+//!
+//! For every wire-bound type the Nolus controller emits, this test:
+//!   1. Constructs the typed value (using `CurrencyDTO<PaymentGroup>` /
+//!      `CoinDTO<PaymentGroup>`).
+//!   2. Serialises it via `serde_json`.
+//!   3. Deserialises the resulting JSON into the equivalent
+//!      `remote_profit_wire::*` (stringly-typed) type.
+//!   4. Re-serialises the wire value.
+//!   5. Asserts byte-for-byte equality between the typed and wire JSON.
+//!
+//! This pins the contract that the wire-only crate, consumed from outside the
+//! monorepo, can losslessly carry every packet the typed controller produces.
+
+use currencies::testing::{PaymentC1, PaymentC2, PaymentC3};
+use finance::coin::Coin;
+
+use remote_profit::{
+    callback::{RemoteErrorMessage, RemoteOperationOutcome, RemoteProfitCallback},
+    envelope::PacketEnvelope,
+    msg::{CloseProfitParams, OpenProfitParams, Operation, SwapParams, TransferOutParams},
+    response::{
+        CloseProfitResponse, OpenProfitResponse, OperationResponse, RemoteProfitId, SwapResponse,
+        TransferOutResponse,
+    },
+    version::ProtocolVersion,
+};
+
+use remote_profit_wire::{
+    callback::{RemoteOperationOutcome as WireOutcome, RemoteProfitCallback as WireCallback},
+    envelope::PacketEnvelope as WireEnvelope,
+    msg::Operation as WireOperation,
+    response::OperationResponse as WireResponse,
+};
+
+#[test]
+fn operation_open_profit_byte_identical() {
+    assert_cross_surface_eq::<Operation, WireOperation>(&Operation::OpenProfit(open_profit()));
+}
+
+#[test]
+fn operation_close_profit_byte_identical() {
+    assert_cross_surface_eq::<Operation, WireOperation>(&Operation::CloseProfit(
+        CloseProfitParams {},
+    ));
+}
+
+#[test]
+fn operation_swap_byte_identical() {
+    assert_cross_surface_eq::<Operation, WireOperation>(&Operation::Swap(swap()));
+}
+
+#[test]
+fn operation_transfer_out_byte_identical() {
+    assert_cross_surface_eq::<Operation, WireOperation>(&Operation::TransferOut(transfer_out()));
+}
+
+#[test]
+fn response_open_profit_byte_identical() {
+    let typed = OperationResponse::OpenProfit(OpenProfitResponse {
+        remote_profit_id: RemoteProfitId::new("So1RayProfit").expect("base58 profit id"),
+    });
+    assert_cross_surface_eq::<OperationResponse, WireResponse>(&typed);
+}
+
+#[test]
+fn response_close_profit_byte_identical() {
+    let typed = OperationResponse::CloseProfit(CloseProfitResponse {});
+    assert_cross_surface_eq::<OperationResponse, WireResponse>(&typed);
+}
+
+#[test]
+fn response_swap_byte_identical() {
+    let typed = OperationResponse::Swap(SwapResponse {
+        amount_out: Coin::<PaymentC2>::new(42).into(),
+    });
+    assert_cross_surface_eq::<OperationResponse, WireResponse>(&typed);
+}
+
+#[test]
+fn response_transfer_out_byte_identical() {
+    let typed = OperationResponse::TransferOut(TransferOutResponse {});
+    assert_cross_surface_eq::<OperationResponse, WireResponse>(&typed);
+}
+
+#[test]
+fn callback_operation_ok_byte_identical() {
+    let typed =
+        RemoteOperationOutcome::OperationOk(WireResponse::CloseProfit(CloseProfitResponse {}));
+    assert_cross_surface_eq::<RemoteOperationOutcome, WireOutcome>(&typed);
+}
+
+#[test]
+fn callback_operation_err_byte_identical() {
+    let typed = RemoteOperationOutcome::OperationErr(
+        RemoteErrorMessage::new("dex pool drained").expect("short message"),
+    );
+    assert_cross_surface_eq::<RemoteOperationOutcome, WireOutcome>(&typed);
+}
+
+#[test]
+fn callback_operation_timeout_byte_identical() {
+    let typed = RemoteOperationOutcome::OperationTimeout;
+    assert_cross_surface_eq::<RemoteOperationOutcome, WireOutcome>(&typed);
+}
+
+// AC (#636): a NON-ZERO nonce on the envelope crosses the typed→JSON→wire→JSON
+// surface byte-identically, so field-order drift between the typed and wire
+// `PacketEnvelope` (nonce must be the last field, after `version`) is caught.
+#[test]
+fn packet_envelope_byte_identical() {
+    let typed = PacketEnvelope {
+        operation: Operation::Swap(swap()),
+        version: ProtocolVersion,
+        nonce: 7,
+    };
+    assert_cross_surface_eq::<PacketEnvelope, WireEnvelope>(&typed);
+}
+
+// AC (#636): a NON-ZERO nonce on the callback crosses the typed→wire surface
+// byte-identically, so the `{ nonce, outcome }` field order stays in lockstep
+// between the typed and wire `RemoteProfitCallback`.
+#[test]
+fn callback_carries_nonce_byte_identical() {
+    let typed = RemoteProfitCallback {
+        nonce: 7,
+        outcome: RemoteOperationOutcome::OperationOk(WireResponse::CloseProfit(
+            CloseProfitResponse {},
+        )),
+    };
+    assert_cross_surface_eq::<RemoteProfitCallback, WireCallback>(&typed);
+}
+
+fn assert_cross_surface_eq<T, W>(typed: &T)
+where
+    T: serde::Serialize,
+    W: serde::Serialize + serde::de::DeserializeOwned,
+{
+    let typed_json = serde_json::to_string(typed).expect("typed serialization");
+    let wire: W =
+        serde_json::from_str(&typed_json).expect("wire crate must accept typed-emitted JSON");
+    let wire_json = serde_json::to_string(&wire).expect("wire serialization");
+    assert_eq!(
+        typed_json, wire_json,
+        "wire round-trip must be byte-identical"
+    );
+}
+
+fn open_profit() -> OpenProfitParams {
+    OpenProfitParams::new(7)
+}
+
+fn swap() -> SwapParams {
+    SwapParams::new(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    )
+    .expect("distinct non-zero amounts")
+}
+
+fn transfer_out() -> TransferOutParams {
+    TransferOutParams::new(Coin::<PaymentC3>::new(1000).into()).expect("non-zero amount")
+}


### PR DESCRIPTION
Builds on #683. Second piece of #652 (Remote Profit Protocol): the typed `remote_profit` package that wraps the `remote_profit_wire` contract.

This adds:

- Currency-typed operation params and responses (amounts as `CoinDTO<PaymentGroup>`), with total, lossless conversions to the wire types.
- The controller stub builders the profit contract will drive: `open`, `swap`, and `transfer_out` as no-reply submessages, and `close` as a reply-on-error (best-effort) submessage so a failed close cannot revert the payout it rides with.
- A cross-surface test asserting the typed surface serialises byte-identically to the wire surface for every operation, response, and callback.

The stub addresses the controller purely by address and serialized JSON via a marker trait, with no dependency on the controller contract crate.

No behaviour change to existing crates. Part of #652; does not close it. Stacked on #683 — review and merge that first.
