### PR TITLE
feat(lease): auto-requote the liquidation swap on remote-swap timeout

### DIFF
--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/mod.rs
@@ -67,3 +67,22 @@ pub fn auto_start(
     let events = event::emit_auto_close(strategy, env, &lease.lease.addr);
     FullClose {}.start(lease, events.into(), Calculator::default(), env, querier)
 }
+
+#[cfg(all(feature = "internal.test.contract", test))]
+mod tests {
+    use dex::SlippageCalculator;
+
+    use crate::api::LeaseAssetCurrencies;
+
+    use super::Calculator;
+
+    /// Truth table (#660): the customer-close legs run `AcceptAnyNonZeroSwap`,
+    /// which keeps the `REQUOTES_ON_TIMEOUT` default of `false` — a
+    /// customer-close timeout re-emits the pinned floor verbatim, unlike the
+    /// liquidation legs sharing the same `SellAsset` spec.
+    /// COMPILE-RED: blocked on `SlippageCalculator::REQUOTES_ON_TIMEOUT`.
+    #[test]
+    fn customer_close_calculator_does_not_requote_on_timeout() {
+        assert!(!<Calculator as SlippageCalculator<LeaseAssetCurrencies>>::REQUOTES_ON_TIMEOUT);
+    }
+}

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/mod.rs
@@ -76,11 +76,10 @@ mod tests {
 
     use super::Calculator;
 
-    /// Truth table (#660): the customer-close legs run `AcceptAnyNonZeroSwap`,
+    /// Truth table: the customer-close legs run `AcceptAnyNonZeroSwap`,
     /// which keeps the `REQUOTES_ON_TIMEOUT` default of `false` — a
     /// customer-close timeout re-emits the pinned floor verbatim, unlike the
     /// liquidation legs sharing the same `SellAsset` spec.
-    /// COMPILE-RED: blocked on `SlippageCalculator::REQUOTES_ON_TIMEOUT`.
     #[test]
     fn customer_close_calculator_does_not_requote_on_timeout() {
         assert!(!<Calculator as SlippageCalculator<LeaseAssetCurrencies>>::REQUOTES_ON_TIMEOUT);

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/mod.rs
@@ -82,6 +82,6 @@ mod tests {
     /// liquidation legs sharing the same `SellAsset` spec.
     #[test]
     fn customer_close_calculator_does_not_requote_on_timeout() {
-        assert!(!<Calculator as SlippageCalculator<LeaseAssetCurrencies>>::REQUOTES_ON_TIMEOUT);
+        const { assert!(!<Calculator as SlippageCalculator<LeaseAssetCurrencies>>::REQUOTES_ON_TIMEOUT) }
     }
 }

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/mod.rs
@@ -64,12 +64,11 @@ mod tests {
 
     use super::Calculator;
 
-    /// Truth table (#660): the liquidation legs run `AcceptUpToMaxSlippage`,
+    /// Truth table: the liquidation legs run `AcceptUpToMaxSlippage`,
     /// the ONLY requote-on-timeout calculator class. The `SellAsset` spec
     /// forwards `CalculatorT::REQUOTES_ON_TIMEOUT`, so a liquidation leg —
     /// full and partial alike — re-quotes its floor from the live oracle on
     /// every in-budget timeout.
-    /// COMPILE-RED: blocked on `SlippageCalculator::REQUOTES_ON_TIMEOUT`.
     #[test]
     fn liquidation_calculator_requotes_on_timeout() {
         assert!(<Calculator as SlippageCalculator<LeaseAssetCurrencies>>::REQUOTES_ON_TIMEOUT);

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/mod.rs
@@ -71,6 +71,6 @@ mod tests {
     /// every in-budget timeout.
     #[test]
     fn liquidation_calculator_requotes_on_timeout() {
-        assert!(<Calculator as SlippageCalculator<LeaseAssetCurrencies>>::REQUOTES_ON_TIMEOUT);
+        const { assert!(<Calculator as SlippageCalculator<LeaseAssetCurrencies>>::REQUOTES_ON_TIMEOUT) }
     }
 }

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/mod.rs
@@ -55,3 +55,23 @@ impl From<Cause> for ApiCause {
         }
     }
 }
+
+#[cfg(all(feature = "internal.test.contract", test))]
+mod tests {
+    use dex::SlippageCalculator;
+
+    use crate::api::LeaseAssetCurrencies;
+
+    use super::Calculator;
+
+    /// Truth table (#660): the liquidation legs run `AcceptUpToMaxSlippage`,
+    /// the ONLY requote-on-timeout calculator class. The `SellAsset` spec
+    /// forwards `CalculatorT::REQUOTES_ON_TIMEOUT`, so a liquidation leg —
+    /// full and partial alike — re-quotes its floor from the live oracle on
+    /// every in-budget timeout.
+    /// COMPILE-RED: blocked on `SlippageCalculator::REQUOTES_ON_TIMEOUT`.
+    #[test]
+    fn liquidation_calculator_requotes_on_timeout() {
+        assert!(<Calculator as SlippageCalculator<LeaseAssetCurrencies>>::REQUOTES_ON_TIMEOUT);
+    }
+}

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
@@ -163,6 +163,10 @@ where
         SlippageEscalation::Park
     }
 
+    fn requote_on_timeout(&self) -> bool {
+        <CalculatorT as SlippageCalculator<Self::InG>>::REQUOTES_ON_TIMEOUT
+    }
+
     fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>> {
         iter::once(*self.repayable.amount(&self.lease))
     }

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -595,11 +595,10 @@ mod tests {
         assert_eq!(Ok(expected), min_out);
     }
 
-    /// Truth table (#660): the opening swap keeps the verbatim re-emission
+    /// Truth table: the opening swap keeps the verbatim re-emission
     /// class — `requote_on_timeout` stays at its `false` default even though
     /// the opening calculator reads the oracle. The detection-first opening
     /// timeout semantics are unchanged.
-    /// COMPILE-RED: blocked on `SwapTask::requote_on_timeout`.
     #[test]
     fn opening_spec_does_not_requote_on_timeout() {
         assert!(!spec().requote_on_timeout());

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -595,6 +595,16 @@ mod tests {
         assert_eq!(Ok(expected), min_out);
     }
 
+    /// Truth table (#660): the opening swap keeps the verbatim re-emission
+    /// class — `requote_on_timeout` stays at its `false` default even though
+    /// the opening calculator reads the oracle. The detection-first opening
+    /// timeout semantics are unchanged.
+    /// COMPILE-RED: blocked on `SwapTask::requote_on_timeout`.
+    #[test]
+    fn opening_spec_does_not_requote_on_timeout() {
+        assert!(!spec().requote_on_timeout());
+    }
+
     struct ProbeMinOut<'querier, Task>
     where
         Task: SwapTask,

--- a/protocol/contracts/profit/src/state/buy_back.rs
+++ b/protocol/contracts/profit/src/state/buy_back.rs
@@ -305,10 +305,9 @@ mod tests {
 
     use super::{BuyBack, Config};
 
-    /// Truth table (#660): the profit buy-back runs `AcceptAnyNonZeroSwap`
+    /// Truth table: the profit buy-back runs `AcceptAnyNonZeroSwap`
     /// and keeps the verbatim re-emission class — `requote_on_timeout` stays
     /// at its `false` default.
-    /// COMPILE-RED: blocked on `SwapTask::requote_on_timeout`.
     #[test]
     fn buy_back_does_not_requote_on_timeout() {
         assert!(!spec().requote_on_timeout());

--- a/protocol/contracts/profit/src/state/buy_back.rs
+++ b/protocol/contracts/profit/src/state/buy_back.rs
@@ -291,3 +291,61 @@ enum ControllerExecuteMsg {
 }
 
 impl ControllerInnerMessage for ControllerExecuteMsg {}
+
+#[cfg(all(feature = "internal.test.contract", test))]
+mod tests {
+    use currencies::testing::PaymentC3;
+    use dex::{Account, ConnectionParams, Ics20Channel, SwapTask};
+    use finance::coin::Coin;
+    use remote_profit_wire::profit_id::RemoteProfitId;
+    use sdk::cosmwasm_std::{self, Addr};
+    use timealarms::stub::TimeAlarmsRef;
+
+    use crate::state::VaultConfig;
+
+    use super::{BuyBack, Config};
+
+    /// Truth table (#660): the profit buy-back runs `AcceptAnyNonZeroSwap`
+    /// and keeps the verbatim re-emission class — `requote_on_timeout` stays
+    /// at its `false` default.
+    /// COMPILE-RED: blocked on `SwapTask::requote_on_timeout`.
+    #[test]
+    fn buy_back_does_not_requote_on_timeout() {
+        assert!(!spec().requote_on_timeout());
+    }
+
+    fn spec() -> BuyBack {
+        BuyBack::new(config(), vec![Coin::<PaymentC3>::new(1_000).into()])
+            .expect("the buy-back spec should build")
+    }
+
+    fn config() -> Config {
+        Config::new(
+            24,
+            Addr::unchecked("treasury"),
+            oracle_platform::OracleRef::unchecked(Addr::unchecked("oracle")),
+            TimeAlarmsRef::unchecked("timealarms"),
+            Account::funding(
+                Addr::unchecked("profit"),
+                ConnectionParams {
+                    connection_id: "connection-0".to_owned(),
+                    transfer_channel: Ics20Channel {
+                        local_endpoint: "channel-0".to_owned(),
+                        remote_endpoint: "channel-2048".to_owned(),
+                    },
+                },
+            ),
+            Addr::unchecked("controller"),
+            VaultConfig {
+                code_id: cosmwasm_std::from_json(b"3").expect("a valid code id"),
+                address: Addr::unchecked("drain-vault"),
+            },
+        )
+        .with_profit_authority(profit_authority())
+    }
+
+    fn profit_authority() -> RemoteProfitId {
+        RemoteProfitId::new("StubPda1111111111111111111111111111".to_owned())
+            .expect("a base58 sample")
+    }
+}

--- a/protocol/docs/remote-lease-admin-runbook.md
+++ b/protocol/docs/remote-lease-admin-runbook.md
@@ -253,10 +253,19 @@ lease's dex state machine.**
   event so the ack commits and the relayer loop unblocks.
 - **Lease** auto-recovers: on a swap leg, timeouts re-emit up to a per-operation budget
   then park at the slippage-anomaly terminal; under-floor errors escalate per policy;
-  underpaid acks re-emit with a bumped nonce. The opening/repay **funding** legs are
-  forward-only instead — a timeout or error ack re-emits the single in-flight ICS-20
-  transfer verbatim, with no budget and no park (the refunded coin must go out again for
-  the open/repay to progress).
+  underpaid acks re-emit with a bumped nonce. **Liquidation** swap legs re-quote their
+  floor from the live oracle on each in-budget timeout re-emission — bounded by
+  `MaxSlippages.liquidation`, tracking the price both down and up, clamped to `>= 1` —
+  so a stale floor cannot strand a liquidation as the market moves; the opening, repay,
+  customer-close, and profit buy-back legs instead re-emit the **pinned** floor verbatim.
+  An oracle-query failure at re-quote time falls back to the pinned floor and marks the
+  retry event `requote = skipped`. The re-quote is escalation-agnostic — the past-budget
+  escalation never re-quotes — so floor erosion stays bounded by the retry budget and the
+  leg still parks at the slippage-anomaly terminal intact, carrying the last re-quoted
+  floor. `Heal` on a live swap leg is unaffected: it re-emits the pinned floor (§4.3).
+  The opening/repay **funding** legs are forward-only instead — a timeout or error ack
+  re-emits the single in-flight ICS-20 transfer verbatim, with no budget and no park (the
+  refunded coin must go out again for the open/repay to progress).
 - **Controller** never retries on the lease's behalf.
 - Relayer retry **cadence/max-retries** is hermes-lite relayer configuration, not a
   contract property — consult the relayer for the actual numbers.
@@ -320,8 +329,10 @@ the channel-level timeout over an eager `Heal`.
 
 There is no contract query for the in-flight nonce. Diagnose via emitted events:
 `heal`/re-emit, `anomaly/under-min-out`, `anomaly/slippage-anomaly-parked`,
-`anomaly/price-alarm-dropped`, `timeout/retry`, and `absorbed/<reason>` (reasons include
-`nonce-mismatch`, `parked-response`/`-error`/`-timeout`, `undecodable-response`,
+`anomaly/price-alarm-dropped`, `timeout/retry` (on a liquidation leg it additionally
+carries `min-out-prev` + `min-out` when it re-quoted, or `requote = skipped` when the
+oracle query failed and the pinned floor was reused), and `absorbed/<reason>` (reasons
+include `nonce-mismatch`, `parked-response`/`-error`/`-timeout`, `undecodable-response`,
 `out-currency-mismatch`) — plus `StateResponse`.
 
 ---

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -981,7 +981,7 @@ where
             C: CurrencyDef,
             C::Group: MemberOf<G> + MemberOf<G::TopG>,
         {
-            Ord::max(floor, Coin::new(REQUOTE_FLOOR_MIN)).into()
+            floor.max(Coin::new(REQUOTE_FLOOR_MIN)).into()
         }
     }
 

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -26,7 +26,7 @@
 //! - the pinned per-leg floor (`in_flight_min_out`) - a re-emission repeats the
 //!   exact promise of the original, so the counterparty enforces one and the
 //!   same floor however many times the leg goes out. The one carve-out is the
-//!   liquidation timeout re-quote (#660): a spec whose
+//!   liquidation timeout re-quote: a spec whose
 //!   [`SwapTask::requote_on_timeout`][crate::SwapTask::requote_on_timeout] is
 //!   `true` re-quotes the floor from the live oracle on each in-budget timeout
 //!   and overwrites `in_flight_min_out` before re-emitting, so the promise
@@ -147,7 +147,7 @@ where
 /// coin list is persisted. The slippage floor promised for the in-flight
 /// leg is pinned in `in_flight_min_out` when the leg is opened and reused
 /// verbatim by every re-emission - acknowledgment validation never
-/// consults the live oracle. A requote-class spec (liquidation, #660) is the
+/// consults the live oracle. A requote-class spec (liquidation) is the
 /// exception on the timeout path only: it re-quotes the floor from the live
 /// oracle and overwrites `in_flight_min_out` before each in-budget
 /// re-emission; acknowledgment validation still uses the pinned value.
@@ -425,7 +425,7 @@ where
     ///
     /// A verbatim re-emission repeats the exact promise of the original
     /// emission so the counterparty enforces one and the same floor however
-    /// many times the leg goes out. A liquidation timeout re-quote (#660)
+    /// many times the leg goes out. A liquidation timeout re-quote
     /// overwrites `in_flight_min_out` before scheduling, so the re-emitted
     /// floor tracks the live oracle rather than the original promise.
     fn schedule(&self) -> Result<Batch> {
@@ -705,7 +705,7 @@ where
     /// A timeout re-emits the in-flight leg up to the spec's per-op retry
     /// budget and escalates past it - the opened legs park while the opening
     /// swap keeps re-emitting unbounded. Within budget a requote-class spec
-    /// (liquidation, #660) re-quotes the floor from the live oracle first; the
+    /// (liquidation) re-quotes the floor from the live oracle first; the
     /// past-budget escalation is always verbatim.
     fn on_remote_timeout(
         self,
@@ -1010,7 +1010,7 @@ pub(super) mod mock {
     pub const CONTROLLER: &str = "controller";
     pub const WRONG_VARIANT_PAYLOAD: &[u8] = b"wrong-variant";
     /// The failure reason the mock's calculator reports once a test arms
-    /// [`MockSpec::set_quote_failure`] — the #660 stand-in for an oracle
+    /// [`MockSpec::set_quote_failure`] — the stand-in for an oracle
     /// query error during a timeout requote.
     pub const FAILING_QUOTE: &str = "mock quote failure";
     pub const SLIPPAGE_PROTECTION_SENTINEL: CoinsNb = CoinsNb::MAX;
@@ -1042,13 +1042,13 @@ pub(super) mod mock {
         anomaly_resolution_authorised: bool,
         #[serde(default)]
         unwinds_on_zero_acked: bool,
-        /// #660: opts the spec into the requote-on-timeout class. Read by the
+        /// Opts the spec into the requote-on-timeout class. Read by the
         /// spec's `SwapTask::requote_on_timeout` override once the seam
         /// lands; `#[serde(default)]` keeps the legacy fixtures
         /// deserializing to the verbatim class.
         #[serde(default)]
         requotes_on_timeout: bool,
-        /// #660: makes the calculator's `min_output` fail, standing in for
+        /// Makes the calculator's `min_output` fail, standing in for
         /// an oracle query error during a timeout requote.
         #[serde(default)]
         quote_fails: bool,
@@ -2236,22 +2236,10 @@ mod tests {
         assert_eq!(0, restored.in_flight_nonce);
     }
 
-    // -----------------------------------------------------------------------
-    // #660 — liquidation auto-requote: an in-budget TIMEOUT of a requote-class
-    // spec re-quotes the in-flight leg's floor from the live oracle before the
-    // re-emission (no monotonic clamp, floor >= 1, oracle failure falls back
-    // to the pinned floor). Every other trigger — underpaid ack, default-class
-    // timeout, past-budget escalation, heal — re-emits the pinned floor
-    // verbatim. Seam (not yet implemented): `SwapTask::requote_on_timeout`
-    // defaulted `false` + MockSpec override reading `requotes_on_timeout`, and
-    // `SlippageCalculator::REQUOTES_ON_TIMEOUT` defaulted `false`.
-    // -----------------------------------------------------------------------
-
-    /// AC (#660 / U1): an in-budget timeout of a requote-class spec re-quotes
+    /// An in-budget timeout of a requote-class spec re-quotes
     /// the floor from the live oracle — DOWN, with no monotonic clamp — and
     /// the re-emission both promises and pins the fresh floor. The retry
     /// event carries the previous and the requoted floor.
-    /// RED-behavioral until the requote lands in `on_remote_timeout`.
     #[test]
     fn timeout_requotes_the_floor_down() {
         const PINNED_FLOOR: Amount = 40;
@@ -2280,9 +2268,8 @@ mod tests {
         assert_eq!(1, node.timeouts);
     }
 
-    /// AC (#660 / U2): the requote also tracks the oracle UP — the promise
+    /// The requote also tracks the oracle UP — the promise
     /// tightens when the live quote demands more.
-    /// RED-behavioral until the requote lands.
     #[test]
     fn timeout_requotes_the_floor_up() {
         const PINNED_FLOOR: Amount = 40;
@@ -2311,11 +2298,10 @@ mod tests {
         assert_eq!(1, node.timeouts);
     }
 
-    /// AC (#660 / U3): requote rounds spend the same timeout budget as
+    /// Requote rounds spend the same timeout budget as
     /// verbatim re-emissions — `acks_left`, `total_out` and the counters
     /// carry across requotes — and the round past the budget parks WITHOUT
     /// requoting, freezing the LAST requoted floor at the terminal.
-    /// RED-behavioral until the requote lands.
     #[test]
     fn requote_rounds_spend_the_budget_and_park_with_the_last_floor() {
         const BASE_FLOOR: Amount = 40;
@@ -2349,7 +2335,7 @@ mod tests {
         assert_terminal(2, &coin_out(50), &coin_out(last_floor), &terminal);
     }
 
-    /// AC (#660 / U4): every requote round re-emits with a strictly greater
+    /// Every requote round re-emits with a strictly greater
     /// nonce, so the superseded packet's late acknowledgment is absorbed —
     /// the floor overwrite stays coupled to the nonce bump.
     #[test]
@@ -2391,7 +2377,7 @@ mod tests {
         assert_node(2, &coin_out(50), &coin_out(PINNED_FLOOR - 10), &node);
     }
 
-    /// AC (#660 / U5): an UNDERPAID-ack re-emission stays pinned even for a
+    /// An UNDERPAID-ack re-emission stays pinned even for a
     /// requote-class spec — the requote is triggered by a timeout, never by
     /// an under-floor acknowledgment. GREEN today; must stay green.
     #[test]
@@ -2424,7 +2410,7 @@ mod tests {
         assert_node(2, &coin_out(50), &coin_out(PINNED_FLOOR), &node);
     }
 
-    /// AC (#660 / U6): a default-class spec re-emits the PINNED floor on
+    /// A default-class spec re-emits the PINNED floor on
     /// timeout even when the live oracle has moved — the requote is opt-in
     /// per spec. GREEN today; must stay green.
     #[test]
@@ -2449,10 +2435,10 @@ mod tests {
         assert_node(2, &coin_out(50), &coin_out(PINNED_FLOOR), &node);
     }
 
-    /// AC (#660 / U7): a `ReEmit`-escalation, requote-class spec requotes
+    /// A `ReEmit`-escalation, requote-class spec requotes
     /// only WITHIN the budget — the escalation's past-budget re-emission
     /// repeats the last requoted floor verbatim, however the oracle has
-    /// moved since. RED-behavioral until the in-budget requote lands.
+    /// moved since.
     #[test]
     fn reemit_escalation_past_budget_stays_verbatim() {
         const PINNED_FLOOR: Amount = 40;
@@ -2490,9 +2476,9 @@ mod tests {
         assert_node(2, &coin_out(50), &coin_out(REQUOTED_FLOOR), &node);
     }
 
-    /// AC (#660 / U8): a collapsed quote requotes the floor to the minimum
+    /// A collapsed quote requotes the floor to the minimum
     /// of 1, never 0 — a zero `min_out` would revert the counterparty's swap
-    /// params. RED-behavioral until the requote lands.
+    /// params.
     #[test]
     fn requote_of_a_collapsed_quote_clamps_the_floor_to_one() {
         const PINNED_FLOOR: Amount = 40;
@@ -2520,10 +2506,10 @@ mod tests {
         assert_node(2, &coin_out(50), &coin_out(CLAMPED_FLOOR), &node);
     }
 
-    /// AC (#660 / U9): an oracle failure during the requote falls back to
+    /// An oracle failure during the requote falls back to
     /// the pinned floor for that round — the re-emission still goes out, the
     /// budget is still consumed, the event marks the skipped requote, and
-    /// the park stays reachable. RED-behavioral until the requote lands.
+    /// the park stays reachable.
     #[test]
     fn failed_quote_falls_back_to_the_pinned_floor() {
         const PINNED_FLOOR: Amount = 40;
@@ -2558,10 +2544,9 @@ mod tests {
         assert_terminal(2, &coin_out(50), &coin_out(PINNED_FLOOR), &terminal);
     }
 
-    /// AC (#660 / U10): a node persisted before #660 carries no requote
+    /// A node persisted before this change carries no requote
     /// toggle in the spec; the defaulted field must load `false` so legacy
     /// leases keep the verbatim re-emission class.
-    /// COMPILE-RED: blocked on `SwapTask::requote_on_timeout`.
     #[test]
     fn legacy_remote_swap_without_requote_toggle_stays_verbatim_class() {
         use crate::SwapTask;
@@ -2569,14 +2554,12 @@ mod tests {
         let legacy_remote_swap = br#"{"spec":{"coins":[{"amount":"100","ticker":"ticker#2"},{"amount":"50","ticker":"ticker#1"},{"amount":"70","ticker":"ticker#2"}],"floor":1,"budget":3},"acks_left":1,"total_out":{"amount":"80","ticker":"ticker#1"},"in_flight_min_out":{"amount":"1","ticker":"ticker#1"},"timeouts":0,"errors":0,"in_flight_nonce":3}"#;
 
         let restored: Node = sdk::cosmwasm_std::from_json(legacy_remote_swap.as_slice())
-            .expect("the pre-#660 state should deserialize");
+            .expect("the legacy state should deserialize");
         assert!(!restored.spec.requote_on_timeout());
     }
 
-    /// Truth table (#660): the MockSpec defaults to the verbatim class; the
+    /// Truth table: the MockSpec defaults to the verbatim class; the
     /// toggle flips it into the requote class.
-    /// COMPILE-RED: blocked on `SwapTask::requote_on_timeout` + the MockSpec
-    /// override reading `requotes_on_timeout`.
     #[test]
     fn mock_spec_requote_class_follows_its_toggle() {
         use crate::SwapTask;
@@ -2585,11 +2568,10 @@ mod tests {
         assert!(requoting_spec3().requote_on_timeout());
     }
 
-    /// Truth table (#660): a calculator that does not override
+    /// Truth table: a calculator that does not override
     /// `REQUOTES_ON_TIMEOUT` inherits the `false` default — only
     /// `AcceptUpToMaxSlippage` opts in (pinned in the lease crate against the
     /// production alias).
-    /// COMPILE-RED: blocked on `SlippageCalculator::REQUOTES_ON_TIMEOUT`.
     #[test]
     fn calculator_default_is_no_requote_on_timeout() {
         use currency::{CurrencyDef, Group, MemberOf};
@@ -2746,7 +2728,7 @@ mod tests {
         MockSpec::new(vec![coin_in(100), coin_out(50), coin_in(70)])
     }
 
-    /// [`spec3`] opted into the #660 requote-on-timeout class.
+    /// [`spec3`] opted into the requote-on-timeout class.
     fn requoting_spec3() -> MockSpec {
         let mut spec = spec3();
         spec.set_requotes_on_timeout();
@@ -2788,7 +2770,7 @@ mod tests {
     }
 
     /// The verbatim timeout retry: the pinned floor re-emitted, no requote
-    /// attributes on the event (#660).
+    /// attributes on the event.
     fn timeout_response_with_floor(
         leg: &CoinDTO<OutG>,
         pinned_floor: &CoinDTO<OutG>,
@@ -2802,7 +2784,7 @@ mod tests {
         )
     }
 
-    /// The requoting timeout retry (#660): the fresh floor is promised on the
+    /// The requoting timeout retry: the fresh floor is promised on the
     /// wire, and the retry event gains the additive `min-out-prev` /
     /// `min-out` coin attributes — the SPEC of the event keys.
     fn requote_timeout_response(
@@ -2821,7 +2803,7 @@ mod tests {
         )
     }
 
-    /// The oracle-failure fallback round (#660): the pinned floor re-emitted
+    /// The oracle-failure fallback round: the pinned floor re-emitted
     /// and the skipped requote marked with `requote = skipped` — the SPEC of
     /// the skip-marker key.
     fn skipped_requote_timeout_response(

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -207,6 +207,8 @@ where
     _finisher: PhantomData<HandlerT>,
 }
 
+struct ClampToMin;
+
 impl<SwapTask, SEnum> RemoteSwap<SwapTask, SEnum>
 where
     SwapTask: SwapTaskT + RemoteSwapClient,
@@ -344,14 +346,18 @@ where
     }
 
     /// Re-quote the in-flight liquidation leg's floor from the live oracle and
-    /// re-emit against it, falling back to the verbatim pinned floor when the
-    /// oracle query fails. Either way the re-emission goes out, the nonce
-    /// bumps once and the retry budget is spent, so the timeout handler never
-    /// errors and the park safety net stays reachable.
+    /// re-emit against it. An oracle-query failure falls back to the verbatim
+    /// pinned floor - the re-emission still goes out, the nonce bumps once and
+    /// the budget is spent, so the park safety net stays reachable. A
+    /// leg-lookup failure, by contrast, is an internal invariant breach: it
+    /// propagates as a typed error out of the handler, exactly as the verbatim
+    /// re-emission path's identical lookup does, rather than masquerading as a
+    /// benign skipped re-quote.
     fn reemit_requoted(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
         match self.requoted_floor(querier) {
-            Some(fresh_floor) => self.reemit_with_requote(fresh_floor, querier, env),
-            None => self.reemit_skipping_requote(querier, env),
+            Ok(Some(fresh_floor)) => self.reemit_with_requote(fresh_floor, querier, env),
+            Ok(None) => self.reemit_skipping_requote(querier, env),
+            Err(leg_lookup_failed) => leg_lookup_failed.into(),
         }
     }
 
@@ -497,16 +503,21 @@ where
     }
 
     /// Re-quote the in-flight leg's floor from the live oracle, clamped so a
-    /// collapsed quote never promises below [`REQUOTE_FLOOR_MIN`]. Returns
-    /// `None` when the leg lookup or the oracle query fails, so the caller
-    /// falls back to the pinned floor rather than surfacing an error.
-    fn requoted_floor(&self, querier: QuerierWrapper<'_>) -> Option<CoinDTO<SwapTask::OutG>> {
-        self.in_flight_leg()
-            .and_then(|coin_in| {
-                leg_min_out(&self.spec, coin_in, self.total_out.currency(), querier)
-            })
-            .map(clamp_floor)
-            .ok()
+    /// collapsed quote never promises below [`REQUOTE_FLOOR_MIN`]. An oracle
+    /// query failure yields `Ok(None)`, so the caller falls back to the pinned
+    /// floor and marks the re-quote skipped. A leg-lookup failure is an
+    /// internal invariant breach, not a benign skip: it surfaces as `Err` and
+    /// propagates out of the handler exactly as the verbatim re-emission path's
+    /// identical lookup does.
+    fn requoted_floor(
+        &self,
+        querier: QuerierWrapper<'_>,
+    ) -> Result<Option<CoinDTO<SwapTask::OutG>>> {
+        self.in_flight_leg().map(|coin_in| {
+            leg_min_out(&self.spec, coin_in, self.total_out.currency(), querier)
+                .map(clamp_floor)
+                .ok()
+        })
     }
 
     /// Rebuild the node for a re-quote re-emission: the freshly re-quoted
@@ -865,6 +876,21 @@ where
     }
 }
 
+impl<G> WithCoin<G> for ClampToMin
+where
+    G: Group,
+{
+    type Outcome = CoinDTO<G>;
+
+    fn on<C>(self, floor: Coin<C>) -> Self::Outcome
+    where
+        C: CurrencyDef,
+        C::Group: MemberOf<G> + MemberOf<G::TopG>,
+    {
+        floor.max(Coin::new(REQUOTE_FLOOR_MIN)).into()
+    }
+}
+
 pub(super) fn swappable_coins<SwapTask>(
     spec: &SwapTask,
     out_currency: CurrencyDTO<SwapTask::OutG>,
@@ -968,23 +994,6 @@ fn clamp_floor<G>(floor: CoinDTO<G>) -> CoinDTO<G>
 where
     G: Group,
 {
-    struct ClampToMin;
-
-    impl<G> WithCoin<G> for ClampToMin
-    where
-        G: Group,
-    {
-        type Outcome = CoinDTO<G>;
-
-        fn on<C>(self, floor: Coin<C>) -> Self::Outcome
-        where
-            C: CurrencyDef,
-            C::Group: MemberOf<G> + MemberOf<G::TopG>,
-        {
-            floor.max(Coin::new(REQUOTE_FLOOR_MIN)).into()
-        }
-    }
-
     floor.with_coin(ClampToMin)
 }
 

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -25,7 +25,15 @@
 //!   consecutive leg sharing the input currency;
 //! - the pinned per-leg floor (`in_flight_min_out`) - a re-emission repeats the
 //!   exact promise of the original, so the counterparty enforces one and the
-//!   same floor however many times the leg goes out.
+//!   same floor however many times the leg goes out. The one carve-out is the
+//!   liquidation timeout re-quote (#660): a spec whose
+//!   [`SwapTask::requote_on_timeout`][crate::SwapTask::requote_on_timeout] is
+//!   `true` re-quotes the floor from the live oracle on each in-budget timeout
+//!   and overwrites `in_flight_min_out` before re-emitting, so the promise
+//!   tracks the moving price. Each re-quote is still coupled to a single nonce
+//!   bump, so a superseded packet's late callback is absorbed exactly as under
+//!   the verbatim path; correctness rests on the nonce, not on the floor being
+//!   constant.
 //!
 //! `heal` therefore stays permissionless and re-emits the leg verbatim - same
 //! coin-in, same pinned floor, fresh nonce - leaving idempotency to the nonce
@@ -40,7 +48,7 @@ use serde::{Deserialize, Serialize};
 
 use currency::{CurrencyDTO, CurrencyDef, Group, MemberOf};
 use finance::{
-    coin::{Coin, CoinDTO, WithCoin},
+    coin::{Amount, Coin, CoinDTO, WithCoin},
     duration::Duration,
     instant::Instant,
     zero::Zero,
@@ -68,7 +76,14 @@ const EVENT_KEY_ABSORBED: &str = "absorbed";
 const EVENT_KEY_ANOMALY: &str = "anomaly";
 const EVENT_KEY_HEAL: &str = "heal";
 const EVENT_KEY_TOTAL_OUT: &str = "total-out";
+const EVENT_KEY_MIN_OUT_PREV: &str = "min-out-prev";
+const EVENT_KEY_MIN_OUT: &str = "min-out";
+const EVENT_KEY_REQUOTE: &str = "requote";
 const EVENT_VALUE_REEMIT: &str = "re-emit";
+const EVENT_VALUE_REQUOTE_SKIPPED: &str = "skipped";
+/// A collapsed re-quote clamps to this floor - a zero `min_out` would revert
+/// the counterparty's swap-params validation.
+const REQUOTE_FLOOR_MIN: Amount = 1;
 const ABSORB_UNDECODABLE: &str = "undecodable-response";
 const ABSORB_UNEXPECTED_VARIANT: &str = "unexpected-response-variant";
 const ABSORB_CURRENCY_MISMATCH: &str = "out-currency-mismatch";
@@ -132,7 +147,10 @@ where
 /// coin list is persisted. The slippage floor promised for the in-flight
 /// leg is pinned in `in_flight_min_out` when the leg is opened and reused
 /// verbatim by every re-emission - acknowledgment validation never
-/// consults the live oracle.
+/// consults the live oracle. A requote-class spec (liquidation, #660) is the
+/// exception on the timeout path only: it re-quotes the floor from the live
+/// oracle and overwrites `in_flight_min_out` before each in-budget
+/// re-emission; acknowledgment validation still uses the pinned value.
 #[derive(Serialize, Deserialize)]
 #[serde(
     bound(
@@ -303,6 +321,19 @@ where
         })
     }
 
+    /// Re-emit the in-flight leg on an in-budget timeout. A liquidation
+    /// (requote-class) spec re-quotes the floor from the live oracle before
+    /// the re-emission; every other class re-emits the pinned floor verbatim.
+    /// The past-budget escalation is always verbatim, so this dispatch is
+    /// reached only within budget.
+    fn reemit_on_timeout(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
+        if self.spec.requote_on_timeout() {
+            self.reemit_requoted(querier, env)
+        } else {
+            self.reemit_in_flight(querier, env)
+        }
+    }
+
     /// Re-emit the in-flight leg verbatim after a transient failure, keeping
     /// the pinned floor and the accumulated progress intact. The fresh nonce
     /// supersedes the timed-out packet so a late callback for it is absorbed.
@@ -310,6 +341,50 @@ where
         let node = self.with_bumped_nonce();
         let leg_label = node.spec.label();
         timeout::on_timeout_retry(node, leg_label, querier, env).into()
+    }
+
+    /// Re-quote the in-flight liquidation leg's floor from the live oracle and
+    /// re-emit against it, falling back to the verbatim pinned floor when the
+    /// oracle query fails. Either way the re-emission goes out, the nonce
+    /// bumps once and the retry budget is spent, so the timeout handler never
+    /// errors and the park safety net stays reachable.
+    fn reemit_requoted(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
+        match self.requoted_floor(querier) {
+            Some(fresh_floor) => self.reemit_with_requote(fresh_floor, querier, env),
+            None => self.reemit_skipping_requote(querier, env),
+        }
+    }
+
+    /// Re-emit promising the freshly re-quoted floor, tagging the retry event
+    /// with the previous and the fresh floor. The nonce bumps once and the
+    /// retry counters carry across, so a requote spends the same budget as a
+    /// verbatim re-emission.
+    fn reemit_with_requote(
+        self,
+        fresh_floor: CoinDTO<SwapTask::OutG>,
+        querier: QuerierWrapper<'_>,
+        env: Env,
+    ) -> HandlerResult<Self> {
+        let prev_floor = self.in_flight_min_out;
+        let node = self.requoted(fresh_floor);
+        let leg_label = node.spec.label();
+        timeout::on_timeout_retry_extended(node, leg_label, querier, env, |emitter| {
+            emitter
+                .emit_coin_dto(EVENT_KEY_MIN_OUT_PREV, &prev_floor)
+                .emit_coin_dto(EVENT_KEY_MIN_OUT, &fresh_floor)
+        })
+        .into()
+    }
+
+    /// Fall back to the verbatim pinned floor when the oracle query fails at
+    /// re-quote time, marking the skipped requote on the retry event.
+    fn reemit_skipping_requote(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
+        let node = self.with_bumped_nonce();
+        let leg_label = node.spec.label();
+        timeout::on_timeout_retry_extended(node, leg_label, querier, env, |emitter| {
+            emitter.emit(EVENT_KEY_REQUOTE, EVENT_VALUE_REQUOTE_SKIPPED)
+        })
+        .into()
     }
 
     /// Re-emit the in-flight leg after a heal, signalling the recovery with
@@ -345,11 +420,14 @@ impl<SwapTask, SEnum> RemoteSwap<SwapTask, SEnum>
 where
     SwapTask: SwapTaskT + RemoteSwapClient,
 {
-    /// Emit, or re-emit, the in-flight leg with its pinned floor
+    /// Emit, or re-emit, the in-flight leg with the floor currently held in
+    /// `in_flight_min_out`
     ///
-    /// Re-emissions repeat the exact promise of the original emission so
-    /// the counterparty enforces one and the same floor however many
-    /// times the leg goes out.
+    /// A verbatim re-emission repeats the exact promise of the original
+    /// emission so the counterparty enforces one and the same floor however
+    /// many times the leg goes out. A liquidation timeout re-quote (#660)
+    /// overwrites `in_flight_min_out` before scheduling, so the re-emitted
+    /// floor tracks the live oracle rather than the original promise.
     fn schedule(&self) -> Result<Batch> {
         self.in_flight_leg().and_then(|coin_in| {
             self.spec
@@ -416,6 +494,36 @@ where
         };
         debug_assert!(ret.invariant_held());
         ret
+    }
+
+    /// Re-quote the in-flight leg's floor from the live oracle, clamped so a
+    /// collapsed quote never promises below [`REQUOTE_FLOOR_MIN`]. Returns
+    /// `None` when the leg lookup or the oracle query fails, so the caller
+    /// falls back to the pinned floor rather than surfacing an error.
+    fn requoted_floor(&self, querier: QuerierWrapper<'_>) -> Option<CoinDTO<SwapTask::OutG>> {
+        self.in_flight_leg()
+            .and_then(|coin_in| {
+                leg_min_out(&self.spec, coin_in, self.total_out.currency(), querier)
+            })
+            .map(clamp_floor)
+            .ok()
+    }
+
+    /// Rebuild the node for a re-quote re-emission: the freshly re-quoted
+    /// floor replaces the pinned one, the nonce bumps once so the superseded
+    /// packet's late callback is absorbed, and the retry counters carry across
+    /// unchanged - a re-quote must spend the same budget as a verbatim
+    /// re-emission, unlike [`RemoteSwap::open_leg`] which resets them.
+    fn requoted(self, fresh_floor: CoinDTO<SwapTask::OutG>) -> Self {
+        Self::internal_new(
+            self.spec,
+            self.acks_left,
+            self.total_out,
+            fresh_floor,
+            self.timeouts,
+            self.errors,
+            self.in_flight_nonce.saturating_add(1),
+        )
     }
 
     fn internal_new(
@@ -596,7 +704,9 @@ where
 
     /// A timeout re-emits the in-flight leg up to the spec's per-op retry
     /// budget and escalates past it - the opened legs park while the opening
-    /// swap keeps re-emitting unbounded.
+    /// swap keeps re-emitting unbounded. Within budget a requote-class spec
+    /// (liquidation, #660) re-quotes the floor from the live oracle first; the
+    /// past-budget escalation is always verbatim.
     fn on_remote_timeout(
         self,
         nonce: u64,
@@ -608,7 +718,7 @@ where
         }
         let bumped = self.with_incremented_timeouts();
         if bumped.timeouts <= bumped.spec.timeout_retry_budget() {
-            bumped.reemit_in_flight(querier, env)
+            bumped.reemit_on_timeout(querier, env)
         } else {
             bumped.escalate(querier, env)
         }
@@ -854,6 +964,30 @@ where
     total.with_coin(AddOther { more })
 }
 
+fn clamp_floor<G>(floor: CoinDTO<G>) -> CoinDTO<G>
+where
+    G: Group,
+{
+    struct ClampToMin;
+
+    impl<G> WithCoin<G> for ClampToMin
+    where
+        G: Group,
+    {
+        type Outcome = CoinDTO<G>;
+
+        fn on<C>(self, floor: Coin<C>) -> Self::Outcome
+        where
+            C: CurrencyDef,
+            C::Group: MemberOf<G> + MemberOf<G::TopG>,
+        {
+            Ord::max(floor, Coin::new(REQUOTE_FLOOR_MIN)).into()
+        }
+    }
+
+    floor.with_coin(ClampToMin)
+}
+
 #[cfg(test)]
 pub(super) mod mock {
     use serde::{Deserialize, Serialize};
@@ -875,6 +1009,10 @@ pub(super) mod mock {
     pub const LABEL: &str = "RemoteSwapMock";
     pub const CONTROLLER: &str = "controller";
     pub const WRONG_VARIANT_PAYLOAD: &[u8] = b"wrong-variant";
+    /// The failure reason the mock's calculator reports once a test arms
+    /// [`MockSpec::set_quote_failure`] — the #660 stand-in for an oracle
+    /// query error during a timeout requote.
+    pub const FAILING_QUOTE: &str = "mock quote failure";
     pub const SLIPPAGE_PROTECTION_SENTINEL: CoinsNb = CoinsNb::MAX;
     /// The distinctive [`SwapTask::Result`] the mock's
     /// [`RemoteSwapClient::unwind`] returns, so a test can tell the unwind
@@ -904,6 +1042,16 @@ pub(super) mod mock {
         anomaly_resolution_authorised: bool,
         #[serde(default)]
         unwinds_on_zero_acked: bool,
+        /// #660: opts the spec into the requote-on-timeout class. Read by the
+        /// spec's `SwapTask::requote_on_timeout` override once the seam
+        /// lands; `#[serde(default)]` keeps the legacy fixtures
+        /// deserializing to the verbatim class.
+        #[serde(default)]
+        requotes_on_timeout: bool,
+        /// #660: makes the calculator's `min_output` fail, standing in for
+        /// an oracle query error during a timeout requote.
+        #[serde(default)]
+        quote_fails: bool,
     }
 
     #[derive(Serialize)]
@@ -914,6 +1062,7 @@ pub(super) mod mock {
 
     struct FloorCalculator {
         floor: Amount,
+        fails: bool,
     }
 
     impl MockSpec {
@@ -925,6 +1074,8 @@ pub(super) mod mock {
                 escalation: Escalation::Park,
                 anomaly_resolution_authorised: true,
                 unwinds_on_zero_acked: false,
+                requotes_on_timeout: false,
+                quote_fails: false,
             }
         }
 
@@ -946,6 +1097,14 @@ pub(super) mod mock {
 
         pub fn set_unwinds_on_zero_acked(&mut self) {
             self.unwinds_on_zero_acked = true;
+        }
+
+        pub fn set_requotes_on_timeout(&mut self) {
+            self.requotes_on_timeout = true;
+        }
+
+        pub fn set_quote_failure(&mut self) {
+            self.quote_fails = true;
         }
     }
 
@@ -1005,6 +1164,10 @@ pub(super) mod mock {
             self.unwinds_on_zero_acked
         }
 
+        fn requote_on_timeout(&self) -> bool {
+            self.requotes_on_timeout
+        }
+
         fn coins(&self) -> impl IntoIterator<Item = CoinDTO<SuperGroup>> {
             self.coins.clone()
         }
@@ -1013,7 +1176,10 @@ pub(super) mod mock {
         where
             WithCalc: WithCalculator<Self>,
         {
-            with_calc.on(&FloorCalculator { floor: self.floor })
+            with_calc.on(&FloorCalculator {
+                floor: self.floor,
+                fails: self.quote_fails,
+            })
         }
 
         fn into_output_task<Cmd>(self, cmd: Cmd) -> Cmd::Output
@@ -1112,7 +1278,11 @@ pub(super) mod mock {
             _input: &CoinDTO<SuperGroup>,
             _querier: QuerierWrapper<'_>,
         ) -> Result<Coin<SuperGroupTestC1>> {
-            Ok(Coin::new(self.floor))
+            if self.fails {
+                Err(Error::remote_swap_client(FAILING_QUOTE))
+            } else {
+                Ok(Coin::new(self.floor))
+            }
         }
     }
 
@@ -2066,6 +2236,386 @@ mod tests {
         assert_eq!(0, restored.in_flight_nonce);
     }
 
+    // -----------------------------------------------------------------------
+    // #660 — liquidation auto-requote: an in-budget TIMEOUT of a requote-class
+    // spec re-quotes the in-flight leg's floor from the live oracle before the
+    // re-emission (no monotonic clamp, floor >= 1, oracle failure falls back
+    // to the pinned floor). Every other trigger — underpaid ack, default-class
+    // timeout, past-budget escalation, heal — re-emits the pinned floor
+    // verbatim. Seam (not yet implemented): `SwapTask::requote_on_timeout`
+    // defaulted `false` + MockSpec override reading `requotes_on_timeout`, and
+    // `SlippageCalculator::REQUOTES_ON_TIMEOUT` defaulted `false`.
+    // -----------------------------------------------------------------------
+
+    /// AC (#660 / U1): an in-budget timeout of a requote-class spec re-quotes
+    /// the floor from the live oracle — DOWN, with no monotonic clamp — and
+    /// the re-emission both promises and pins the fresh floor. The retry
+    /// event carries the previous and the requoted floor.
+    /// RED-behavioral until the requote lands in `on_remote_timeout`.
+    #[test]
+    fn timeout_requotes_the_floor_down() {
+        const PINNED_FLOOR: Amount = 40;
+        const DROPPED_FLOOR: Amount = 25;
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+        let env = testing::mock_env();
+
+        let mut spec = requoting_spec3();
+        spec.set_floor(PINNED_FLOOR);
+        let (_response, mut node) = continued(Node::start(spec, &env, querier));
+        node.spec.set_floor(DROPPED_FLOOR);
+
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_timeout(nonce, querier, env.clone()));
+        assert_eq!(
+            requote_timeout_response(
+                &coin_in(100),
+                &coin_out(PINNED_FLOOR),
+                &coin_out(DROPPED_FLOOR),
+                &env,
+            ),
+            response
+        );
+        assert_node(2, &coin_out(50), &coin_out(DROPPED_FLOOR), &node);
+        assert_eq!(1, node.timeouts);
+    }
+
+    /// AC (#660 / U2): the requote also tracks the oracle UP — the promise
+    /// tightens when the live quote demands more.
+    /// RED-behavioral until the requote lands.
+    #[test]
+    fn timeout_requotes_the_floor_up() {
+        const PINNED_FLOOR: Amount = 40;
+        const RAISED_FLOOR: Amount = 90;
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+        let env = testing::mock_env();
+
+        let mut spec = requoting_spec3();
+        spec.set_floor(PINNED_FLOOR);
+        let (_response, mut node) = continued(Node::start(spec, &env, querier));
+        node.spec.set_floor(RAISED_FLOOR);
+
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_timeout(nonce, querier, env.clone()));
+        assert_eq!(
+            requote_timeout_response(
+                &coin_in(100),
+                &coin_out(PINNED_FLOOR),
+                &coin_out(RAISED_FLOOR),
+                &env,
+            ),
+            response
+        );
+        assert_node(2, &coin_out(50), &coin_out(RAISED_FLOOR), &node);
+        assert_eq!(1, node.timeouts);
+    }
+
+    /// AC (#660 / U3): requote rounds spend the same timeout budget as
+    /// verbatim re-emissions — `acks_left`, `total_out` and the counters
+    /// carry across requotes — and the round past the budget parks WITHOUT
+    /// requoting, freezing the LAST requoted floor at the terminal.
+    /// RED-behavioral until the requote lands.
+    #[test]
+    fn requote_rounds_spend_the_budget_and_park_with_the_last_floor() {
+        const BASE_FLOOR: Amount = 40;
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let mut spec = requoting_spec3();
+        spec.set_floor(BASE_FLOOR);
+        let (_response, mut node) = continued(Node::start(spec, &testing::mock_env(), querier));
+
+        let budget = mock_budget();
+        for round in 1..=budget {
+            let fresh = BASE_FLOOR + Amount::from(round);
+            node.spec.set_floor(fresh);
+            let nonce = node.in_flight_nonce;
+            let (_response, next) =
+                continued(node.on_remote_timeout(nonce, querier, testing::mock_env()));
+            node = next;
+            assert_node(2, &coin_out(50), &coin_out(fresh), &node);
+            assert_eq!(round, node.timeouts);
+        }
+
+        // the oracle moves again, yet the past-budget round parks verbatim —
+        // no requote on the way into the terminal
+        let last_floor = BASE_FLOOR + Amount::from(budget);
+        node.spec.set_floor(BASE_FLOOR * 100);
+        let nonce = node.in_flight_nonce;
+        let (response, terminal) =
+            parked(node.on_remote_timeout(nonce, querier, testing::mock_env()));
+        assert_eq!(parked_response(), response);
+        assert_terminal(2, &coin_out(50), &coin_out(last_floor), &terminal);
+    }
+
+    /// AC (#660 / U4): every requote round re-emits with a strictly greater
+    /// nonce, so the superseded packet's late acknowledgment is absorbed —
+    /// the floor overwrite stays coupled to the nonce bump.
+    #[test]
+    fn requote_reemission_bumps_the_nonce_each_round() {
+        const PINNED_FLOOR: Amount = 40;
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let mut spec = requoting_spec3();
+        spec.set_floor(PINNED_FLOOR);
+        let (_response, mut node) = continued(Node::start(spec, &testing::mock_env(), querier));
+
+        node.spec.set_floor(PINNED_FLOOR - 15);
+        let first_nonce = node.in_flight_nonce;
+        let (_response, mut node) =
+            continued(node.on_remote_timeout(first_nonce, querier, testing::mock_env()));
+        assert!(
+            first_nonce < node.in_flight_nonce,
+            "the first requote round must re-emit with a strictly greater nonce"
+        );
+
+        node.spec.set_floor(PINNED_FLOOR - 10);
+        let second_nonce = node.in_flight_nonce;
+        let (_response, node) =
+            continued(node.on_remote_timeout(second_nonce, querier, testing::mock_env()));
+        assert!(
+            second_nonce < node.in_flight_nonce,
+            "every requote round must re-emit with a strictly greater nonce"
+        );
+
+        // the first packet's late ack carries a stale nonce → absorbed
+        let (response, node) = continued(node.on_remote_response(
+            payload(&coin_out(PINNED_FLOOR)),
+            first_nonce,
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(absorb_response("nonce-mismatch"), response);
+        assert_node(2, &coin_out(50), &coin_out(PINNED_FLOOR - 10), &node);
+    }
+
+    /// AC (#660 / U5): an UNDERPAID-ack re-emission stays pinned even for a
+    /// requote-class spec — the requote is triggered by a timeout, never by
+    /// an under-floor acknowledgment. GREEN today; must stay green.
+    #[test]
+    fn underpaid_ack_stays_pinned_for_a_requote_class_spec() {
+        const PINNED_FLOOR: Amount = 40;
+        const RAISED_FLOOR: Amount = 100;
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let mut spec = requoting_spec3();
+        spec.set_floor(PINNED_FLOOR);
+        let (_response, mut node) = continued(Node::start(spec, &testing::mock_env(), querier));
+        node.spec.set_floor(RAISED_FLOOR);
+
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_response(
+            payload(&coin_out(PINNED_FLOOR - 1)),
+            nonce,
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(
+            MessageResponse::messages_with_event(
+                mock::swap_request(&coin_in(100), &coin_out(PINNED_FLOOR))
+                    .expect("a valid swap request"),
+                Emitter::of_type(mock::LABEL).emit("anomaly", "under-min-out"),
+            ),
+            response
+        );
+        assert_node(2, &coin_out(50), &coin_out(PINNED_FLOOR), &node);
+    }
+
+    /// AC (#660 / U6): a default-class spec re-emits the PINNED floor on
+    /// timeout even when the live oracle has moved — the requote is opt-in
+    /// per spec. GREEN today; must stay green.
+    #[test]
+    fn timeout_stays_pinned_for_a_default_class_spec() {
+        const PINNED_FLOOR: Amount = 40;
+        const DROPPED_FLOOR: Amount = 25;
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+        let env = testing::mock_env();
+
+        let mut spec = spec3();
+        spec.set_floor(PINNED_FLOOR);
+        let (_response, mut node) = continued(Node::start(spec, &env, querier));
+        node.spec.set_floor(DROPPED_FLOOR);
+
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_timeout(nonce, querier, env.clone()));
+        assert_eq!(
+            timeout_response_with_floor(&coin_in(100), &coin_out(PINNED_FLOOR), &env),
+            response
+        );
+        assert_node(2, &coin_out(50), &coin_out(PINNED_FLOOR), &node);
+    }
+
+    /// AC (#660 / U7): a `ReEmit`-escalation, requote-class spec requotes
+    /// only WITHIN the budget — the escalation's past-budget re-emission
+    /// repeats the last requoted floor verbatim, however the oracle has
+    /// moved since. RED-behavioral until the in-budget requote lands.
+    #[test]
+    fn reemit_escalation_past_budget_stays_verbatim() {
+        const PINNED_FLOOR: Amount = 40;
+        const REQUOTED_FLOOR: Amount = 25;
+        const MOVED_AGAIN_FLOOR: Amount = 90;
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let mut spec = requoting_spec3();
+        spec.set_reemit();
+        spec.set_floor(PINNED_FLOOR);
+        let (_response, mut node) = continued(Node::start(spec, &testing::mock_env(), querier));
+
+        node.spec.set_floor(REQUOTED_FLOOR);
+        let budget = mock_budget();
+        for _round in 0..budget {
+            let nonce = node.in_flight_nonce;
+            let (_response, next) =
+                continued(node.on_remote_timeout(nonce, querier, testing::mock_env()));
+            node = next;
+        }
+        assert_node(2, &coin_out(50), &coin_out(REQUOTED_FLOOR), &node);
+        assert_eq!(budget, node.timeouts);
+
+        // past the budget the ReEmit escalation repeats the last floor
+        // verbatim — a moved oracle must NOT leak into it
+        node.spec.set_floor(MOVED_AGAIN_FLOOR);
+        let env = testing::mock_env();
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_timeout(nonce, querier, env.clone()));
+        assert_eq!(
+            timeout_response_with_floor(&coin_in(100), &coin_out(REQUOTED_FLOOR), &env),
+            response
+        );
+        assert_node(2, &coin_out(50), &coin_out(REQUOTED_FLOOR), &node);
+    }
+
+    /// AC (#660 / U8): a collapsed quote requotes the floor to the minimum
+    /// of 1, never 0 — a zero `min_out` would revert the counterparty's swap
+    /// params. RED-behavioral until the requote lands.
+    #[test]
+    fn requote_of_a_collapsed_quote_clamps_the_floor_to_one() {
+        const PINNED_FLOOR: Amount = 40;
+        const CLAMPED_FLOOR: Amount = 1;
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+        let env = testing::mock_env();
+
+        let mut spec = requoting_spec3();
+        spec.set_floor(PINNED_FLOOR);
+        let (_response, mut node) = continued(Node::start(spec, &env, querier));
+        node.spec.set_floor(0);
+
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_timeout(nonce, querier, env.clone()));
+        assert_eq!(
+            requote_timeout_response(
+                &coin_in(100),
+                &coin_out(PINNED_FLOOR),
+                &coin_out(CLAMPED_FLOOR),
+                &env,
+            ),
+            response
+        );
+        assert_node(2, &coin_out(50), &coin_out(CLAMPED_FLOOR), &node);
+    }
+
+    /// AC (#660 / U9): an oracle failure during the requote falls back to
+    /// the pinned floor for that round — the re-emission still goes out, the
+    /// budget is still consumed, the event marks the skipped requote, and
+    /// the park stays reachable. RED-behavioral until the requote lands.
+    #[test]
+    fn failed_quote_falls_back_to_the_pinned_floor() {
+        const PINNED_FLOOR: Amount = 40;
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+        let env = testing::mock_env();
+
+        let mut spec = requoting_spec3();
+        spec.set_floor(PINNED_FLOOR);
+        let (_response, mut node) = continued(Node::start(spec, &env, querier));
+        node.spec.set_quote_failure();
+
+        let nonce = node.in_flight_nonce;
+        let (response, node) = continued(node.on_remote_timeout(nonce, querier, env.clone()));
+        assert_eq!(
+            skipped_requote_timeout_response(&coin_in(100), &coin_out(PINNED_FLOOR), &env),
+            response
+        );
+        assert_node(2, &coin_out(50), &coin_out(PINNED_FLOOR), &node);
+        assert_eq!(1, node.timeouts);
+
+        // the skip rounds consumed budget all the same: the remaining rounds
+        // keep retrying and the round past the budget parks
+        let budget = mock_budget();
+        let node = (1..budget).fold(node, |node, _round| {
+            let nonce = node.in_flight_nonce;
+            continued(node.on_remote_timeout(nonce, querier, testing::mock_env())).1
+        });
+        let nonce = node.in_flight_nonce;
+        let (_response, terminal) =
+            parked(node.on_remote_timeout(nonce, querier, testing::mock_env()));
+        assert_terminal(2, &coin_out(50), &coin_out(PINNED_FLOOR), &terminal);
+    }
+
+    /// AC (#660 / U10): a node persisted before #660 carries no requote
+    /// toggle in the spec; the defaulted field must load `false` so legacy
+    /// leases keep the verbatim re-emission class.
+    /// COMPILE-RED: blocked on `SwapTask::requote_on_timeout`.
+    #[test]
+    fn legacy_remote_swap_without_requote_toggle_stays_verbatim_class() {
+        use crate::SwapTask;
+
+        let legacy_remote_swap = br#"{"spec":{"coins":[{"amount":"100","ticker":"ticker#2"},{"amount":"50","ticker":"ticker#1"},{"amount":"70","ticker":"ticker#2"}],"floor":1,"budget":3},"acks_left":1,"total_out":{"amount":"80","ticker":"ticker#1"},"in_flight_min_out":{"amount":"1","ticker":"ticker#1"},"timeouts":0,"errors":0,"in_flight_nonce":3}"#;
+
+        let restored: Node = sdk::cosmwasm_std::from_json(legacy_remote_swap.as_slice())
+            .expect("the pre-#660 state should deserialize");
+        assert!(!restored.spec.requote_on_timeout());
+    }
+
+    /// Truth table (#660): the MockSpec defaults to the verbatim class; the
+    /// toggle flips it into the requote class.
+    /// COMPILE-RED: blocked on `SwapTask::requote_on_timeout` + the MockSpec
+    /// override reading `requotes_on_timeout`.
+    #[test]
+    fn mock_spec_requote_class_follows_its_toggle() {
+        use crate::SwapTask;
+
+        assert!(!spec3().requote_on_timeout());
+        assert!(requoting_spec3().requote_on_timeout());
+    }
+
+    /// Truth table (#660): a calculator that does not override
+    /// `REQUOTES_ON_TIMEOUT` inherits the `false` default — only
+    /// `AcceptUpToMaxSlippage` opts in (pinned in the lease crate against the
+    /// production alias).
+    /// COMPILE-RED: blocked on `SlippageCalculator::REQUOTES_ON_TIMEOUT`.
+    #[test]
+    fn calculator_default_is_no_requote_on_timeout() {
+        use currency::{CurrencyDef, Group, MemberOf};
+
+        use crate::{SlippageCalculator, SwapTask, WithCalculator};
+
+        struct ProbeRequoteClass;
+        impl<Task> WithCalculator<Task> for ProbeRequoteClass
+        where
+            Task: SwapTask,
+        {
+            type Output = bool;
+
+            fn on<CalculatorT>(self, _calculator: &CalculatorT) -> Self::Output
+            where
+                CalculatorT: SlippageCalculator<Task::InG>,
+                <<CalculatorT as SlippageCalculator<Task::InG>>::OutC as CurrencyDef>::Group:
+                    MemberOf<Task::OutG> + MemberOf<<Task::InG as Group>::TopG>,
+            {
+                CalculatorT::REQUOTES_ON_TIMEOUT
+            }
+        }
+
+        assert!(!spec3().with_slippage_calc(ProbeRequoteClass));
+    }
+
     fn assert_node(
         expected_acks: CoinsNb,
         expected_total: &CoinDTO<OutG>,
@@ -2196,6 +2746,13 @@ mod tests {
         MockSpec::new(vec![coin_in(100), coin_out(50), coin_in(70)])
     }
 
+    /// [`spec3`] opted into the #660 requote-on-timeout class.
+    fn requoting_spec3() -> MockSpec {
+        let mut spec = spec3();
+        spec.set_requotes_on_timeout();
+        spec
+    }
+
     /// Two swap legs and no output-currency coin to fold, so the node starts
     /// with `total_out == 0` - the zero-acked precondition the unwind path
     /// gates on.
@@ -2227,6 +2784,57 @@ mod tests {
             Emitter::of_type(mock::LABEL)
                 .emit("id", env.contract.address.clone())
                 .emit("timeout", "retry"),
+        )
+    }
+
+    /// The verbatim timeout retry: the pinned floor re-emitted, no requote
+    /// attributes on the event (#660).
+    fn timeout_response_with_floor(
+        leg: &CoinDTO<OutG>,
+        pinned_floor: &CoinDTO<OutG>,
+        env: &Env,
+    ) -> MessageResponse {
+        MessageResponse::messages_with_event(
+            mock::swap_request(leg, pinned_floor).expect("a valid swap request"),
+            Emitter::of_type(mock::LABEL)
+                .emit("id", env.contract.address.clone())
+                .emit("timeout", "retry"),
+        )
+    }
+
+    /// The requoting timeout retry (#660): the fresh floor is promised on the
+    /// wire, and the retry event gains the additive `min-out-prev` /
+    /// `min-out` coin attributes — the SPEC of the event keys.
+    fn requote_timeout_response(
+        leg: &CoinDTO<OutG>,
+        prev_floor: &CoinDTO<OutG>,
+        fresh_floor: &CoinDTO<OutG>,
+        env: &Env,
+    ) -> MessageResponse {
+        MessageResponse::messages_with_event(
+            mock::swap_request(leg, fresh_floor).expect("a valid swap request"),
+            Emitter::of_type(mock::LABEL)
+                .emit("id", env.contract.address.clone())
+                .emit("timeout", "retry")
+                .emit_coin_dto("min-out-prev", prev_floor)
+                .emit_coin_dto("min-out", fresh_floor),
+        )
+    }
+
+    /// The oracle-failure fallback round (#660): the pinned floor re-emitted
+    /// and the skipped requote marked with `requote = skipped` — the SPEC of
+    /// the skip-marker key.
+    fn skipped_requote_timeout_response(
+        leg: &CoinDTO<OutG>,
+        pinned_floor: &CoinDTO<OutG>,
+        env: &Env,
+    ) -> MessageResponse {
+        MessageResponse::messages_with_event(
+            mock::swap_request(leg, pinned_floor).expect("a valid swap request"),
+            Emitter::of_type(mock::LABEL)
+                .emit("id", env.contract.address.clone())
+                .emit("timeout", "retry")
+                .emit("requote", "skipped"),
         )
     }
 

--- a/protocol/packages/dex/src/impl_/slippage/percent.rs
+++ b/protocol/packages/dex/src/impl_/slippage/percent.rs
@@ -84,6 +84,8 @@ where
 {
     type OutC = OutC;
 
+    const REQUOTES_ON_TIMEOUT: bool = true;
+
     fn min_output(
         &self,
         input: &CoinDTO<InG>,

--- a/protocol/packages/dex/src/impl_/timeout.rs
+++ b/protocol/packages/dex/src/impl_/timeout.rs
@@ -18,10 +18,29 @@ where
     S: Enterable + Into<SEnum>,
     L: Into<String>,
 {
+    on_timeout_retry_extended(current_state, state_label, querier, env, |emitter| emitter)
+}
+
+/// Re-emit like [`on_timeout_retry`], with `extend` appending extra
+/// attributes to the retry event. The #660 liquidation requote carries the
+/// previous and the freshly re-quoted floor there, or marks a skipped
+/// requote, on top of the base `timeout = retry`.
+pub(crate) fn on_timeout_retry_extended<S, SEnum, L, Extend>(
+    current_state: S,
+    state_label: L,
+    querier: QuerierWrapper<'_>,
+    env: Env,
+    extend: Extend,
+) -> Result<StateMachineResponse<SEnum>>
+where
+    S: Enterable + Into<SEnum>,
+    L: Into<String>,
+    Extend: FnOnce(Emitter) -> Emitter,
+{
     current_state
         .enter(env.block.time.into_instant(), querier)
         .map(|batch| {
-            let emitter = emit_timeout(state_label, env.contract.address);
+            let emitter = extend(emit_timeout(state_label, env.contract.address));
 
             StateMachineResponse::from(
                 MessageResponse::messages_with_event(batch, emitter),

--- a/protocol/packages/dex/src/impl_/timeout.rs
+++ b/protocol/packages/dex/src/impl_/timeout.rs
@@ -22,7 +22,7 @@ where
 }
 
 /// Re-emit like [`on_timeout_retry`], with `extend` appending extra
-/// attributes to the retry event. The #660 liquidation requote carries the
+/// attributes to the retry event. The liquidation requote carries the
 /// previous and the freshly re-quoted floor there, or marks a skipped
 /// requote, on top of the base `timeout = retry`.
 pub(crate) fn on_timeout_retry_extended<S, SEnum, L, Extend>(

--- a/protocol/packages/dex/src/slippage.rs
+++ b/protocol/packages/dex/src/slippage.rs
@@ -32,6 +32,16 @@ where
     /// The output swap currency
     type OutC: CurrencyDef;
 
+    /// Whether a leg quoted by this calculator re-quotes its floor from the
+    /// live oracle on each in-budget timeout, instead of re-emitting the
+    /// floor pinned at the leg's first emission.
+    ///
+    /// Defaults to `false` - the pinned floor is re-emitted verbatim. Only
+    /// the bounded max-slippage liquidation calculator opts in, so a
+    /// liquidation leg tracks the live price down and up as it retries while
+    /// every other class keeps its original promise.
+    const REQUOTES_ON_TIMEOUT: bool = false;
+
     /// Determine the minimum output amount of a swap
     ///
     /// An anomaly is triggered if the output amount cannot be satisfied. The

--- a/protocol/packages/dex/src/swap_task.rs
+++ b/protocol/packages/dex/src/swap_task.rs
@@ -90,6 +90,22 @@ where
         false
     }
 
+    /// Whether an in-flight leg re-quotes its floor from the live oracle on
+    /// each in-budget timeout, instead of re-emitting the floor pinned at the
+    /// leg's first emission.
+    ///
+    /// Defaults to `false`: opening, repay, customer-close and profit
+    /// buy-back legs re-emit the pinned floor verbatim, so their promise is
+    /// stable across retries. Only the liquidation `SellAsset` spec overrides
+    /// it, forwarding its calculator's `SlippageCalculator::REQUOTES_ON_TIMEOUT`
+    /// so a liquidation leg re-quotes bounded by `MaxSlippages.liquidation`
+    /// and clears against a moving price. Re-quoting is only meaningful with a
+    /// `SlippageEscalation::Park` escalation - the past-budget re-emission is
+    /// always verbatim.
+    fn requote_on_timeout(&self) -> bool {
+        false
+    }
+
     /// Provide the coins, at least one, this swap is about.
     /// The iteration is done always in the same order.
     //

--- a/protocol/packages/dex/src/swap_task.rs
+++ b/protocol/packages/dex/src/swap_task.rs
@@ -99,9 +99,16 @@ where
     /// stable across retries. Only the liquidation `SellAsset` spec overrides
     /// it, forwarding its calculator's `SlippageCalculator::REQUOTES_ON_TIMEOUT`
     /// so a liquidation leg re-quotes bounded by `MaxSlippages.liquidation`
-    /// and clears against a moving price. Re-quoting is only meaningful with a
-    /// `SlippageEscalation::Park` escalation - the past-budget re-emission is
-    /// always verbatim.
+    /// and clears against a moving price. The re-quote applies only to
+    /// in-budget timeout re-emissions and is escalation-agnostic; floor
+    /// erosion stays bounded by the retry budget under any escalation policy,
+    /// because the past-budget path never re-quotes. A requote-class spec is
+    /// nonetheless expected to pair with `SlippageEscalation::Park` so the
+    /// anomaly terminal fires past budget - the only production requote class,
+    /// liquidation `SellAsset`, hardcodes `Park`. A hypothetical `ReEmit`
+    /// pairing would freeze the last requoted floor past budget and re-emit it
+    /// unbounded without ever parking, which is why new requote-class specs
+    /// should pair with `Park`.
     fn requote_on_timeout(&self) -> bool {
         false
     }

--- a/tests/src/lease/remote_lease_slippage_terminal.rs
+++ b/tests/src/lease/remote_lease_slippage_terminal.rs
@@ -400,18 +400,10 @@ fn buy_asset_zero_acked_error_unwinds() {
     );
 }
 
-// --- #660 liquidation auto-requote on timeout ----------------------------
-//
-// On each bounded timeout of a LIQUIDATION swap the floor re-quotes from the
-// live oracle (`AcceptUpToMaxSlippage(max_slippage.liquidation)` per round,
-// no episode cap, no monotonic clamp); every other flow keeps the verbatim
-// pinned-floor re-emission. RED-behavioral tests fail on the floor staying
-// pinned; the verbatim guards are green today and must stay green.
-
-/// #660 (I1): an in-budget timeout of a liquidation leg re-quotes the floor
+/// An in-budget timeout of a liquidation leg re-quotes the floor
 /// from the live oracle. The price DROPPED between emissions, so the fresh
 /// floor is LOWER than the pinned one — no monotonic clamp; the liquidation
-/// lowers its promise to clear. RED until #660 lands.
+/// lowers its promise to clear.
 #[test]
 fn liquidation_timeout_requotes_the_floor_down() {
     let mut test_case = create_test_case();
@@ -435,8 +427,8 @@ fn liquidation_timeout_requotes_the_floor_down() {
     assert_liquidation_swap_in_flight(&test_case, &lease);
 }
 
-/// #660 (I2): the requote also tracks the oracle UP — a risen price tightens
-/// the promise of the re-emitted leg. RED until #660 lands.
+/// The requote also tracks the oracle UP — a risen price tightens
+/// the promise of the re-emitted leg.
 #[test]
 fn liquidation_timeout_requotes_the_floor_up() {
     let mut test_case = create_test_case();
@@ -460,12 +452,11 @@ fn liquidation_timeout_requotes_the_floor_up() {
     assert_liquidation_swap_in_flight(&test_case, &lease);
 }
 
-/// #660 (I3): a partial (overdue) liquidation that requotes DOWN on a
+/// A partial (overdue) liquidation that requotes DOWN on a
 /// timeout and then CLEARS at the fresh floor settles exactly as an
 /// untimed-out one: the proceeds repay the overdue+due interest in full and
 /// the position continues with the liquidated slice removed (mirrors
-/// `liquidation::time`). RED until #660 lands (the floor stays pinned on the
-/// way).
+/// `liquidation::time`).
 #[test]
 fn partial_liquidation_requote_then_clear_settles_the_position() {
     const DOWNPAYMENT_AMOUNT: Amount = 1_000_000_000;
@@ -569,10 +560,9 @@ fn partial_liquidation_requote_then_clear_settles_the_position() {
     }
 }
 
-/// #660 (I4): a FULL liquidation that requotes DOWN on a timeout and then
+/// A FULL liquidation that requotes DOWN on a timeout and then
 /// CLEARS at the fresh floor drives to the `Liquidated` end state exactly as
-/// an untimed-out one (mirrors `liquidation::price::full_liquidation`). RED
-/// until #660 lands (the floor stays pinned on the way).
+/// an untimed-out one (mirrors `liquidation::price::full_liquidation`).
 #[test]
 fn full_liquidation_requote_then_clear_liquidates() {
     let mut test_case = create_test_case();
@@ -605,7 +595,7 @@ fn full_liquidation_requote_then_clear_liquidates() {
     );
 }
 
-/// #660 (I5): a customer-close leg keeps the verbatim pinned floor across
+/// A customer-close leg keeps the verbatim pinned floor across
 /// timeouts — the `AcceptAnyNonZeroSwap` constant floor of 1 never moves,
 /// oracle move or not. Green today; must stay green.
 #[test]
@@ -627,7 +617,7 @@ fn customer_close_floor_stays_verbatim_across_timeouts() {
     assert_customer_close_swap_in_flight(&test_case, &lease);
 }
 
-/// #660 (I6): a repay (`BuyLpn`) leg keeps the verbatim pinned floor across
+/// A repay (`BuyLpn`) leg keeps the verbatim pinned floor across
 /// timeouts — the constant floor of 1 never moves. This is the behavioral
 /// pin of `BuyLpn::requote_on_timeout() == false`. Green today; must stay
 /// green.
@@ -649,7 +639,7 @@ fn repay_floor_stays_verbatim_across_timeouts() {
     assert_repay_swap_in_flight(&test_case, &lease);
 }
 
-/// #660 (I7): an opening (`BuyAsset`) leg keeps the verbatim pinned floor
+/// An opening (`BuyAsset`) leg keeps the verbatim pinned floor
 /// across timeouts even though its calculator reads the oracle — a moved
 /// price must NOT leak into the re-emission; detection-first opening
 /// semantics are preserved. Green today; must stay green.
@@ -670,10 +660,9 @@ fn opening_floor_stays_verbatim_across_timeouts() {
     assert_opening_swap_in_flight(&test_case, &lease);
 }
 
-/// #660 (I8): requote rounds spend the same timeout budget; the round past
+/// Requote rounds spend the same timeout budget; the round past
 /// it parks with the LAST requoted floor still promised, and the parked
-/// query keeps the `SlippageProtectionActivated` shape. RED until #660
-/// lands.
+/// query keeps the `SlippageProtectionActivated` shape.
 #[test]
 fn park_after_budget_holds_the_last_requoted_floor() {
     let mut test_case = create_test_case();
@@ -714,7 +703,7 @@ fn park_after_budget_holds_the_last_requoted_floor() {
     assert_eq!(last_floor, latest_min_out(&test_case, &lease));
 }
 
-/// #660 (I9): the operator heal of a parked liquidation is UNCHANGED by the
+/// The operator heal of a parked liquidation is UNCHANGED by the
 /// auto-requote: it still re-quotes from the live oracle, resets the
 /// counters, and re-enters the live swap sequence. Green today; must stay
 /// green — and it pins the exact fresh-quote floor arithmetic the requote
@@ -746,9 +735,9 @@ fn heal_after_park_still_requotes_and_resets() {
     assert_liquidation_swap_in_flight(&test_case, &lease);
 }
 
-/// #660 (I10): a requote round's retry event carries the previous and the
+/// A requote round's retry event carries the previous and the
 /// fresh floor as coin attributes — `min-out-prev-*` and `min-out-*`,
-/// additive to the existing `timeout = retry`. RED until #660 lands.
+/// additive to the existing `timeout = retry`.
 #[test]
 fn requote_round_emits_previous_and_fresh_floor() {
     let mut test_case = create_test_case();
@@ -774,10 +763,10 @@ fn requote_round_emits_previous_and_fresh_floor() {
     );
 }
 
-/// #660 (I10, fallback): with the oracle's price EXPIRED (feed validity is
+/// With the oracle's price EXPIRED (feed validity is
 /// 5s x 12 samples in the test oracle), the requote's quote fails; the round
 /// falls back to the pinned floor, still goes out, and marks the skipped
-/// requote with `requote = skipped`. RED until #660 lands.
+/// requote with `requote = skipped`.
 #[test]
 fn expired_price_requote_falls_back_to_the_pinned_floor() {
     let mut test_case = create_test_case();
@@ -805,7 +794,7 @@ fn create_test_case() -> LeaseTestCase {
 }
 
 /// Feed a fresh `base <-> quote` observation WITHOUT dispatching price
-/// alarms — the #660 requote reads the oracle synchronously at timeout
+/// alarms — the requote reads the oracle synchronously at timeout
 /// delivery, so no alarm round-trip is involved and the in-flight swap state
 /// stays untouched.
 fn feed_price_quietly(test_case: &mut LeaseTestCase, base: LeaseCoin, quote: LpnCoin) {

--- a/tests/src/lease/remote_lease_slippage_terminal.rs
+++ b/tests/src/lease/remote_lease_slippage_terminal.rs
@@ -30,8 +30,8 @@
 
 use crate::common::testing;
 use access_control::error::Error as AccessError;
-use dex::Error as DexError;
-use finance::coin::Amount;
+use dex::{Error as DexError, MaxSlippage};
+use finance::{coin::Amount, duration::Duration, fraction::Unit, price};
 use lease::{
     api::{
         ExecuteMsg,
@@ -41,10 +41,14 @@ use lease::{
     error::ContractError,
 };
 use remote_lease::callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome};
-use sdk::cosmwasm_std::{Addr, Event};
+use sdk::{
+    cosmwasm_std::{Addr, Event},
+    cw_multi_test::AppResponse,
+};
 
 use crate::common::{
-    self, LEASE_ADMIN, USER,
+    self, ADMIN, LEASE_ADMIN, USER,
+    leaser::Instantiator as LeaserInstantiator,
     remote_lease_controller_stub::{self as stub, ResponseMode, op_tag},
     test_case::TestCase,
 };
@@ -59,6 +63,13 @@ const CLOSE_POSITION_EVENT: &str = "wasm-ls-close-position";
 const LIQUIDATION_BUDGET: u8 = 5;
 const CUSTOMER_CLOSE_BUDGET: u8 = 2;
 const REPAY_BUDGET: u8 = 3;
+
+/// The literal-floor opening amounts of the full-liquidation driver: the base
+/// is chosen close to the asset amount to trigger a full liquidation (mirrors
+/// `liquidation::price`). The close swap sells the whole
+/// `FULL_LIQ_LEASE_AMOUNT`.
+const FULL_LIQ_LEASE_AMOUNT: Amount = 2428571428570;
+const FULL_LIQ_BORROWED_AMOUNT: Amount = 1857142857142;
 
 // --- #3 error -> immediate terminal -------------------------------------
 
@@ -389,10 +400,441 @@ fn buy_asset_zero_acked_error_unwinds() {
     );
 }
 
+// --- #660 liquidation auto-requote on timeout ----------------------------
+//
+// On each bounded timeout of a LIQUIDATION swap the floor re-quotes from the
+// live oracle (`AcceptUpToMaxSlippage(max_slippage.liquidation)` per round,
+// no episode cap, no monotonic clamp); every other flow keeps the verbatim
+// pinned-floor re-emission. RED-behavioral tests fail on the floor staying
+// pinned; the verbatim guards are green today and must stay green.
+
+/// #660 (I1): an in-budget timeout of a liquidation leg re-quotes the floor
+/// from the live oracle. The price DROPPED between emissions, so the fresh
+/// floor is LOWER than the pinned one — no monotonic clamp; the liquidation
+/// lowers its promise to clear. RED until #660 lands.
+#[test]
+fn liquidation_timeout_requotes_the_floor_down() {
+    let mut test_case = create_test_case();
+    let lease = drive_into_liquidation_swap(&mut test_case);
+    let floor_before = latest_min_out(&test_case, &lease);
+
+    let (base, quote) = (LeaseCoin::new(2), LpnCoin::new(1));
+    feed_price_quietly(&mut test_case, base, quote);
+    let _reemit = inject_timeout(&mut test_case, &lease);
+
+    let floor_after = latest_min_out(&test_case, &lease);
+    let expected = liquidation_floor_at(LeaseCoin::new(FULL_LIQ_LEASE_AMOUNT), base, quote);
+    assert_eq!(
+        expected, floor_after,
+        "the re-emission must promise the fresh-quote floor, was {floor_before}",
+    );
+    assert!(
+        floor_after < floor_before,
+        "a dropped price must LOWER the requoted floor, was {floor_before}, now {floor_after}",
+    );
+    assert_liquidation_swap_in_flight(&test_case, &lease);
+}
+
+/// #660 (I2): the requote also tracks the oracle UP — a risen price tightens
+/// the promise of the re-emitted leg. RED until #660 lands.
+#[test]
+fn liquidation_timeout_requotes_the_floor_up() {
+    let mut test_case = create_test_case();
+    let lease = drive_into_liquidation_swap(&mut test_case);
+    let floor_before = latest_min_out(&test_case, &lease);
+
+    let (base, quote) = (LeaseCoin::new(1), LpnCoin::new(2));
+    feed_price_quietly(&mut test_case, base, quote);
+    let _reemit = inject_timeout(&mut test_case, &lease);
+
+    let floor_after = latest_min_out(&test_case, &lease);
+    let expected = liquidation_floor_at(LeaseCoin::new(FULL_LIQ_LEASE_AMOUNT), base, quote);
+    assert_eq!(
+        expected, floor_after,
+        "the re-emission must promise the fresh-quote floor, was {floor_before}",
+    );
+    assert!(
+        floor_before < floor_after,
+        "a risen price must RAISE the requoted floor, was {floor_before}, now {floor_after}",
+    );
+    assert_liquidation_swap_in_flight(&test_case, &lease);
+}
+
+/// #660 (I3): a partial (overdue) liquidation that requotes DOWN on a
+/// timeout and then CLEARS at the fresh floor settles exactly as an
+/// untimed-out one: the proceeds repay the overdue+due interest in full and
+/// the position continues with the liquidated slice removed (mirrors
+/// `liquidation::time`). RED until #660 lands (the floor stays pinned on the
+/// way).
+#[test]
+fn partial_liquidation_requote_then_clear_settles_the_position() {
+    const DOWNPAYMENT_AMOUNT: Amount = 1_000_000_000;
+    // the total interest due for LeaserInstantiator::REPAYMENT_PERIOD =
+    // (7% + 3%) * 65/(100-65) * downpayment * REPAYMENT_PERIOD/365
+    const LIQUIDATION_AMOUNT: Amount = 45792562;
+    let mut test_case = create_test_case();
+    let lease = super::open_lease(
+        &mut test_case,
+        common::coin::<PaymentCurrency>(DOWNPAYMENT_AMOUNT),
+        None,
+    );
+    let controller = test_case.address_book.remote_lease_controller().clone();
+
+    let StateResponse::Opened {
+        amount: lease_amount,
+        ..
+    } = super::state_query(&test_case, lease.clone())
+    else {
+        unreachable!()
+    };
+    let lease_amount: LeaseCoin = lease_amount.try_into().unwrap();
+
+    test_case
+        .app
+        .time_shift(LeaserInstantiator::REPAYMENT_PERIOD);
+    super::feed_price(&mut test_case);
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+    // the time alarm starts the overdue partial liquidation; the sell-asset
+    // swap is held in flight by the Delayed mode
+    let () = test_case
+        .app
+        .execute(
+            test_case.address_book.time_alarms().clone(),
+            lease.clone(),
+            &ExecuteMsg::TimeAlarm {},
+            &[],
+        )
+        .unwrap()
+        .ignore_response()
+        .unwrap_response();
+    assert_liquidation_swap_in_flight(&test_case, &lease);
+    assert_eq!(
+        LIQUIDATION_AMOUNT,
+        super::recorded_close_swap(&test_case, &lease)
+            .coin_in()
+            .amount(),
+        "the overdue liquidation must sell exactly the interest-due slice",
+    );
+
+    // the price halves; the timeout requotes the slice's floor down
+    let (base, quote) = (LeaseCoin::new(2), LpnCoin::new(1));
+    feed_price_quietly(&mut test_case, base, quote);
+    let _reemit = inject_timeout(&mut test_case, &lease);
+    assert_eq!(
+        liquidation_floor_at(LeaseCoin::new(LIQUIDATION_AMOUNT), base, quote),
+        latest_min_out(&test_case, &lease),
+        "the re-emission must promise the fresh-quote floor",
+    );
+
+    // restore the identity price so the settlement mirrors the untimed-out
+    // flow, then clear the re-emitted leg — the identity payout is well
+    // above the requoted floor
+    super::feed_price(&mut test_case);
+    let _ack = stub::deliver_pending_callback(&mut test_case.app, &controller, op_tag::SWAP);
+    let (proceeds, liquidation_end): (LpnCoin, AppResponse) =
+        super::settle_close_proceeds(&mut test_case, &lease);
+    assert_eq!(LpnCoin::new(LIQUIDATION_AMOUNT), proceeds);
+    expect_attribute(
+        &liquidation_end.events,
+        "wasm-ls-liquidation",
+        "amount-amount",
+        &LIQUIDATION_AMOUNT.to_string(),
+    );
+
+    // the slice is gone, the dues are settled, the position lives on
+    match super::state_query(&test_case, lease) {
+        StateResponse::Opened {
+            amount,
+            due_interest,
+            due_margin,
+            overdue_interest,
+            overdue_margin,
+            ..
+        } => {
+            assert_eq!(
+                lease_amount - LeaseCoin::new(LIQUIDATION_AMOUNT),
+                LeaseCoin::try_from(amount).unwrap(),
+            );
+            assert!(due_interest.is_zero());
+            assert!(due_margin.is_zero());
+            assert!(overdue_interest.is_zero());
+            assert!(overdue_margin.is_zero());
+        }
+        other => panic!("expected the position to continue opened, got {other:?}"),
+    }
+}
+
+/// #660 (I4): a FULL liquidation that requotes DOWN on a timeout and then
+/// CLEARS at the fresh floor drives to the `Liquidated` end state exactly as
+/// an untimed-out one (mirrors `liquidation::price::full_liquidation`). RED
+/// until #660 lands (the floor stays pinned on the way).
+#[test]
+fn full_liquidation_requote_then_clear_liquidates() {
+    let mut test_case = create_test_case();
+    let lease = drive_into_liquidation_swap(&mut test_case);
+    let controller = test_case.address_book.remote_lease_controller().clone();
+
+    let (base, quote) = (LeaseCoin::new(2), LpnCoin::new(1));
+    feed_price_quietly(&mut test_case, base, quote);
+    let _reemit = inject_timeout(&mut test_case, &lease);
+    assert_eq!(
+        liquidation_floor_at(LeaseCoin::new(FULL_LIQ_LEASE_AMOUNT), base, quote),
+        latest_min_out(&test_case, &lease),
+        "the re-emission must promise the fresh-quote floor",
+    );
+
+    // the counterparty clears the re-emitted leg; the identity payout is
+    // well above the requoted floor
+    let _ack = stub::deliver_pending_callback(&mut test_case.app, &controller, op_tag::SWAP);
+    let (proceeds, arrival): (LpnCoin, AppResponse) =
+        super::settle_close_proceeds(&mut test_case, &lease);
+    assert_eq!(LpnCoin::new(FULL_LIQ_LEASE_AMOUNT), proceeds);
+    arrival.assert_event(&Event::new("wasm-ls-liquidation").add_attribute("loan-close", "true"));
+
+    assert!(
+        matches!(
+            super::state_query(&test_case, lease),
+            StateResponse::Liquidated()
+        ),
+        "the requoted-then-cleared full liquidation must end Liquidated",
+    );
+}
+
+/// #660 (I5): a customer-close leg keeps the verbatim pinned floor across
+/// timeouts — the `AcceptAnyNonZeroSwap` constant floor of 1 never moves,
+/// oracle move or not. Green today; must stay green.
+#[test]
+fn customer_close_floor_stays_verbatim_across_timeouts() {
+    let mut test_case = create_test_case();
+    let lease = drive_into_customer_close_swap(&mut test_case);
+    let floor_before = latest_min_out(&test_case, &lease);
+    assert_eq!(1, floor_before, "AcceptAnyNonZeroSwap pins a floor of 1");
+
+    feed_price_quietly(&mut test_case, LeaseCoin::new(1), LpnCoin::new(2));
+    let _first = inject_timeout(&mut test_case, &lease);
+    let _second = inject_timeout(&mut test_case, &lease);
+
+    assert_eq!(
+        floor_before,
+        latest_min_out(&test_case, &lease),
+        "a customer-close timeout must re-emit the pinned floor verbatim",
+    );
+    assert_customer_close_swap_in_flight(&test_case, &lease);
+}
+
+/// #660 (I6): a repay (`BuyLpn`) leg keeps the verbatim pinned floor across
+/// timeouts — the constant floor of 1 never moves. This is the behavioral
+/// pin of `BuyLpn::requote_on_timeout() == false`. Green today; must stay
+/// green.
+#[test]
+fn repay_floor_stays_verbatim_across_timeouts() {
+    let mut test_case = create_test_case();
+    let lease = drive_into_repay_swap(&mut test_case);
+    let floor_before = latest_min_out(&test_case, &lease);
+    assert_eq!(1, floor_before, "AcceptAnyNonZeroSwap pins a floor of 1");
+
+    feed_price_quietly(&mut test_case, LeaseCoin::new(1), LpnCoin::new(2));
+    let _reemit = inject_timeout(&mut test_case, &lease);
+
+    assert_eq!(
+        floor_before,
+        latest_min_out(&test_case, &lease),
+        "a repay timeout must re-emit the pinned floor verbatim",
+    );
+    assert_repay_swap_in_flight(&test_case, &lease);
+}
+
+/// #660 (I7): an opening (`BuyAsset`) leg keeps the verbatim pinned floor
+/// across timeouts even though its calculator reads the oracle — a moved
+/// price must NOT leak into the re-emission; detection-first opening
+/// semantics are preserved. Green today; must stay green.
+#[test]
+fn opening_floor_stays_verbatim_across_timeouts() {
+    let (mut test_case, lease, _controller) = start_open_with_delayed_swap();
+    let floor_before = latest_min_out(&test_case, &lease);
+
+    // move the asset price so a requote WOULD change the floor
+    feed_price_quietly(&mut test_case, LeaseCoin::new(1), LpnCoin::new(2));
+    let _reemit = inject_timeout(&mut test_case, &lease);
+
+    assert_eq!(
+        floor_before,
+        latest_min_out(&test_case, &lease),
+        "an opening timeout must re-emit the pinned floor verbatim",
+    );
+    assert_opening_swap_in_flight(&test_case, &lease);
+}
+
+/// #660 (I8): requote rounds spend the same timeout budget; the round past
+/// it parks with the LAST requoted floor still promised, and the parked
+/// query keeps the `SlippageProtectionActivated` shape. RED until #660
+/// lands.
+#[test]
+fn park_after_budget_holds_the_last_requoted_floor() {
+    let mut test_case = create_test_case();
+    let lease = drive_into_liquidation_swap(&mut test_case);
+
+    feed_price_quietly(&mut test_case, LeaseCoin::new(2), LpnCoin::new(1));
+    for round in 0..(LIQUIDATION_BUDGET - 1) {
+        let _reemit = inject_timeout(&mut test_case, &lease);
+        assert!(
+            !is_slippage_protection_activated(&test_case, &lease),
+            "the lease must still be retrying within budget, round {}",
+            round + 1,
+        );
+    }
+
+    // the price moves once more before the last in-budget round
+    let (base, quote) = (LeaseCoin::new(4), LpnCoin::new(1));
+    feed_price_quietly(&mut test_case, base, quote);
+    let _reemit = inject_timeout(&mut test_case, &lease);
+    assert!(!is_slippage_protection_activated(&test_case, &lease));
+    let last_floor = latest_min_out(&test_case, &lease);
+    assert_eq!(
+        liquidation_floor_at(LeaseCoin::new(FULL_LIQ_LEASE_AMOUNT), base, quote),
+        last_floor,
+        "the last in-budget round must promise the fresh-quote floor",
+    );
+
+    // the round past the budget parks without re-emitting — the last
+    // requoted floor stays the standing promise
+    let swaps_at_budget = recorded_swap_count(&test_case, &lease);
+    let _park = inject_timeout(&mut test_case, &lease);
+    assert_eq!(
+        swaps_at_budget,
+        recorded_swap_count(&test_case, &lease),
+        "the timeout past the budget must park, not re-emit",
+    );
+    assert_slippage_protection_activated(&test_case, &lease);
+    assert_eq!(last_floor, latest_min_out(&test_case, &lease));
+}
+
+/// #660 (I9): the operator heal of a parked liquidation is UNCHANGED by the
+/// auto-requote: it still re-quotes from the live oracle, resets the
+/// counters, and re-enters the live swap sequence. Green today; must stay
+/// green — and it pins the exact fresh-quote floor arithmetic the requote
+/// tests reuse.
+#[test]
+fn heal_after_park_still_requotes_and_resets() {
+    let mut test_case = create_test_case();
+    let lease = park_liquidation(&mut test_case);
+
+    let (base, quote) = (LeaseCoin::new(1), LpnCoin::new(2));
+    feed_price_quietly(&mut test_case, base, quote);
+    let healed = test_case
+        .app
+        .execute(
+            testing::user(LEASE_ADMIN),
+            lease.clone(),
+            &ExecuteMsg::Heal(),
+            &[],
+        )
+        .expect("the lease admin must heal a parked lease")
+        .unwrap_response();
+    expect_attribute(&healed.events, LIQUIDATION_SWAP_EVENT, "heal", "re-emit");
+
+    assert_eq!(
+        liquidation_floor_at(LeaseCoin::new(FULL_LIQ_LEASE_AMOUNT), base, quote),
+        latest_min_out(&test_case, &lease),
+        "the heal must re-quote the floor from the live oracle",
+    );
+    assert_liquidation_swap_in_flight(&test_case, &lease);
+}
+
+/// #660 (I10): a requote round's retry event carries the previous and the
+/// fresh floor as coin attributes — `min-out-prev-*` and `min-out-*`,
+/// additive to the existing `timeout = retry`. RED until #660 lands.
+#[test]
+fn requote_round_emits_previous_and_fresh_floor() {
+    let mut test_case = create_test_case();
+    let lease = drive_into_liquidation_swap(&mut test_case);
+    let floor_before = latest_min_out(&test_case, &lease);
+
+    let (base, quote) = (LeaseCoin::new(2), LpnCoin::new(1));
+    feed_price_quietly(&mut test_case, base, quote);
+    let reemit = inject_timeout(&mut test_case, &lease);
+
+    expect_attribute(&reemit.events, LIQUIDATION_SWAP_EVENT, "timeout", "retry");
+    expect_attribute(
+        &reemit.events,
+        LIQUIDATION_SWAP_EVENT,
+        "min-out-prev-amount",
+        &floor_before.to_string(),
+    );
+    expect_attribute(
+        &reemit.events,
+        LIQUIDATION_SWAP_EVENT,
+        "min-out-amount",
+        &liquidation_floor_at(LeaseCoin::new(FULL_LIQ_LEASE_AMOUNT), base, quote).to_string(),
+    );
+}
+
+/// #660 (I10, fallback): with the oracle's price EXPIRED (feed validity is
+/// 5s x 12 samples in the test oracle), the requote's quote fails; the round
+/// falls back to the pinned floor, still goes out, and marks the skipped
+/// requote with `requote = skipped`. RED until #660 lands.
+#[test]
+fn expired_price_requote_falls_back_to_the_pinned_floor() {
+    let mut test_case = create_test_case();
+    let lease = drive_into_liquidation_swap(&mut test_case);
+    let floor_before = latest_min_out(&test_case, &lease);
+
+    // outlive the feed validity so the synchronous quote at the timeout
+    // delivery fails
+    test_case.app.time_shift(Duration::from_secs(3_600));
+    let reemit = inject_timeout(&mut test_case, &lease);
+
+    expect_attribute(&reemit.events, LIQUIDATION_SWAP_EVENT, "requote", "skipped");
+    assert_eq!(
+        floor_before,
+        latest_min_out(&test_case, &lease),
+        "an oracle failure at requote must fall back to the pinned floor",
+    );
+    assert_liquidation_swap_in_flight(&test_case, &lease);
+}
+
 // === drivers =============================================================
 
 fn create_test_case() -> LeaseTestCase {
     super::create_test_case::<PaymentCurrency>()
+}
+
+/// Feed a fresh `base <-> quote` observation WITHOUT dispatching price
+/// alarms — the #660 requote reads the oracle synchronously at timeout
+/// delivery, so no alarm round-trip is involved and the in-flight swap state
+/// stays untouched.
+fn feed_price_quietly(test_case: &mut LeaseTestCase, base: LeaseCoin, quote: LpnCoin) {
+    let _feed = common::oracle::feed_price(test_case, testing::user(ADMIN), base, quote);
+}
+
+/// Inject an `OperationTimeout` for the lease's in-flight leg (the stub
+/// remaps the nonce onto the last emitted one).
+fn inject_timeout(test_case: &mut LeaseTestCase, lease: &Addr) -> AppResponse {
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    stub::inject_callback(
+        &mut test_case.app,
+        &controller,
+        lease,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationTimeout,
+        },
+    )
+}
+
+/// The floor a fresh liquidation (re-)quote must pin: the liquidation
+/// max-slippage bound applied to the live-oracle quote of the in-flight leg.
+fn liquidation_floor_at(coin_in: LeaseCoin, base: LeaseCoin, quote: LpnCoin) -> Amount {
+    MaxSlippage::unchecked(LeaserInstantiator::MAX_SLIPPAGE)
+        .min_out(
+            price::total(coin_in, price::total_of(base).is(quote)).expect("a representable quote"),
+        )
+        .to_primitive()
 }
 
 /// Open a lease and drop the price into a full-liquidation, holding the
@@ -408,14 +850,10 @@ fn drive_into_liquidation_swap(test_case: &mut LeaseTestCase) -> Addr {
         ResponseMode::Delayed,
     );
 
-    // the literal-floor opening amounts; the base is chosen close to the
-    // asset amount to trigger a full liquidation (mirrors liquidation::price)
-    let lease_amount: Amount = 2428571428570;
-    let borrowed_amount: Amount = 1857142857142;
     let () = super::deliver_new_price(
         test_case,
-        common::coin(lease_amount - 2),
-        common::coin(borrowed_amount),
+        common::coin(FULL_LIQ_LEASE_AMOUNT - 2),
+        common::coin(FULL_LIQ_BORROWED_AMOUNT),
     )
     .ignore_response()
     .unwrap_response();


### PR DESCRIPTION
Closes #660. Successor to #655's detection-first valve — this is the deferred automatic-recovery half, for the liquidation class only.

## What changes

On each **in-budget timeout** of the liquidation swap leg, the floor (min_out) is recomputed against the **live oracle**, bounded by MaxSlippages.liquidation, instead of re-emitting the pinned floor verbatim — so a stuck liquidation self-clears without an operator Heal once transport recovers. Selection is by calculator class: a new REQUOTES_ON_TIMEOUT associated const on the slippage-calculator trait, true only for the max-slippage calculator (liquidation's); the swap-task surface forwards it. Opening, repay, customer-close, and profit buy-back keep verbatim pinned re-emission — zero behavior change, pinned by tests.

Mechanics:
- The floor tracks the live quote **both directions** (no monotonic clamp — lowering-to-clear is the point), clamped to a minimum of 1.
- Oracle failure at re-quote time falls back to the verbatim pinned re-emission (the timeout callback never errors, so the delivery transaction never reverts); the retry event carries a requote = skipped marker.
- Each re-emission bumps the correlation nonce exactly once and preserves the timeout/error counters — the retry budget still exhausts, the anomaly terminal still fires past budget and carries the last re-quoted floor. Heal semantics are unchanged.
- Past-budget escalation never re-quotes, so floor erosion is bounded by the retry budget under any escalation policy.
- Re-quoting retry events carry min-out-prev / min-out attributes for observability.
- No storage layout change, no wire-format change, no version bump.

## Deploy precondition

**This must not be deployed before the relayer re-quotes the delivery route per re-delivery.** Until then, route staleness collapses into floor-unmeetability and the auto-requote degrades into avoidable floor erosion (still bounded by MaxSlippages.liquidation). Deployment ordering stays with the operator, alongside the existing remote-program liveness gate.

## Cross-chain note

Verified against the counterparty implementation: the remote executor enforces **each packet's own min_out** (nothing is pinned first-seen, no content-keyed dedup), so re-emissions carrying different floors are safe by construction. Two in-flight emissions of one leg can both execute (pre-existing transport property, unrelated to this change); the per-leg nonce plus positional correlation credits exactly one outcome and absorbs the superseded ack — covered by tests.

## Tests

27 new tests written ahead of the implementation and driven to green: unit coverage for the re-quote (both directions), budget-spend-then-park with the last floor, nonce monotonicity, oracle-failure fallback, collapsed-quote clamp, verbatim guards for every other class; end-to-end integration coverage for requote-then-clear (partial and full liquidation), park-after-budget, heal-after-park, event attributes, and the unchanged classes. Existing suites pass unmodified and behave identically to main. Full build/format/lint/test matrix green on the protocol and integration workspaces (194 integration tests). Independent review: 12-item checklist pass, security scan clear (no findings above informational), project-rule audit pass. Operator runbook updated (retry semantics and observability markers).