### PR TITLE
fix: validate the rotated lease code id on NewLeaseCode

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -69,6 +69,32 @@ if it survives on 1.94. Bump the pinned version here in lockstep with
 Tried first (did not work): treating local 1.95-only findings as CI blockers
 and patching untouched code to silence them.
 
+### `cargo lint` / `cargo run-test` from the repo root silently match 0 packages
+
+**Symptom:** Running `cargo lint` or `cargo run-test` from the checkout **root** exits
+`0` with no output — it reads like a clean pass. It isn't: nothing was linted or tested.
+
+**Cause:** These are `cargo each` aliases that select packages by cargo-each **tag**, and
+the tags live in the per-workspace members. The repo root has **no `Cargo.toml`** (the
+workspaces are `protocol/`, `tests/`, `platform/`, plus tooling in `tools/`), so the tag
+match resolves to the empty set and `each` exits `0`. Worse, a stray `Cargo.toml`
+**above** the checkout hijacks cargo's upward manifest walk and runs against the wrong
+tree entirely.
+
+**Fix:** Always run the gates **inside** a workspace dir — `protocol/`, `tests/`,
+`platform/`, or `tools/` — never from the repo root. Real CI iterates the workspaces via
+`ci/for-each-workspace.sh`; mirror that. Two corollaries:
+
+- `cargo lint` runs **without** `--all-targets`, so it does not compile `#[cfg(test)]`
+  modules. When the change adds test code, lint it explicitly:
+  `cargo clippy -p <crate> --features <...> --all-targets` (or `cargo lint-all` — see the
+  Cargo section's "Pre-push lint" entry).
+- **Exit `0` with zero output is not a PASS.** A real test run prints per-suite counts;
+  require that evidence before calling it green.
+
+Tried first (did not work): `cargo lint` / `cargo run-test` from the repo root and
+reading the `0` exit as success.
+
 ## CosmWasm
 
 ### `CosmosMsg::Any` rejected by the WASM optimizer's `cosmwasm-check` step

--- a/protocol/contracts/lpp/Cargo.toml
+++ b/protocol/contracts/lpp/Cargo.toml
@@ -54,3 +54,4 @@ serde = { workspace = true, features = ["derive"] }
 currencies = { workspace = true, features = ["testing"] }
 finance = { workspace = true, features = ["testing"] }
 platform = { workspace = true, features = ["testing"] }
+sdk = { workspace = true, features = ["testing"] }

--- a/protocol/contracts/lpp/src/contract/mod.rs
+++ b/protocol/contracts/lpp/src/contract/mod.rs
@@ -42,6 +42,8 @@ mod borrow;
 mod error;
 mod lender;
 mod rewards;
+#[cfg(test)]
+mod tests;
 
 const CONTRACT_STORAGE_VERSION: VersionSegment = 3;
 const CURRENT_RELEASE: ProtocolPackageRelease = ProtocolPackageRelease::current(
@@ -326,9 +328,6 @@ fn set_lease_code(deps: DepsMut<'_>, new_lease_code: Code) -> Result<()> {
     .map_err(ContractError::from)
     .and_then(|validated_code| Config::update_lease_code(deps.storage, validated_code))
 }
-
-#[cfg(test)]
-mod tests;
 
 #[cfg(test)]
 pub(crate) mod test {

--- a/protocol/contracts/lpp/src/contract/mod.rs
+++ b/protocol/contracts/lpp/src/contract/mod.rs
@@ -12,7 +12,13 @@ use currencies::{
 };
 use cw_time::IntoInstant;
 
-use platform::{bank, error as platform_error, message::Response as PlatformResponse, response};
+use platform::{
+    bank,
+    contract::{self, Code, CodeId},
+    error as platform_error,
+    message::Response as PlatformResponse,
+    response,
+};
 use sdk::{
     cosmwasm_ext::Response as CwResponse,
     cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, entry_point},
@@ -117,7 +123,7 @@ pub fn execute(
             )
             .check(&info)?;
 
-            Config::update_lease_code(deps.storage, new_lease_code)
+            set_lease_code(deps, new_lease_code)
                 .map(|()| PlatformResponse::default())
                 .map(response::response_only_messages)
         }
@@ -306,6 +312,23 @@ fn to_stable(
     stub::from_quote::<_, LpnCurrencies, StableCurrency, PaymentGroup>(oracle, total, querier)
         .map_err(ContractError::ConvertFromQuote)
 }
+
+/// Confirm the rotated lease code exists on-chain before persisting it.
+///
+/// `instantiate` validates `lease_code` through `try_validate`; this mirrors
+/// that check on the update path so an admin cannot persist a non-existent code
+/// id that would then reject every lease authorising against the pool.
+fn set_lease_code(deps: DepsMut<'_>, new_lease_code: Code) -> Result<()> {
+    Code::try_new(
+        CodeId::from(new_lease_code),
+        &contract::validator(deps.querier),
+    )
+    .map_err(ContractError::from)
+    .and_then(|validated_code| Config::update_lease_code(deps.storage, validated_code))
+}
+
+#[cfg(test)]
+mod tests;
 
 #[cfg(test)]
 pub(crate) mod test {

--- a/protocol/contracts/lpp/src/contract/tests.rs
+++ b/protocol/contracts/lpp/src/contract/tests.rs
@@ -1,0 +1,128 @@
+use finance::percent::Percent100;
+use platform::contract::Code;
+use sdk::{
+    cosmwasm_std::{
+        Deps, MessageInfo, OwnedDeps, SystemError, SystemResult, WasmQuery,
+        testing::{self, MockApi, MockQuerier, MockStorage},
+    },
+    testing as sdk_testing,
+};
+
+use crate::{
+    borrow::InterestRate,
+    contract::{ContractError, execute, instantiate},
+    msg::{ExecuteMsg, InstantiateMsg},
+    state::Config,
+};
+
+const ADMIN: &str = "admin";
+const NON_ADMIN: &str = "intruder";
+const CREATOR: &str = "creator";
+const LEASE_CODE_ID: u64 = 17;
+const BASE_INTEREST_RATE: Percent100 = Percent100::from_permille(70);
+const UTILIZATION_OPTIMAL: Percent100 = Percent100::from_permille(700);
+const ADDON_OPTIMAL_INTEREST_RATE: Percent100 = Percent100::from_permille(20);
+const MIN_UTILIZATION: Percent100 = Percent100::from_permille(0);
+
+#[test]
+fn new_lease_code_admin_succeeds() {
+    let mut deps = deps();
+    instantiate_default(&mut deps);
+
+    let new_code = Code::unchecked(LEASE_CODE_ID + 5);
+    let res = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(ADMIN),
+        ExecuteMsg::NewLeaseCode {
+            lease_code: new_code,
+        },
+    )
+    .unwrap();
+    assert_eq!(0, res.messages.len());
+    assert_stored_lease_code(new_code, deps.as_ref());
+}
+
+#[test]
+fn new_lease_code_non_admin_rejected() {
+    let mut deps = deps();
+    instantiate_default(&mut deps);
+
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(NON_ADMIN),
+        ExecuteMsg::NewLeaseCode {
+            lease_code: Code::unchecked(LEASE_CODE_ID + 1),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(err, ContractError::Unauthorized(_)), "got {err:?}");
+    assert_stored_lease_code(Code::unchecked(LEASE_CODE_ID), deps.as_ref());
+}
+
+#[test]
+fn new_lease_code_rejects_unknown_code() {
+    let mut deps = deps();
+    instantiate_default(&mut deps);
+
+    // The rotated code id now resolves to no on-chain code, so the existence
+    // check must reject it and leave the stored code untouched.
+    deps.querier.update_wasm(|query| match query {
+        WasmQuery::CodeInfo { code_id } => {
+            SystemResult::Err(SystemError::NoSuchCode { code_id: *code_id })
+        }
+        _ => unimplemented!("unexpected wasm query in this test"),
+    });
+
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(ADMIN),
+        ExecuteMsg::NewLeaseCode {
+            lease_code: Code::unchecked(LEASE_CODE_ID + 9),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(err, ContractError::Platform(_)), "got {err:?}");
+    assert_stored_lease_code(Code::unchecked(LEASE_CODE_ID), deps.as_ref());
+}
+
+fn deps() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
+    sdk_testing::mock_deps_with_contracts([])
+}
+
+fn instantiate_default(deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>) {
+    instantiate(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(CREATOR),
+        instantiate_msg(),
+    )
+    .unwrap();
+}
+
+fn instantiate_msg() -> InstantiateMsg {
+    InstantiateMsg {
+        protocol_admin: sdk_testing::user(ADMIN),
+        lease_code: LEASE_CODE_ID.into(),
+        borrow_rate: InterestRate::new(
+            BASE_INTEREST_RATE,
+            UTILIZATION_OPTIMAL,
+            ADDON_OPTIMAL_INTEREST_RATE,
+        )
+        .expect("Couldn't construct interest rate value!"),
+        min_utilization: MIN_UTILIZATION,
+    }
+}
+
+fn sender(who: &str) -> MessageInfo {
+    MessageInfo {
+        sender: sdk_testing::user(who),
+        funds: vec![],
+    }
+}
+
+fn assert_stored_lease_code(expected: Code, deps: Deps<'_>) {
+    assert_eq!(expected, Config::load(deps.storage).unwrap().lease_code());
+}

--- a/protocol/contracts/remote_lease/src/contract.rs
+++ b/protocol/contracts/remote_lease/src/contract.rs
@@ -4,7 +4,12 @@ use access_control::SingleUserAccess;
 use cosmwasm_std::Storage;
 use cw_time::{IntoInstant as _, IntoTimestamp as _};
 use finance::{duration::Duration, instant::Instant};
-use platform::{error as platform_error, message::Response as PlatformResponse, response};
+use platform::{
+    contract::{self, Code, CodeId},
+    error as platform_error,
+    message::Response as PlatformResponse,
+    response,
+};
 use remote_lease::{
     envelope::{LeaseAddrOnWire, PacketEnvelope},
     msg::Operation,
@@ -122,7 +127,7 @@ pub fn execute(
         ExecuteMsg::NewLeaseCode {
             lease_code: new_lease_code,
         } => authorize_protocol_admin_only(deps.storage.deref(), &info)
-            .and_then(|()| Config::update_lease_code(deps.storage, new_lease_code))
+            .and_then(|()| set_lease_code(deps, new_lease_code))
             .map(|()| PlatformResponse::default()),
         ExecuteMsg::OpenLease { params, timeout } => send_operation(
             deps,
@@ -207,6 +212,20 @@ fn authorize_protocol_admin_only(store: &dyn Storage, call_message: &MessageInfo
     SingleUserAccess::new(store, crate::access_control::PROTOCOL_ADMIN_KEY)
         .check(call_message)
         .map_err(Into::into)
+}
+
+/// Confirm the rotated lease code exists on-chain before persisting it.
+///
+/// `instantiate` validates `lease_code` through `try_validate`; this mirrors
+/// that check on the update path so an admin cannot persist a non-existent code
+/// id that would then reject every authorised caller and brick outbound emission.
+fn set_lease_code(deps: DepsMut<'_>, new_lease_code: Code) -> Result<()> {
+    Code::try_new(
+        CodeId::from(new_lease_code),
+        &contract::validator(deps.querier),
+    )
+    .map_err(Error::from)
+    .and_then(|validated_code| Config::update_lease_code(deps.storage, validated_code))
 }
 
 fn open_channel(storage: &mut dyn Storage, env: &Env) -> Result<PlatformResponse> {

--- a/protocol/contracts/remote_lease/src/contract/tests/execute_admin.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/execute_admin.rs
@@ -2,7 +2,7 @@ use platform::contract::{Code, CodeId, external};
 use sdk::{
     cosmos_sdk_proto::prost::Message as _,
     cosmwasm_ext::{CosmosMsg, SubMsg},
-    cosmwasm_std::{AnyMsg, IbcMsg, testing},
+    cosmwasm_std::{AnyMsg, IbcMsg, SystemError, SystemResult, WasmQuery, testing},
     ibc_proto::ibc::core::channel::v1::MsgChannelOpenInit,
 };
 
@@ -207,6 +207,41 @@ fn new_lease_code_non_admin_rejected() {
     )
     .unwrap_err();
     assert!(matches!(err, Error::Unauthorized(_)), "got {err:?}");
+
+    let config = query_config(deps.as_ref());
+    assert_eq!(external::Code::from(LEASE_CODE_ID), config.lease_code_id);
+}
+
+#[test]
+fn new_lease_code_rejects_unknown_code() {
+    let mut deps = deps();
+    instantiate(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(super::CREATOR),
+        instantiate_msg(),
+    )
+    .unwrap();
+
+    // The rotated code id now resolves to no on-chain code, so the existence
+    // check must reject it and leave the stored code untouched.
+    deps.querier.update_wasm(|query| match query {
+        WasmQuery::CodeInfo { code_id } => {
+            SystemResult::Err(SystemError::NoSuchCode { code_id: *code_id })
+        }
+        _ => unimplemented!("unexpected wasm query in this test"),
+    });
+
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(ADMIN),
+        ExecuteMsg::NewLeaseCode {
+            lease_code: Code::unchecked(LEASE_CODE_ID + 9),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::Platform(_)), "got {err:?}");
 
     let config = query_config(deps.as_ref());
     assert_eq!(external::Code::from(LEASE_CODE_ID), config.lease_code_id);

--- a/protocol/contracts/reserve/src/contract.rs
+++ b/protocol/contracts/reserve/src/contract.rs
@@ -30,6 +30,9 @@ use crate::{
     state::Config,
 };
 
+#[cfg(test)]
+mod tests;
+
 const CONTRACT_STORAGE_VERSION: VersionSegment = 0;
 const CURRENT_RELEASE: ProtocolPackageRelease = ProtocolPackageRelease::current(
     package_name!(),
@@ -195,6 +198,3 @@ fn dump_balance_to(
             PlatformResponse::messages_only(reserve_account.into())
         })
 }
-
-#[cfg(test)]
-mod tests;

--- a/protocol/contracts/reserve/src/contract.rs
+++ b/protocol/contracts/reserve/src/contract.rs
@@ -8,7 +8,7 @@ use finance::coin::Coin;
 use platform::{
     bank::{self, BankAccount, BankAccountView},
     batch::{Emit, Emitter},
-    contract::{self, Validator},
+    contract::{self, Code, CodeId, Validator},
     error as platform_error,
     message::Response as PlatformResponse,
     response,
@@ -91,10 +91,11 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<CwResponse> {
+    let api = deps.api;
     match msg {
         ExecuteMsg::NewLeaseCode(code) => {
             authorize_protocol_admin_only(deps.storage.deref(), &info)
-                .and_then(|()| Config::update_lease_code(deps.storage, code))
+                .and_then(|()| set_lease_code(deps, code))
                 .map(|()| PlatformResponse::default())
         }
         ExecuteMsg::CoverLiquidationLosses(amount) => Config::load(deps.storage)
@@ -114,7 +115,7 @@ pub fn execute(
         }
     }
     .map(response::response_only_messages)
-    .inspect_err(platform_error::log(deps.api))
+    .inspect_err(platform_error::log(api))
 }
 
 #[entry_point]
@@ -138,6 +139,21 @@ fn authorize_protocol_admin_only(store: &dyn Storage, call_message: &MessageInfo
     SingleUserAccess::new(store, crate::access_control::PROTOCOL_ADMIN_KEY)
         .check(call_message)
         .map_err(Into::into)
+}
+
+/// Confirm the rotated lease code exists on-chain before persisting it.
+///
+/// `instantiate` validates `lease_code` through `try_validate`; this mirrors
+/// that check on the update path so an admin cannot persist a non-existent code
+/// id that would then reject every authorised caller and brick downstream lease
+/// loss coverage.
+fn set_lease_code(deps: DepsMut<'_>, new_lease_code: Code) -> Result<()> {
+    Code::try_new(
+        CodeId::from(new_lease_code),
+        &contract::validator(deps.querier),
+    )
+    .map_err(Error::from)
+    .and_then(|validated_code| Config::update_lease_code(deps.storage, validated_code))
 }
 
 fn do_cover_losses(
@@ -179,3 +195,6 @@ fn dump_balance_to(
             PlatformResponse::messages_only(reserve_account.into())
         })
 }
+
+#[cfg(test)]
+mod tests;

--- a/protocol/contracts/reserve/src/contract/tests.rs
+++ b/protocol/contracts/reserve/src/contract/tests.rs
@@ -1,0 +1,110 @@
+use platform::contract::Code;
+use sdk::{
+    cosmwasm_std::{
+        Deps, MessageInfo, OwnedDeps, SystemError, SystemResult, WasmQuery,
+        testing::{self, MockApi, MockQuerier, MockStorage},
+    },
+    testing as sdk_testing,
+};
+
+use crate::{
+    api::{ExecuteMsg, InstantiateMsg},
+    contract::{execute, instantiate},
+    error::Error,
+    state::Config,
+};
+
+const ADMIN: &str = "admin";
+const NON_ADMIN: &str = "intruder";
+const CREATOR: &str = "creator";
+const LEASE_CODE_ID: u64 = 17;
+
+#[test]
+fn new_lease_code_admin_succeeds() {
+    let mut deps = deps();
+    instantiate_default(&mut deps);
+
+    let new_code = Code::unchecked(LEASE_CODE_ID + 5);
+    let res = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(ADMIN),
+        ExecuteMsg::NewLeaseCode(new_code),
+    )
+    .unwrap();
+    assert_eq!(0, res.messages.len());
+    assert_stored_lease_code(new_code, deps.as_ref());
+}
+
+#[test]
+fn new_lease_code_non_admin_rejected() {
+    let mut deps = deps();
+    instantiate_default(&mut deps);
+
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(NON_ADMIN),
+        ExecuteMsg::NewLeaseCode(Code::unchecked(LEASE_CODE_ID + 1)),
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::Unauthorized(_)), "got {err:?}");
+    assert_stored_lease_code(Code::unchecked(LEASE_CODE_ID), deps.as_ref());
+}
+
+#[test]
+fn new_lease_code_rejects_unknown_code() {
+    let mut deps = deps();
+    instantiate_default(&mut deps);
+
+    // The rotated code id now resolves to no on-chain code, so the existence
+    // check must reject it and leave the stored code untouched.
+    deps.querier.update_wasm(|query| match query {
+        WasmQuery::CodeInfo { code_id } => {
+            SystemResult::Err(SystemError::NoSuchCode { code_id: *code_id })
+        }
+        _ => unimplemented!("unexpected wasm query in this test"),
+    });
+
+    let err = execute(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(ADMIN),
+        ExecuteMsg::NewLeaseCode(Code::unchecked(LEASE_CODE_ID + 9)),
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::Platform(_)), "got {err:?}");
+    assert_stored_lease_code(Code::unchecked(LEASE_CODE_ID), deps.as_ref());
+}
+
+fn deps() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
+    sdk_testing::mock_deps_with_contracts([])
+}
+
+fn instantiate_default(deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>) {
+    instantiate(
+        deps.as_mut(),
+        testing::mock_env(),
+        sender(CREATOR),
+        instantiate_msg(),
+    )
+    .unwrap();
+}
+
+fn instantiate_msg() -> InstantiateMsg {
+    InstantiateMsg {
+        protocol_admin: sdk_testing::user(ADMIN).into_string(),
+        lease_code: LEASE_CODE_ID.into(),
+    }
+}
+
+fn sender(who: &str) -> MessageInfo {
+    MessageInfo {
+        sender: sdk_testing::user(who),
+        funds: vec![],
+    }
+}
+
+fn assert_stored_lease_code(expected: Code, deps: Deps<'_>) {
+    assert_eq!(expected, Config::load(deps.storage).unwrap().lease_code());
+}

