### PR TITLE
feat(dex): let the drain task choose its arrival account

### DIFF
--- a/protocol/packages/dex/src/impl_/funds_arrival.rs
+++ b/protocol/packages/dex/src/impl_/funds_arrival.rs
@@ -80,7 +80,7 @@ where
 {
     pub(super) fn try_complete(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
         self.spec
-            .all_received(&env.contract.address, querier)
+            .all_received(self.spec.arrival_account(&env.contract.address), querier)
             .map_or_else(Into::into, |received| {
                 if received {
                     response::res_finished(self.spec.finish(&env, querier))
@@ -225,6 +225,27 @@ mod tests {
         assert_eq!(
             mock::FINISH_RESULT,
             finished(arrival(true).on_time_alarm(querier, testing::mock_env(), alarms_delivery()))
+        );
+    }
+
+    #[test]
+    fn arrival_polls_the_task_supplied_account() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+        let env = testing::mock_env();
+
+        // The mock reports arrival only when polled with this sub-account,
+        // which differs from `env.contract.address`; completing proves the gate
+        // routes the poll through `arrival_account`, not the contract address.
+        let sub_account = Addr::unchecked("drain-sub-account");
+        assert_ne!(sub_account, env.contract.address);
+        let mut spec = MockSpec::new(vec![coin(100)]);
+        spec.set_received(true);
+        spec.set_arrival_account(sub_account);
+
+        assert_eq!(
+            mock::FINISH_RESULT,
+            finished(Arrival::new(spec).on_time_alarm(querier, env, alarms_delivery()))
         );
     }
 

--- a/protocol/packages/dex/src/impl_/remote_transfer_out.rs
+++ b/protocol/packages/dex/src/impl_/remote_transfer_out.rs
@@ -133,7 +133,7 @@ where
     /// dedicated sub-account overrides this — and must snapshot its arrival
     /// baseline against that same account, so the gate's baseline and poll
     /// stay on one account.
-    fn arrival_account<'a>(&'a self, contract: &'a Addr) -> &'a Addr {
+    fn arrival_account<'arrival>(&'arrival self, contract: &'arrival Addr) -> &'arrival Addr {
         contract
     }
 
@@ -577,7 +577,7 @@ pub(super) mod mock {
             }
         }
 
-        fn arrival_account<'a>(&'a self, contract: &'a Addr) -> &'a Addr {
+        fn arrival_account<'arrival>(&'arrival self, contract: &'arrival Addr) -> &'arrival Addr {
             self.arrival_account.as_ref().unwrap_or(contract)
         }
 

--- a/protocol/packages/dex/src/impl_/remote_transfer_out.rs
+++ b/protocol/packages/dex/src/impl_/remote_transfer_out.rs
@@ -127,6 +127,16 @@ where
     /// the scheduled transfer's and not another operation's.
     fn decode_response(&self, payload: &[u8]) -> Result<()>;
 
+    /// The local account the arrival gate polls for the drained coins.
+    ///
+    /// Defaults to the draining contract's own address. A drain landing in a
+    /// dedicated sub-account overrides this — and must snapshot its arrival
+    /// baseline against that same account, so the gate's baseline and poll
+    /// stay on one account.
+    fn arrival_account<'a>(&'a self, contract: &'a Addr) -> &'a Addr {
+        contract
+    }
+
     /// Have all the transferred coins arrived on the local `account`
     fn all_received(&self, account: &Addr, querier: QuerierWrapper<'_>) -> Result<bool>;
 
@@ -491,6 +501,8 @@ pub(super) mod mock {
         coins: Vec<CoinDTO<SuperGroup>>,
         received: bool,
         time_alarms: TimeAlarmsRef,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        arrival_account: Option<Addr>,
     }
 
     #[derive(Serialize)]
@@ -504,11 +516,16 @@ pub(super) mod mock {
                 coins,
                 received: false,
                 time_alarms: TimeAlarmsRef::unchecked(TIME_ALARMS),
+                arrival_account: None,
             }
         }
 
         pub fn set_received(&mut self, received: bool) {
             self.received = received;
+        }
+
+        pub fn set_arrival_account(&mut self, account: Addr) {
+            self.arrival_account = Some(account);
         }
     }
 
@@ -560,8 +577,19 @@ pub(super) mod mock {
             }
         }
 
-        fn all_received(&self, _account: &Addr, _querier: QuerierWrapper<'_>) -> Result<bool> {
-            Ok(self.received)
+        fn arrival_account<'a>(&'a self, contract: &'a Addr) -> &'a Addr {
+            self.arrival_account.as_ref().unwrap_or(contract)
+        }
+
+        // When an arrival account is set, report arrival only if polled with
+        // that account — so a test can prove the gate routes the poll through
+        // `arrival_account` rather than the contract's own address.
+        fn all_received(&self, account: &Addr, _querier: QuerierWrapper<'_>) -> Result<bool> {
+            let polled_expected = self
+                .arrival_account
+                .as_ref()
+                .is_none_or(|expected| account == expected);
+            Ok(self.received && polled_expected)
         }
 
         fn finish(self, _env: &Env, _querier: QuerierWrapper<'_>) -> Self::Result {


### PR DESCRIPTION
The drain's funds-arrival gate polled the contract's own address for the drained coins. A future profit drain needs to poll a dedicated account it does not otherwise receive on, so this adds an `arrival_account` seam on `RemoteTransferOutTask`, defaulting to the contract address.

The change is purely additive: every existing lease drain inherits the default and is unchanged in behaviour and stored shape (`skip_serializing_if` keeps the test mock's serde byte-identical). A regression test asserts the gate polls the task-supplied account when a task overrides it, and fails if the poll stops routing through `arrival_account`.

Follow-up (for the drain that introduces the first override): an overriding drain must snapshot its arrival baseline against the same account it polls, so the gate's baseline and poll stay aligned. Today that consistency is by convention. The overriding drain should persist the baseline account and couple the two sides so the invariant is enforced rather than only documented.
