### PR TITLE
refactor(remote_lease_wire): tighten wire-type invariants, drop dead error

### DIFF
--- a/protocol/packages/remote_lease_wire/src/callback.rs
+++ b/protocol/packages/remote_lease_wire/src/callback.rs
@@ -64,7 +64,9 @@ impl RemoteErrorMessage {
         let message: String = message.into();
         let actual = message.len();
         if actual <= OPERATION_ERR_MAX_BYTES {
-            Ok(Self(message))
+            let value = Self(message);
+            debug_assert!(value.invariant_held());
+            Ok(value)
         } else {
             Err(Error::CallbackErrorTooLong {
                 actual,
@@ -92,15 +94,20 @@ impl RemoteErrorMessage {
     ///
     /// In debug builds, panics if `message` exceeds [`OPERATION_ERR_MAX_BYTES`].
     pub fn from_static(message: &'static str) -> Self {
+        let value = Self(message.to_owned());
         debug_assert!(
-            message.len() <= OPERATION_ERR_MAX_BYTES,
+            value.invariant_held(),
             "RemoteErrorMessage::from_static exceeds OPERATION_ERR_MAX_BYTES"
         );
-        Self(message.to_owned())
+        value
     }
 
     pub fn as_str(&self) -> &str {
         self.0.as_str()
+    }
+
+    pub fn invariant_held(&self) -> bool {
+        self.0.len() <= OPERATION_ERR_MAX_BYTES
     }
 }
 

--- a/protocol/packages/remote_lease_wire/src/error.rs
+++ b/protocol/packages/remote_lease_wire/src/error.rs
@@ -27,10 +27,4 @@ pub enum Error {
 
     #[error("remote-lease-id contains a non-base58 byte 0x{byte:02x}")]
     RemoteLeaseIdInvalidCharacter { byte: u8 },
-
-    #[error("protocol version mismatch: expected {expected}, got {actual}")]
-    ProtocolVersionMismatch {
-        expected: &'static str,
-        actual: String,
-    },
 }

--- a/protocol/packages/remote_lease_wire/src/lease_id.rs
+++ b/protocol/packages/remote_lease_wire/src/lease_id.rs
@@ -30,11 +30,17 @@ impl RemoteLeaseId {
         S: Into<String>,
     {
         let value: String = value.into();
-        validate(&value).map(|()| Self(value))
+        validate(&value)
+            .map(|()| Self(value))
+            .inspect(|id| debug_assert!(id.invariant_held()))
     }
 
     pub fn as_str(&self) -> &str {
         self.0.as_str()
+    }
+
+    pub fn invariant_held(&self) -> bool {
+        validate(&self.0).is_ok()
     }
 }
 

--- a/protocol/packages/remote_lease_wire/src/tests.rs
+++ b/protocol/packages/remote_lease_wire/src/tests.rs
@@ -137,7 +137,8 @@ fn callback_operation_timeout_serde() {
 #[test]
 fn callback_error_message_at_cap_accepted() {
     let payload = "x".repeat(OPERATION_ERR_MAX_BYTES);
-    RemoteErrorMessage::new(payload).expect("payload at the cap must be accepted");
+    let value = RemoteErrorMessage::new(payload).expect("payload at the cap must be accepted");
+    assert!(value.invariant_held());
 }
 
 #[test]
@@ -164,6 +165,7 @@ fn callback_error_message_deserialize_over_cap_rejected() {
 fn callback_error_message_from_static_accepted() {
     let value = RemoteErrorMessage::from_static("timeout");
     assert_eq!("timeout", value.as_str());
+    assert!(value.invariant_held());
     assert_round_trip_eq(
         r#"{"operation_err":"timeout"}"#,
         &RemoteOperationOutcome::OperationErr(value),
@@ -423,7 +425,8 @@ fn remote_lease_id_empty_rejected() {
 #[test]
 fn remote_lease_id_at_cap_accepted() {
     let payload = "a".repeat(REMOTE_LEASE_ID_MAX_BYTES);
-    RemoteLeaseId::new(payload).expect("payload at the cap must be accepted");
+    let id = RemoteLeaseId::new(payload).expect("payload at the cap must be accepted");
+    assert!(id.invariant_held());
 }
 
 #[test]


### PR DESCRIPTION
Closes #686.

Resolves the three audit items, mirroring the remote_profit_wire twin where applicable:

1. **invariant_held self-checks added** — RemoteErrorMessage and RemoteLeaseId now expose invariant_held() and debug_assert it post-construction, matching SwapParams/TransferOutParams in the same crate. Purely additive.
2. **Dead error variant removed** — Error::ProtocolVersionMismatch was never constructed (the version-mismatch path surfaces a serde error string); deleted, matching the profit wire's resolution.
3. **from_static kept with its documented literal-only contract** — unlike the profit twin (which removed its unused from_static), the lease wire's has real callers in the lease opening/unwind paths, so it stays with the debug_assert-enforced cap. Tradeoff: a release build without debug assertions would admit an over-cap static literal introduced by a future dev; accepted since callers are in-repo compile-time literals exercised by tests.

The serialized wire format is unchanged — the existing wire-shape tests pass unmodified (57 crate tests green, incl. the invariant and version-mismatch cases). Full build/format/lint/test matrix green on the protocol and integration workspaces. Independent review: 12-item checklist pass, security scan clear, project-rule audit pass.