--- a/protocol/docs/remote-lease-admin-runbook.md
+++ b/protocol/docs/remote-lease-admin-runbook.md
@@ -186,13 +186,27 @@ lease-side `wasm-ls-close-remote-lease` events out-of-band until none remain in 
 Updates **only** `Config.lease_code` and emits **zero** messages. No channel impact.
 `protocol_admin` only.
 
-### 3.2 The silent-success trap
+### 3.2 Rotation is existence-checked (the former silent-success trap)
 
-`Code` deserializes with **no on-chain existence check** — a typo'd or non-existent code
-id **succeeds silently**. The only later symptom is that **every** legitimate lease call
-fails with `UnauthorisedCaller` (the controller authorizes packet senders against
-`Config.lease_code`). **Mandatory:** immediately after `NewLeaseCode`, run
-`QueryMsg::Config()` and confirm `lease_code_id` equals the redeployed Lease code id.
+`NewLeaseCode` confirms the rotated id exists on-chain (`WasmQuery::CodeInfo` via
+`Code::try_new`) **before** persisting — the same check `instantiate` runs on
+`lease_code`. A typo'd or non-existent id is **rejected with a typed error and the stored
+`lease_code` is left unchanged**; the rotation simply does not take effect. The
+remote_lease controller, `reserve`, and `lpp` all validate on rotation now (`leaser` and
+`remote_profit` already did), so a bad id can no longer slip through any of them.
+
+This closes the old trap: previously `Code` deserialized with **no** existence check, so a
+typo'd id **succeeded silently** and **bricked the contract until a corrective rotation** —
+every legitimate lease call then failed with `UnauthorisedCaller` (the controller
+authorizes packet senders against `Config.lease_code`). The failure mode has shifted: a
+bad rotation now **fails closed with state unchanged** instead of leaving a bricked
+contract behind.
+
+**Existence is not correctness.** The check proves the id resolves to *some* uploaded
+code, not that it is the *right* redeployed Lease. A valid-but-wrong id still passes and
+still strands lease calls with `UnauthorisedCaller`. **Still recommended:** immediately
+after `NewLeaseCode`, run `QueryMsg::Config()` and confirm `lease_code_id` equals the
+redeployed Lease code id.
 
 ### 3.3 Coordination with a Lease redeploy
 
@@ -229,7 +243,11 @@ old-code lease to a terminal state before rotating.**
 
 ### 3.6 Failure & recovery
 
-- **Wrong id** → re-issue `NewLeaseCode` with the correct id (no other state touched).
+- **Non-existent id** → rejected up-front with a typed error; nothing is persisted and the
+  live `lease_code` is unchanged (§3.2). Re-issue `NewLeaseCode` with a real id.
+- **Valid-but-wrong id** (resolves on-chain, but not the redeployed Lease) → passes the
+  existence check and is persisted; the symptom is `UnauthorisedCaller` on lease ops.
+  Re-issue `NewLeaseCode` with the correct id (no other state touched).
 - **Stranded old-code lease** → none after the fact; it must reach terminal via the
   existing callback flows. It cannot be upgraded.
 - `NewLeaseCode` on an uninstantiated/corrupted config → `Std` error (config stays unset).

--- a/tests/src/reserve.rs
+++ b/tests/src/reserve.rs
@@ -18,6 +18,7 @@ use sdk::{
 use crate::{
     common::{
         self,
+        lease::Instantiator as LeaseInstantiator,
         leaser::Instantiator as LeaserInstantiator,
         test_case::{
             TestCase, app::App, builder::BlankBuilder as TestCaseBuilder,
@@ -47,7 +48,7 @@ fn instantiate() {
 fn new_lease_code() {
     let mut test_case = TestCaseBuilder::<Lpn>::new().init_reserve().into_generic();
     let reserve = test_case.address_book.reserve().clone();
-    let new_lease_code = Code::unchecked(12);
+    let new_lease_code = LeaseInstantiator::store(&mut test_case.app);
     let err = set_new_lease_code(
         &mut test_case.app,
         reserve.clone(),
@@ -72,6 +73,30 @@ fn new_lease_code() {
 
     assert_lpn(&test_case, reserve.clone(), &currency::dto::<Lpn, _>());
     assert_config(&test_case, reserve, &ConfigResponse::new(new_lease_code));
+}
+
+#[test]
+fn new_lease_code_rejects_unknown_code() {
+    let mut test_case = TestCaseBuilder::<Lpn>::new().init_reserve().into_generic();
+    let reserve = test_case.address_book.reserve().clone();
+    let stored_lease_code = test_case.address_book.lease_code();
+    let unknown_lease_code = Code::unchecked(u64::from(stored_lease_code) + 100);
+
+    let err = set_new_lease_code(
+        &mut test_case.app,
+        reserve.clone(),
+        LeaserInstantiator::expected_addr(),
+        unknown_lease_code,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<ReserveError>(),
+        Some(&ReserveError::Platform(
+            PlatformError::CosmWasmQueryCodeInfo(_)
+        ))
+    ));
+
+    assert_config(&test_case, reserve, &ConfigResponse::new(stored_lease_code));
 }
 
 #[test]


### PR DESCRIPTION
Closes #687.

The NewLeaseCode admin handlers persisted the rotated code id without verifying it exists on-chain, while their own instantiate paths validate it. A protocol admin rotating to a non-existent id was accepted, after which the code-id caller check rejected every authorized caller — bricking outbound emission (remote_lease) or downstream lease instantiation (reserve, lpp) until a corrective rotation.

All three handlers now route rotation through a private set_lease_code that validates via the on-chain code-info query before persisting — the same validate-on-rotation pattern the leaser has always used and remote_profit adopted in #685. A bad rotation is rejected with a typed error and the stored code is left unchanged.

**Scope note:** the issue listed remote_lease and reserve; **lpp is included as well** — review surfaced that it carries the identical unvalidated handler, and the leaser propagates NewLeaseCode to both lpp and reserve, so fixing one co-recipient without the other would be incomplete. A sweep across every code-rotation site confirms none remain unvalidated.

Tests (rejection written first, confirmed failing pre-fix): rejection + success + non-admin cases per contract; the reserve integration test now rotates to a genuinely stored code id, plus a new integration case pinning the rejection and unchanged-state behavior. The admin runbook's rotation section is updated accordingly (existence-checked rotation; the post-rotation Config re-query stays recommended since a valid-but-wrong id still passes). Full build/format/lint/test matrix green on the protocol and integration workspaces (184 integration tests). Independent review: 12-item checklist pass, security scan clear.