### PR TITLE
test(lease): close the remote-lease callback coverage residual

### DIFF
--- a/protocol/contracts/lease/src/contract/state/closed.rs
+++ b/protocol/contracts/lease/src/contract/state/closed.rs
@@ -19,6 +19,85 @@ use crate::{
 
 use super::{Handler, Response, drain::DrainAll};
 
+#[cfg(all(feature = "internal.test.contract", test))]
+mod tests {
+    use platform::{
+        batch::{Batch, Emit, Emitter},
+        message::Response as MessageResponse,
+    };
+    use remote_lease::{
+        callback::{RemoteLeaseCallback, RemoteOperationOutcome},
+        response::{TransferOutResponse, WireOperationResponse},
+    };
+    use sdk::cosmwasm_std::{
+        Addr, Empty, MessageInfo, QuerierWrapper,
+        testing::{self, MockQuerier},
+    };
+
+    use crate::{
+        contract::state::{Response, State, handler::Handler},
+        error::ContractError,
+    };
+
+    use super::Closed;
+
+    const CONTROLLER: &str = "controller";
+    const STRANGER: &str = "stranger";
+
+    #[test]
+    fn late_ack_from_the_controller_is_absorbed() {
+        let response = deliver(info(CONTROLLER)).expect("the late ack should be absorbed");
+
+        assert!(matches!(response.next_state, State::Closed(_)));
+        assert_eq!(absorb_response(), response.response);
+    }
+
+    #[test]
+    fn late_ack_from_a_stranger_rejected() {
+        assert!(matches!(
+            deliver(info(STRANGER)),
+            Err(ContractError::Unauthorized(_))
+        ));
+    }
+
+    fn deliver(info: MessageInfo) -> Result<Response, ContractError> {
+        let mock_querier = MockQuerier::<Empty>::default();
+        closed().on_remote_lease_callback(
+            late_transfer_out_ack(),
+            info,
+            QuerierWrapper::new(&mock_querier),
+            testing::mock_env(),
+        )
+    }
+
+    fn closed() -> Closed {
+        Closed::new(Addr::unchecked(CONTROLLER))
+    }
+
+    fn late_transfer_out_ack() -> RemoteLeaseCallback {
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::TransferOut(
+                TransferOutResponse {},
+            )),
+        }
+    }
+
+    fn info(sender: &str) -> MessageInfo {
+        MessageInfo {
+            sender: Addr::unchecked(sender),
+            funds: vec![],
+        }
+    }
+
+    fn absorb_response() -> MessageResponse {
+        let emitter = Emitter::of_type("ls-remote-lease-late-ack")
+            .emit("id", testing::mock_env().contract.address)
+            .emit("terminal", "closed");
+        MessageResponse::messages_with_event(Batch::default(), emitter)
+    }
+}
+
 const LATE_ACK_EVENT: &str = "ls-remote-lease-late-ack";
 const EVENT_KEY_ID: &str = "id";
 const EVENT_KEY_TERMINAL: &str = "terminal";
@@ -118,82 +197,3 @@ impl Handler for Closed {
 }
 
 impl DrainAll for Closed {}
-
-#[cfg(all(feature = "internal.test.contract", test))]
-mod tests {
-    use platform::{
-        batch::{Batch, Emit, Emitter},
-        message::Response as MessageResponse,
-    };
-    use remote_lease::{
-        callback::{RemoteLeaseCallback, RemoteOperationOutcome},
-        response::{TransferOutResponse, WireOperationResponse},
-    };
-    use sdk::cosmwasm_std::{
-        Addr, Empty, MessageInfo, QuerierWrapper,
-        testing::{self, MockQuerier},
-    };
-
-    use crate::{
-        contract::state::{Response, State, handler::Handler},
-        error::ContractError,
-    };
-
-    use super::Closed;
-
-    const CONTROLLER: &str = "controller";
-    const STRANGER: &str = "stranger";
-
-    #[test]
-    fn late_ack_from_the_controller_is_absorbed() {
-        let response = deliver(info(CONTROLLER)).expect("the late ack should be absorbed");
-
-        assert!(matches!(response.next_state, State::Closed(_)));
-        assert_eq!(absorb_response(), response.response);
-    }
-
-    #[test]
-    fn late_ack_from_a_stranger_rejected() {
-        assert!(matches!(
-            deliver(info(STRANGER)),
-            Err(ContractError::Unauthorized(_))
-        ));
-    }
-
-    fn deliver(info: MessageInfo) -> Result<Response, ContractError> {
-        let mock_querier = MockQuerier::<Empty>::default();
-        closed().on_remote_lease_callback(
-            late_transfer_out_ack(),
-            info,
-            QuerierWrapper::new(&mock_querier),
-            testing::mock_env(),
-        )
-    }
-
-    fn closed() -> Closed {
-        Closed::new(Addr::unchecked(CONTROLLER))
-    }
-
-    fn late_transfer_out_ack() -> RemoteLeaseCallback {
-        RemoteLeaseCallback {
-            nonce: 0,
-            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::TransferOut(
-                TransferOutResponse {},
-            )),
-        }
-    }
-
-    fn info(sender: &str) -> MessageInfo {
-        MessageInfo {
-            sender: Addr::unchecked(sender),
-            funds: vec![],
-        }
-    }
-
-    fn absorb_response() -> MessageResponse {
-        let emitter = Emitter::of_type("ls-remote-lease-late-ack")
-            .emit("id", testing::mock_env().contract.address)
-            .emit("terminal", "closed");
-        MessageResponse::messages_with_event(Batch::default(), emitter)
-    }
-}

--- a/protocol/contracts/lease/src/contract/state/closed.rs
+++ b/protocol/contracts/lease/src/contract/state/closed.rs
@@ -118,3 +118,82 @@ impl Handler for Closed {
 }
 
 impl DrainAll for Closed {}
+
+#[cfg(all(feature = "internal.test.contract", test))]
+mod tests {
+    use platform::{
+        batch::{Batch, Emit, Emitter},
+        message::Response as MessageResponse,
+    };
+    use remote_lease::{
+        callback::{RemoteLeaseCallback, RemoteOperationOutcome},
+        response::{TransferOutResponse, WireOperationResponse},
+    };
+    use sdk::cosmwasm_std::{
+        Addr, Empty, MessageInfo, QuerierWrapper,
+        testing::{self, MockQuerier},
+    };
+
+    use crate::{
+        contract::state::{Response, State, handler::Handler},
+        error::ContractError,
+    };
+
+    use super::Closed;
+
+    const CONTROLLER: &str = "controller";
+    const STRANGER: &str = "stranger";
+
+    #[test]
+    fn late_ack_from_the_controller_is_absorbed() {
+        let response = deliver(info(CONTROLLER)).expect("the late ack should be absorbed");
+
+        assert!(matches!(response.next_state, State::Closed(_)));
+        assert_eq!(absorb_response(), response.response);
+    }
+
+    #[test]
+    fn late_ack_from_a_stranger_rejected() {
+        assert!(matches!(
+            deliver(info(STRANGER)),
+            Err(ContractError::Unauthorized(_))
+        ));
+    }
+
+    fn deliver(info: MessageInfo) -> Result<Response, ContractError> {
+        let mock_querier = MockQuerier::<Empty>::default();
+        closed().on_remote_lease_callback(
+            late_transfer_out_ack(),
+            info,
+            QuerierWrapper::new(&mock_querier),
+            testing::mock_env(),
+        )
+    }
+
+    fn closed() -> Closed {
+        Closed::new(Addr::unchecked(CONTROLLER))
+    }
+
+    fn late_transfer_out_ack() -> RemoteLeaseCallback {
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::TransferOut(
+                TransferOutResponse {},
+            )),
+        }
+    }
+
+    fn info(sender: &str) -> MessageInfo {
+        MessageInfo {
+            sender: Addr::unchecked(sender),
+            funds: vec![],
+        }
+    }
+
+    fn absorb_response() -> MessageResponse {
+        let emitter = Emitter::of_type("ls-remote-lease-late-ack")
+            .emit("id", testing::mock_env().contract.address)
+            .emit("terminal", "closed");
+        MessageResponse::messages_with_event(Batch::default(), emitter)
+    }
+}

--- a/protocol/contracts/lease/src/contract/state/open_failed.rs
+++ b/protocol/contracts/lease/src/contract/state/open_failed.rs
@@ -73,3 +73,107 @@ impl Contract for OpenFailed {
         ))
     }
 }
+
+#[cfg(all(feature = "internal.test.contract", test))]
+mod tests {
+    use platform::{
+        batch::{Batch, Emit, Emitter},
+        message::Response as MessageResponse,
+    };
+    use remote_lease::{
+        callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
+        response::{OpenLeaseResponse, RemoteLeaseId, WireOperationResponse},
+    };
+    use sdk::cosmwasm_std::{
+        self, Addr, ContractResult as CwContractResult, Empty, MessageInfo, QuerierWrapper,
+        SystemResult, WasmQuery,
+        testing::{self, MockQuerier},
+    };
+
+    use crate::{
+        api::authz::{AccessCheck, AccessGranted},
+        contract::{api::Contract, finalize::LeasesRef, state::State},
+        error::ContractError,
+    };
+
+    use super::OpenFailed;
+
+    const LEASER: &str = "leaser";
+    const CONTROLLER: &str = "controller";
+    const STRANGER: &str = "stranger";
+    const REMOTE_LEASE_ID: &str = "StubPda1111111111111111111111111111";
+
+    #[test]
+    fn late_ack_from_authorized_sender_is_absorbed() {
+        let response = deliver(AccessGranted::Yes, CONTROLLER).expect("the late ack is absorbed");
+
+        assert!(matches!(response.next_state, State::OpenFailed(_)));
+        assert_eq!(absorb_response(), response.response);
+    }
+
+    #[test]
+    fn late_ack_from_unauthorized_sender_rejected() {
+        assert!(matches!(
+            deliver(AccessGranted::No, STRANGER),
+            Err(ContractError::Unauthorized(_))
+        ));
+    }
+
+    fn deliver(granted: AccessGranted, sender: &str) -> Result<super::Response, ContractError> {
+        let mock_querier = access_querier(granted);
+        open_failed().on_remote_lease_callback(
+            late_open_ack(),
+            info(sender),
+            QuerierWrapper::new(&mock_querier),
+            testing::mock_env(),
+        )
+    }
+
+    fn open_failed() -> OpenFailed {
+        OpenFailed::new(
+            RemoteErrorMessage::from_static("a prior open failure"),
+            LeasesRef::unchecked(Addr::unchecked(LEASER)),
+        )
+    }
+
+    fn late_open_ack() -> RemoteLeaseCallback {
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::OpenLease(
+                OpenLeaseResponse {
+                    remote_lease_id: RemoteLeaseId::new(REMOTE_LEASE_ID.to_owned())
+                        .expect("a base58 sample"),
+                },
+            )),
+        }
+    }
+
+    fn access_querier(granted: AccessGranted) -> MockQuerier<Empty> {
+        let mut mock_querier = MockQuerier::<Empty>::default();
+        mock_querier.update_wasm(move |query| {
+            let WasmQuery::Smart { msg, .. } = query else {
+                unimplemented!("only smart queries are expected")
+            };
+            let _: AccessCheck =
+                cosmwasm_std::from_json(msg).expect("a remote-lease callback permission query");
+            SystemResult::Ok(CwContractResult::Ok(
+                cosmwasm_std::to_json_binary(&granted).expect("the verdict should serialize"),
+            ))
+        });
+        mock_querier
+    }
+
+    fn info(sender: &str) -> MessageInfo {
+        MessageInfo {
+            sender: Addr::unchecked(sender),
+            funds: vec![],
+        }
+    }
+
+    fn absorb_response() -> MessageResponse {
+        let emitter = Emitter::of_type("ls-remote-lease-late-ack")
+            .emit("id", testing::mock_env().contract.address)
+            .emit("terminal", "open_failed");
+        MessageResponse::messages_with_event(Batch::default(), emitter)
+    }
+}

--- a/protocol/contracts/lease/src/contract/state/open_failed.rs
+++ b/protocol/contracts/lease/src/contract/state/open_failed.rs
@@ -16,64 +16,6 @@ use crate::{
 
 use super::Response;
 
-const LATE_ACK_EVENT: &str = "ls-remote-lease-late-ack";
-
-#[derive(Serialize, Deserialize)]
-pub(crate) struct OpenFailed {
-    reason: RemoteErrorMessage,
-    leases: LeasesRef,
-}
-
-impl OpenFailed {
-    pub(crate) fn new(reason: RemoteErrorMessage, leases: LeasesRef) -> Self {
-        Self { reason, leases }
-    }
-}
-
-impl Contract for OpenFailed {
-    fn state(
-        self,
-        _now: Instant,
-        _due_projection: Duration,
-        _querier: QuerierWrapper<'_>,
-    ) -> ContractResult<QueryStateResponse> {
-        Ok(QueryStateResponse::OpenFailed {
-            reason: self.reason,
-        })
-    }
-
-    /// Absorbs late-after-terminal callbacks. The remote-lease IBC
-    /// channel is UNORDERED, so the original packet's success ack may
-    /// still land here after a timeout already moved us to this
-    /// terminal. Return `Ok` with an observability event so the
-    /// controller's `ibc_packet_ack` commits and the relayer's retry
-    /// loop unblocks. Idempotent — no state mutation.
-    ///
-    /// Gated by the same `remote_lease_callback_permission` check the
-    /// in-flight states use, so a third party cannot spam late-ack
-    /// events against a terminal lease.
-    fn on_remote_lease_callback(
-        self,
-        _callback: RemoteLeaseCallback,
-        info: MessageInfo,
-        querier: QuerierWrapper<'_>,
-        env: Env,
-    ) -> ContractResult<Response> {
-        access_control::check(
-            &self.leases.remote_lease_callback_permission(querier),
-            &info,
-        )
-        .map_err(ContractError::from)?;
-        let emitter = Emitter::of_type(LATE_ACK_EVENT)
-            .emit("id", env.contract.address)
-            .emit("terminal", "open_failed");
-        Ok(StateMachineResponse::from(
-            MessageResponse::messages_with_event(Batch::default(), emitter),
-            super::State::from(self),
-        ))
-    }
-}
-
 #[cfg(all(feature = "internal.test.contract", test))]
 mod tests {
     use platform::{
@@ -175,5 +117,63 @@ mod tests {
             .emit("id", testing::mock_env().contract.address)
             .emit("terminal", "open_failed");
         MessageResponse::messages_with_event(Batch::default(), emitter)
+    }
+}
+
+const LATE_ACK_EVENT: &str = "ls-remote-lease-late-ack";
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct OpenFailed {
+    reason: RemoteErrorMessage,
+    leases: LeasesRef,
+}
+
+impl OpenFailed {
+    pub(crate) fn new(reason: RemoteErrorMessage, leases: LeasesRef) -> Self {
+        Self { reason, leases }
+    }
+}
+
+impl Contract for OpenFailed {
+    fn state(
+        self,
+        _now: Instant,
+        _due_projection: Duration,
+        _querier: QuerierWrapper<'_>,
+    ) -> ContractResult<QueryStateResponse> {
+        Ok(QueryStateResponse::OpenFailed {
+            reason: self.reason,
+        })
+    }
+
+    /// Absorbs late-after-terminal callbacks. The remote-lease IBC
+    /// channel is UNORDERED, so the original packet's success ack may
+    /// still land here after a timeout already moved us to this
+    /// terminal. Return `Ok` with an observability event so the
+    /// controller's `ibc_packet_ack` commits and the relayer's retry
+    /// loop unblocks. Idempotent — no state mutation.
+    ///
+    /// Gated by the same `remote_lease_callback_permission` check the
+    /// in-flight states use, so a third party cannot spam late-ack
+    /// events against a terminal lease.
+    fn on_remote_lease_callback(
+        self,
+        _callback: RemoteLeaseCallback,
+        info: MessageInfo,
+        querier: QuerierWrapper<'_>,
+        env: Env,
+    ) -> ContractResult<Response> {
+        access_control::check(
+            &self.leases.remote_lease_callback_permission(querier),
+            &info,
+        )
+        .map_err(ContractError::from)?;
+        let emitter = Emitter::of_type(LATE_ACK_EVENT)
+            .emit("id", env.contract.address)
+            .emit("terminal", "open_failed");
+        Ok(StateMachineResponse::from(
+            MessageResponse::messages_with_event(Batch::default(), emitter),
+            super::State::from(self),
+        ))
     }
 }

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -242,3 +242,322 @@ enum ControllerExecuteMsg {
 }
 
 impl ControllerInnerMessage for ControllerExecuteMsg {}
+
+#[cfg(all(feature = "internal.test.contract", test))]
+mod tests {
+    use currencies::testing::{LeaseC2, PaymentC1};
+    use cw_time::IntoInstant;
+    use dex::{ConnectionParams, Ics20Channel, MaxSlippage};
+    use finance::{
+        coin::Coin, duration::Duration, instant::Instant, liability::Liability, percent::Percent100,
+    };
+    use lpp::{msg::LoanResponse, stub::LppRef as LppGenericRef};
+    use remote_lease::{
+        callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
+        response::{OpenLeaseResponse, RemoteLeaseId, TransferOutResponse, WireOperationResponse},
+    };
+    use sdk::cosmwasm_std::{
+        self, Addr, ContractResult as CwContractResult, Empty, MessageInfo, QuerierResult,
+        QuerierWrapper, SystemResult, WasmQuery,
+        testing::{self, MockQuerier},
+    };
+    use timealarms::stub::TimeAlarmsRef;
+
+    use crate::{
+        api::{
+            authz::{AccessCheck, AccessGranted},
+            limits::{MaxSlippages, PositionLimits},
+            open::{LoanForm, NewLeaseContract, NewLeaseForm, PositionSpecDTO},
+            query::StateResponse as QueryStateResponse,
+        },
+        contract::{
+            api::Contract,
+            cmd::OpenLoanRespResult,
+            finalize::LeasesRef,
+            state::{Response, State},
+        },
+        error::ContractError,
+        finance::{LpnCurrencies, LpnCurrency, OracleRef},
+    };
+
+    use super::OpenLease;
+
+    const CONTROLLER: &str = "controller";
+    const LEASER: &str = "leaser";
+    const LPP: &str = "lpp";
+    const RESERVE: &str = "reserve";
+    const STRANGER: &str = "stranger";
+    const REMOTE_LEASE_ID: &str = "StubPda1111111111111111111111111111";
+    const DOWNPAYMENT: u128 = 100;
+    const PRINCIPAL: u128 = 500;
+    const INTEREST_RATE_PERCENT: u32 = 5;
+    const MAX_SLIPPAGE_PERCENT: u32 = 20;
+    const INSTANCE_ORDINAL: u16 = 1;
+
+    #[test]
+    fn open_lease_ack_starts_the_funding_leg() {
+        let response = deliver(open_lease_ack(), CONTROLLER, &authorized_querier())
+            .expect("the open-lease ack should start funding");
+
+        assert!(matches!(response.next_state, State::BuyAsset(_)));
+    }
+
+    #[test]
+    fn unexpected_ok_ack_fails_the_open_with_a_fixed_reason() {
+        let response = deliver(unexpected_ok_ack(), CONTROLLER, &authorized_querier())
+            .expect("the unexpected ack should fail the open");
+
+        assert_eq!(
+            "unexpected operation response",
+            open_failed_reason(response)
+        );
+    }
+
+    #[test]
+    fn error_ack_fails_the_open_echoing_the_reason() {
+        const REASON: &str = "solana rejected the open";
+
+        let response = deliver(error_ack(REASON), CONTROLLER, &authorized_querier())
+            .expect("the error ack should fail the open");
+
+        assert_eq!(REASON, open_failed_reason(response));
+    }
+
+    #[test]
+    fn timeout_fails_the_open_with_the_timeout_reason() {
+        let response = deliver(timeout_ack(), CONTROLLER, &authorized_querier())
+            .expect("the timeout should fail the open");
+
+        assert_eq!("timeout", open_failed_reason(response));
+    }
+
+    #[test]
+    fn callback_from_unauthorized_sender_rejected() {
+        assert!(matches!(
+            deliver(open_lease_ack(), STRANGER, &rejecting_querier()),
+            Err(ContractError::Unauthorized(_))
+        ));
+    }
+
+    fn deliver(
+        callback: RemoteLeaseCallback,
+        sender: &str,
+        querier: &MockQuerier<Empty>,
+    ) -> Result<Response, ContractError> {
+        open_lease().on_remote_lease_callback(
+            callback,
+            info(sender),
+            QuerierWrapper::new(querier),
+            testing::mock_env(),
+        )
+    }
+
+    fn open_failed_reason(response: Response) -> String {
+        let mock_querier = MockQuerier::<Empty>::default();
+        match response.next_state {
+            State::OpenFailed(failed) => match failed
+                .state(
+                    testing::mock_env().block.time.into_instant(),
+                    Duration::from_secs(0),
+                    QuerierWrapper::new(&mock_querier),
+                )
+                .expect("the open-failed state query succeeds")
+            {
+                QueryStateResponse::OpenFailed { reason } => reason.as_str().to_owned(),
+                _ => panic!("the open-failed state should report an OpenFailed response"),
+            },
+            _ => panic!("the callback should land the lease in OpenFailed"),
+        }
+    }
+
+    fn open_lease() -> OpenLease {
+        OpenLease::new(
+            new_lease_contract(),
+            Coin::<PaymentC1>::new(DOWNPAYMENT).into(),
+            OpenLoanRespResult {
+                principal: Coin::<LpnCurrency>::new(PRINCIPAL).into(),
+                annual_interest_rate: Percent100::from_percent(INTEREST_RATE_PERCENT),
+            },
+            deps(),
+            Instant::from_seconds(1_000_000),
+        )
+    }
+
+    fn open_lease_ack() -> RemoteLeaseCallback {
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::OpenLease(
+                OpenLeaseResponse {
+                    remote_lease_id: remote_lease_id(),
+                },
+            )),
+        }
+    }
+
+    fn unexpected_ok_ack() -> RemoteLeaseCallback {
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::TransferOut(
+                TransferOutResponse {},
+            )),
+        }
+    }
+
+    fn error_ack(reason: &str) -> RemoteLeaseCallback {
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(
+                RemoteErrorMessage::new(reason).expect("within the cap"),
+            ),
+        }
+    }
+
+    fn timeout_ack() -> RemoteLeaseCallback {
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationTimeout,
+        }
+    }
+
+    fn authorized_querier() -> MockQuerier<Empty> {
+        let mut mock_querier = MockQuerier::<Empty>::default();
+        mock_querier.update_wasm(authorized_handler);
+        mock_querier
+    }
+
+    fn rejecting_querier() -> MockQuerier<Empty> {
+        let mut mock_querier = MockQuerier::<Empty>::default();
+        mock_querier.update_wasm(|query| {
+            let WasmQuery::Smart { msg, .. } = query else {
+                unimplemented!("only smart queries are expected")
+            };
+            let _: AccessCheck =
+                cosmwasm_std::from_json(msg).expect("a remote-lease callback permission query");
+            SystemResult::Ok(CwContractResult::Ok(
+                cosmwasm_std::to_json_binary(&AccessGranted::No)
+                    .expect("the verdict should serialize"),
+            ))
+        });
+        mock_querier
+    }
+
+    /// Answers every query the authorized open-failure and funding paths make:
+    /// the leaser's callback-permission grant and opening slippage bound, the
+    /// reserve's Lpn, and the LPP loan. The loan's interest was last paid at the
+    /// callback instant, so no interest is due and the reserve cover is skipped.
+    fn authorized_handler(query: &WasmQuery) -> QuerierResult {
+        let WasmQuery::Smart { contract_addr, msg } = query else {
+            unimplemented!("only smart queries are expected")
+        };
+        let response = match contract_addr.as_str() {
+            LEASER => {
+                if cosmwasm_std::from_json::<AccessCheck>(msg).is_ok() {
+                    cosmwasm_std::to_json_binary(&AccessGranted::Yes)
+                } else {
+                    let _: PositionLimits =
+                        cosmwasm_std::from_json(msg).expect("a max-slippages query");
+                    cosmwasm_std::to_json_binary(&max_slippages())
+                }
+            }
+            RESERVE => cosmwasm_std::to_json_binary(&currency::dto::<LpnCurrency, LpnCurrencies>()),
+            LPP => cosmwasm_std::to_json_binary(&Some(loan_response())),
+            other => unimplemented!("no query is expected against {other}"),
+        }
+        .expect("the response should serialize");
+        SystemResult::Ok(CwContractResult::Ok(response))
+    }
+
+    fn max_slippages() -> MaxSlippages {
+        MaxSlippages {
+            opening: MaxSlippage::unchecked(Percent100::from_percent(MAX_SLIPPAGE_PERCENT)),
+            liquidation: MaxSlippage::unchecked(Percent100::from_percent(MAX_SLIPPAGE_PERCENT)),
+        }
+    }
+
+    fn loan_response() -> LoanResponse<LpnCurrency> {
+        LoanResponse {
+            principal_due: Coin::new(PRINCIPAL),
+            annual_interest_rate: Percent100::from_percent(INTEREST_RATE_PERCENT),
+            interest_paid: testing::mock_env().block.time.into_instant(),
+        }
+    }
+
+    fn new_lease_contract() -> NewLeaseContract {
+        NewLeaseContract {
+            form: form(),
+            dex: connection_params(),
+            finalizer: Addr::unchecked("finalizer"),
+            remote_lease_controller: Addr::unchecked(CONTROLLER),
+            expected_instance_ordinal: INSTANCE_ORDINAL,
+        }
+    }
+
+    fn form() -> NewLeaseForm {
+        NewLeaseForm {
+            customer: Addr::unchecked("customer"),
+            currency: currency::dto::<LeaseC2, _>(),
+            max_ltd: None,
+            position_spec: PositionSpecDTO::new(
+                liability(),
+                Coin::<LpnCurrency>::new(1_000).into(),
+                Coin::<LpnCurrency>::new(100).into(),
+            ),
+            loan: LoanForm {
+                lpp: Addr::unchecked(LPP),
+                profit: Addr::unchecked("profit"),
+                annual_margin_interest: Percent100::from_permille(31),
+                due_period: Duration::from_secs(100),
+            },
+            reserve: Addr::unchecked(RESERVE),
+            time_alarms: Addr::unchecked("timealarms"),
+            market_price_oracle: Addr::unchecked("oracle"),
+        }
+    }
+
+    fn liability() -> Liability {
+        Liability::new(
+            Percent100::from_percent(65),
+            Percent100::from_percent(70),
+            Percent100::from_percent(73),
+            Percent100::from_percent(75),
+            Percent100::from_percent(78),
+            Percent100::from_percent(80),
+            Duration::from_days(20),
+        )
+    }
+
+    fn deps() -> (
+        LppGenericRef<LpnCurrency>,
+        OracleRef,
+        TimeAlarmsRef,
+        LeasesRef,
+    ) {
+        (
+            LppGenericRef::unchecked(LPP),
+            OracleRef::unchecked(Addr::unchecked("oracle")),
+            TimeAlarmsRef::unchecked("timealarms"),
+            LeasesRef::unchecked(Addr::unchecked(LEASER)),
+        )
+    }
+
+    fn connection_params() -> ConnectionParams {
+        ConnectionParams {
+            connection_id: "connection-0".to_owned(),
+            transfer_channel: Ics20Channel {
+                local_endpoint: "channel-0".to_owned(),
+                remote_endpoint: "channel-2048".to_owned(),
+            },
+        }
+    }
+
+    fn remote_lease_id() -> RemoteLeaseId {
+        RemoteLeaseId::new(REMOTE_LEASE_ID.to_owned()).expect("a base58 sample")
+    }
+
+    fn info(sender: &str) -> MessageInfo {
+        MessageInfo {
+            sender: Addr::unchecked(sender),
+            funds: vec![],
+        }
+    }
+}

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -33,6 +33,367 @@ use crate::{
 
 use super::refund::{OpenFailureRefund, refund_to_open_failed};
 
+#[cfg(all(feature = "internal.test.contract", test))]
+mod tests {
+    use currencies::testing::{LeaseC2, PaymentC1};
+    use cw_time::IntoInstant;
+    use dex::{ConnectionParams, Ics20Channel, MaxSlippage};
+    use finance::{
+        coin::Coin, duration::Duration, instant::Instant, liability::Liability, percent::Percent100,
+    };
+    use lpp::{msg::LoanResponse, stub::LppRef as LppGenericRef};
+    use remote_lease::{
+        callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
+        response::{OpenLeaseResponse, RemoteLeaseId, TransferOutResponse, WireOperationResponse},
+    };
+    use sdk::cosmwasm_std::{
+        self, Addr, ContractResult as CwContractResult, Empty, MessageInfo, QuerierResult,
+        QuerierWrapper, SystemResult, WasmQuery,
+        testing::{self, MockQuerier},
+    };
+    use timealarms::stub::TimeAlarmsRef;
+
+    use crate::{
+        api::{
+            authz::{AccessCheck, AccessGranted},
+            limits::{MaxSlippages, PositionLimits},
+            open::{LoanForm, NewLeaseContract, NewLeaseForm, PositionSpecDTO},
+            query::StateResponse as QueryStateResponse,
+        },
+        contract::{
+            api::Contract,
+            cmd::OpenLoanRespResult,
+            finalize::LeasesRef,
+            state::{Response, State},
+        },
+        error::ContractError,
+        finance::{LpnCurrencies, LpnCurrency, OracleRef},
+    };
+
+    use super::OpenLease;
+
+    const CONTROLLER: &str = "controller";
+    const LEASER: &str = "leaser";
+    const LPP: &str = "lpp";
+    const RESERVE: &str = "reserve";
+    const STRANGER: &str = "stranger";
+    const REMOTE_LEASE_ID: &str = "StubPda1111111111111111111111111111";
+    const DOWNPAYMENT: u128 = 100;
+    const PRINCIPAL: u128 = 500;
+    const INTEREST_RATE_PERCENT: u32 = 5;
+    const MAX_SLIPPAGE_PERCENT: u32 = 20;
+    const INSTANCE_ORDINAL: u16 = 1;
+
+    #[test]
+    fn open_lease_ack_starts_the_funding_leg() {
+        let response = deliver(open_lease_ack(), CONTROLLER, &authorized_querier())
+            .expect("the open-lease ack should start funding");
+
+        assert!(matches!(response.next_state, State::BuyAsset(_)));
+    }
+
+    #[test]
+    fn unexpected_ok_ack_fails_the_open_with_a_fixed_reason() {
+        let response = deliver(unexpected_ok_ack(), CONTROLLER, &authorized_querier())
+            .expect("the unexpected ack should fail the open");
+
+        assert_eq!(
+            "unexpected operation response",
+            open_failed_reason(response)
+        );
+    }
+
+    #[test]
+    fn error_ack_fails_the_open_echoing_the_reason() {
+        const REASON: &str = "solana rejected the open";
+
+        let response = deliver(error_ack(REASON), CONTROLLER, &authorized_querier())
+            .expect("the error ack should fail the open");
+
+        assert_eq!(REASON, open_failed_reason(response));
+    }
+
+    #[test]
+    fn timeout_fails_the_open_with_the_timeout_reason() {
+        let response = deliver(timeout_ack(), CONTROLLER, &authorized_querier())
+            .expect("the timeout should fail the open");
+
+        assert_eq!("timeout", open_failed_reason(response));
+    }
+
+    #[test]
+    fn callback_from_unauthorized_sender_rejected() {
+        assert!(matches!(
+            deliver(open_lease_ack(), STRANGER, &rejecting_querier()),
+            Err(ContractError::Unauthorized(_))
+        ));
+    }
+
+    // The authorized ack clears the permission gate and reaches
+    // `on_open_lease_ack`, but `open_transport`'s max-slippages query fails, so
+    // the error propagates at that `?` instead of the funding leg starting.
+    #[test]
+    fn open_transport_query_failure_propagates() {
+        assert!(matches!(
+            deliver(
+                open_lease_ack(),
+                CONTROLLER,
+                &max_slippage_failing_querier()
+            ),
+            Err(ContractError::PositionLimitsQuery(_))
+        ));
+    }
+
+    fn deliver(
+        callback: RemoteLeaseCallback,
+        sender: &str,
+        querier: &MockQuerier<Empty>,
+    ) -> Result<Response, ContractError> {
+        open_lease().on_remote_lease_callback(
+            callback,
+            info(sender),
+            QuerierWrapper::new(querier),
+            testing::mock_env(),
+        )
+    }
+
+    fn open_failed_reason(response: Response) -> String {
+        let mock_querier = MockQuerier::<Empty>::default();
+        match response.next_state {
+            State::OpenFailed(failed) => match failed
+                .state(
+                    testing::mock_env().block.time.into_instant(),
+                    Duration::from_secs(0),
+                    QuerierWrapper::new(&mock_querier),
+                )
+                .expect("the open-failed state query succeeds")
+            {
+                QueryStateResponse::OpenFailed { reason } => reason.as_str().to_owned(),
+                _ => panic!("the open-failed state should report an OpenFailed response"),
+            },
+            _ => panic!("the callback should land the lease in OpenFailed"),
+        }
+    }
+
+    fn open_lease() -> OpenLease {
+        OpenLease::new(
+            new_lease_contract(),
+            Coin::<PaymentC1>::new(DOWNPAYMENT).into(),
+            OpenLoanRespResult {
+                principal: Coin::<LpnCurrency>::new(PRINCIPAL).into(),
+                annual_interest_rate: Percent100::from_percent(INTEREST_RATE_PERCENT),
+            },
+            deps(),
+            Instant::from_seconds(1_000_000),
+        )
+    }
+
+    fn open_lease_ack() -> RemoteLeaseCallback {
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::OpenLease(
+                OpenLeaseResponse {
+                    remote_lease_id: remote_lease_id(),
+                },
+            )),
+        }
+    }
+
+    fn unexpected_ok_ack() -> RemoteLeaseCallback {
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::TransferOut(
+                TransferOutResponse {},
+            )),
+        }
+    }
+
+    fn error_ack(reason: &str) -> RemoteLeaseCallback {
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(
+                RemoteErrorMessage::new(reason).expect("within the cap"),
+            ),
+        }
+    }
+
+    fn timeout_ack() -> RemoteLeaseCallback {
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationTimeout,
+        }
+    }
+
+    fn authorized_querier() -> MockQuerier<Empty> {
+        let mut mock_querier = MockQuerier::<Empty>::default();
+        mock_querier.update_wasm(answer_authorized_queries);
+        mock_querier
+    }
+
+    fn rejecting_querier() -> MockQuerier<Empty> {
+        let mut mock_querier = MockQuerier::<Empty>::default();
+        mock_querier.update_wasm(|query| {
+            let WasmQuery::Smart { msg, .. } = query else {
+                unimplemented!("only smart queries are expected")
+            };
+            let _: AccessCheck =
+                cosmwasm_std::from_json(msg).expect("a remote-lease callback permission query");
+            SystemResult::Ok(CwContractResult::Ok(
+                cosmwasm_std::to_json_binary(&AccessGranted::No)
+                    .expect("the verdict should serialize"),
+            ))
+        });
+        mock_querier
+    }
+
+    /// Grants the callback-permission check so the ack reaches
+    /// `on_open_lease_ack`, then fails the leaser's max-slippages query so
+    /// `open_transport` propagates the error rather than starting the funding
+    /// leg.
+    fn max_slippage_failing_querier() -> MockQuerier<Empty> {
+        let mut mock_querier = MockQuerier::<Empty>::default();
+        mock_querier.update_wasm(|query| {
+            let WasmQuery::Smart { contract_addr, msg } = query else {
+                unimplemented!("only smart queries are expected")
+            };
+            assert_eq!(LEASER, contract_addr.as_str());
+            if cosmwasm_std::from_json::<AccessCheck>(msg).is_ok() {
+                SystemResult::Ok(CwContractResult::Ok(
+                    cosmwasm_std::to_json_binary(&AccessGranted::Yes)
+                        .expect("the verdict should serialize"),
+                ))
+            } else {
+                let _: PositionLimits =
+                    cosmwasm_std::from_json(msg).expect("a max-slippages query");
+                SystemResult::Ok(CwContractResult::Err(
+                    "the leaser is unavailable".to_owned(),
+                ))
+            }
+        });
+        mock_querier
+    }
+
+    /// Answers every query the authorized open-failure and funding paths make:
+    /// the leaser's callback-permission grant and opening slippage bound, the
+    /// reserve's Lpn, and the LPP loan. The loan's interest was last paid at the
+    /// callback instant, so no interest is due and the reserve cover is skipped.
+    fn answer_authorized_queries(query: &WasmQuery) -> QuerierResult {
+        let WasmQuery::Smart { contract_addr, msg } = query else {
+            unimplemented!("only smart queries are expected")
+        };
+        let response = match contract_addr.as_str() {
+            LEASER => {
+                if cosmwasm_std::from_json::<AccessCheck>(msg).is_ok() {
+                    cosmwasm_std::to_json_binary(&AccessGranted::Yes)
+                } else {
+                    let _: PositionLimits =
+                        cosmwasm_std::from_json(msg).expect("a max-slippages query");
+                    cosmwasm_std::to_json_binary(&max_slippages())
+                }
+            }
+            RESERVE => cosmwasm_std::to_json_binary(&currency::dto::<LpnCurrency, LpnCurrencies>()),
+            LPP => cosmwasm_std::to_json_binary(&Some(loan_response())),
+            other => unimplemented!("no query is expected against {other}"),
+        }
+        .expect("the response should serialize");
+        SystemResult::Ok(CwContractResult::Ok(response))
+    }
+
+    fn max_slippages() -> MaxSlippages {
+        MaxSlippages {
+            opening: MaxSlippage::unchecked(Percent100::from_percent(MAX_SLIPPAGE_PERCENT)),
+            liquidation: MaxSlippage::unchecked(Percent100::from_percent(MAX_SLIPPAGE_PERCENT)),
+        }
+    }
+
+    fn loan_response() -> LoanResponse<LpnCurrency> {
+        LoanResponse {
+            principal_due: Coin::new(PRINCIPAL),
+            annual_interest_rate: Percent100::from_percent(INTEREST_RATE_PERCENT),
+            interest_paid: testing::mock_env().block.time.into_instant(),
+        }
+    }
+
+    fn new_lease_contract() -> NewLeaseContract {
+        NewLeaseContract {
+            form: form(),
+            dex: connection_params(),
+            finalizer: Addr::unchecked("finalizer"),
+            remote_lease_controller: Addr::unchecked(CONTROLLER),
+            expected_instance_ordinal: INSTANCE_ORDINAL,
+        }
+    }
+
+    fn form() -> NewLeaseForm {
+        NewLeaseForm {
+            customer: Addr::unchecked("customer"),
+            currency: currency::dto::<LeaseC2, _>(),
+            max_ltd: None,
+            position_spec: PositionSpecDTO::new(
+                liability(),
+                Coin::<LpnCurrency>::new(1_000).into(),
+                Coin::<LpnCurrency>::new(100).into(),
+            ),
+            loan: LoanForm {
+                lpp: Addr::unchecked(LPP),
+                profit: Addr::unchecked("profit"),
+                annual_margin_interest: Percent100::from_permille(31),
+                due_period: Duration::from_secs(100),
+            },
+            reserve: Addr::unchecked(RESERVE),
+            time_alarms: Addr::unchecked("timealarms"),
+            market_price_oracle: Addr::unchecked("oracle"),
+        }
+    }
+
+    fn liability() -> Liability {
+        Liability::new(
+            Percent100::from_percent(65),
+            Percent100::from_percent(70),
+            Percent100::from_percent(73),
+            Percent100::from_percent(75),
+            Percent100::from_percent(78),
+            Percent100::from_percent(80),
+            Duration::from_days(20),
+        )
+    }
+
+    fn deps() -> (
+        LppGenericRef<LpnCurrency>,
+        OracleRef,
+        TimeAlarmsRef,
+        LeasesRef,
+    ) {
+        (
+            LppGenericRef::unchecked(LPP),
+            OracleRef::unchecked(Addr::unchecked("oracle")),
+            TimeAlarmsRef::unchecked("timealarms"),
+            LeasesRef::unchecked(Addr::unchecked(LEASER)),
+        )
+    }
+
+    fn connection_params() -> ConnectionParams {
+        ConnectionParams {
+            connection_id: "connection-0".to_owned(),
+            transfer_channel: Ics20Channel {
+                local_endpoint: "channel-0".to_owned(),
+                remote_endpoint: "channel-2048".to_owned(),
+            },
+        }
+    }
+
+    fn remote_lease_id() -> RemoteLeaseId {
+        RemoteLeaseId::new(REMOTE_LEASE_ID.to_owned()).expect("a base58 sample")
+    }
+
+    fn info(sender: &str) -> MessageInfo {
+        MessageInfo {
+            sender: Addr::unchecked(sender),
+            funds: vec![],
+        }
+    }
+}
+
 /// Open-failure reason recorded when the IBC layer reports the OpenLease
 /// packet was never acknowledged.
 const TIMEOUT_REASON: &str = "timeout";
@@ -242,364 +603,3 @@ enum ControllerExecuteMsg {
 }
 
 impl ControllerInnerMessage for ControllerExecuteMsg {}
-
-#[cfg(all(feature = "internal.test.contract", test))]
-mod tests {
-    use currencies::testing::{LeaseC2, PaymentC1};
-    use cw_time::IntoInstant;
-    use dex::{ConnectionParams, Ics20Channel, MaxSlippage};
-    use finance::{
-        coin::Coin, duration::Duration, instant::Instant, liability::Liability, percent::Percent100,
-    };
-    use lpp::{msg::LoanResponse, stub::LppRef as LppGenericRef};
-    use remote_lease::{
-        callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
-        response::{OpenLeaseResponse, RemoteLeaseId, TransferOutResponse, WireOperationResponse},
-    };
-    use sdk::cosmwasm_std::{
-        self, Addr, ContractResult as CwContractResult, Empty, MessageInfo, QuerierResult,
-        QuerierWrapper, SystemResult, WasmQuery,
-        testing::{self, MockQuerier},
-    };
-    use timealarms::stub::TimeAlarmsRef;
-
-    use crate::{
-        api::{
-            authz::{AccessCheck, AccessGranted},
-            limits::{MaxSlippages, PositionLimits},
-            open::{LoanForm, NewLeaseContract, NewLeaseForm, PositionSpecDTO},
-            query::StateResponse as QueryStateResponse,
-        },
-        contract::{
-            api::Contract,
-            cmd::OpenLoanRespResult,
-            finalize::LeasesRef,
-            state::{Response, State},
-        },
-        error::ContractError,
-        finance::{LpnCurrencies, LpnCurrency, OracleRef},
-    };
-
-    use super::OpenLease;
-
-    const CONTROLLER: &str = "controller";
-    const LEASER: &str = "leaser";
-    const LPP: &str = "lpp";
-    const RESERVE: &str = "reserve";
-    const STRANGER: &str = "stranger";
-    const REMOTE_LEASE_ID: &str = "StubPda1111111111111111111111111111";
-    const DOWNPAYMENT: u128 = 100;
-    const PRINCIPAL: u128 = 500;
-    const INTEREST_RATE_PERCENT: u32 = 5;
-    const MAX_SLIPPAGE_PERCENT: u32 = 20;
-    const INSTANCE_ORDINAL: u16 = 1;
-
-    #[test]
-    fn open_lease_ack_starts_the_funding_leg() {
-        let response = deliver(open_lease_ack(), CONTROLLER, &authorized_querier())
-            .expect("the open-lease ack should start funding");
-
-        assert!(matches!(response.next_state, State::BuyAsset(_)));
-    }
-
-    #[test]
-    fn unexpected_ok_ack_fails_the_open_with_a_fixed_reason() {
-        let response = deliver(unexpected_ok_ack(), CONTROLLER, &authorized_querier())
-            .expect("the unexpected ack should fail the open");
-
-        assert_eq!(
-            "unexpected operation response",
-            open_failed_reason(response)
-        );
-    }
-
-    #[test]
-    fn error_ack_fails_the_open_echoing_the_reason() {
-        const REASON: &str = "solana rejected the open";
-
-        let response = deliver(error_ack(REASON), CONTROLLER, &authorized_querier())
-            .expect("the error ack should fail the open");
-
-        assert_eq!(REASON, open_failed_reason(response));
-    }
-
-    #[test]
-    fn timeout_fails_the_open_with_the_timeout_reason() {
-        let response = deliver(timeout_ack(), CONTROLLER, &authorized_querier())
-            .expect("the timeout should fail the open");
-
-        assert_eq!("timeout", open_failed_reason(response));
-    }
-
-    #[test]
-    fn callback_from_unauthorized_sender_rejected() {
-        assert!(matches!(
-            deliver(open_lease_ack(), STRANGER, &rejecting_querier()),
-            Err(ContractError::Unauthorized(_))
-        ));
-    }
-
-    // The authorized ack clears the permission gate and reaches
-    // `on_open_lease_ack`, but `open_transport`'s max-slippages query fails, so
-    // the error propagates at that `?` instead of the funding leg starting.
-    #[test]
-    fn open_transport_query_failure_propagates() {
-        assert!(matches!(
-            deliver(
-                open_lease_ack(),
-                CONTROLLER,
-                &max_slippage_failing_querier()
-            ),
-            Err(ContractError::PositionLimitsQuery(_))
-        ));
-    }
-
-    fn deliver(
-        callback: RemoteLeaseCallback,
-        sender: &str,
-        querier: &MockQuerier<Empty>,
-    ) -> Result<Response, ContractError> {
-        open_lease().on_remote_lease_callback(
-            callback,
-            info(sender),
-            QuerierWrapper::new(querier),
-            testing::mock_env(),
-        )
-    }
-
-    fn open_failed_reason(response: Response) -> String {
-        let mock_querier = MockQuerier::<Empty>::default();
-        match response.next_state {
-            State::OpenFailed(failed) => match failed
-                .state(
-                    testing::mock_env().block.time.into_instant(),
-                    Duration::from_secs(0),
-                    QuerierWrapper::new(&mock_querier),
-                )
-                .expect("the open-failed state query succeeds")
-            {
-                QueryStateResponse::OpenFailed { reason } => reason.as_str().to_owned(),
-                _ => panic!("the open-failed state should report an OpenFailed response"),
-            },
-            _ => panic!("the callback should land the lease in OpenFailed"),
-        }
-    }
-
-    fn open_lease() -> OpenLease {
-        OpenLease::new(
-            new_lease_contract(),
-            Coin::<PaymentC1>::new(DOWNPAYMENT).into(),
-            OpenLoanRespResult {
-                principal: Coin::<LpnCurrency>::new(PRINCIPAL).into(),
-                annual_interest_rate: Percent100::from_percent(INTEREST_RATE_PERCENT),
-            },
-            deps(),
-            Instant::from_seconds(1_000_000),
-        )
-    }
-
-    fn open_lease_ack() -> RemoteLeaseCallback {
-        RemoteLeaseCallback {
-            nonce: 0,
-            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::OpenLease(
-                OpenLeaseResponse {
-                    remote_lease_id: remote_lease_id(),
-                },
-            )),
-        }
-    }
-
-    fn unexpected_ok_ack() -> RemoteLeaseCallback {
-        RemoteLeaseCallback {
-            nonce: 0,
-            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::TransferOut(
-                TransferOutResponse {},
-            )),
-        }
-    }
-
-    fn error_ack(reason: &str) -> RemoteLeaseCallback {
-        RemoteLeaseCallback {
-            nonce: 0,
-            outcome: RemoteOperationOutcome::OperationErr(
-                RemoteErrorMessage::new(reason).expect("within the cap"),
-            ),
-        }
-    }
-
-    fn timeout_ack() -> RemoteLeaseCallback {
-        RemoteLeaseCallback {
-            nonce: 0,
-            outcome: RemoteOperationOutcome::OperationTimeout,
-        }
-    }
-
-    fn authorized_querier() -> MockQuerier<Empty> {
-        let mut mock_querier = MockQuerier::<Empty>::default();
-        mock_querier.update_wasm(authorized_handler);
-        mock_querier
-    }
-
-    fn rejecting_querier() -> MockQuerier<Empty> {
-        let mut mock_querier = MockQuerier::<Empty>::default();
-        mock_querier.update_wasm(|query| {
-            let WasmQuery::Smart { msg, .. } = query else {
-                unimplemented!("only smart queries are expected")
-            };
-            let _: AccessCheck =
-                cosmwasm_std::from_json(msg).expect("a remote-lease callback permission query");
-            SystemResult::Ok(CwContractResult::Ok(
-                cosmwasm_std::to_json_binary(&AccessGranted::No)
-                    .expect("the verdict should serialize"),
-            ))
-        });
-        mock_querier
-    }
-
-    /// Grants the callback-permission check so the ack reaches
-    /// `on_open_lease_ack`, then fails the leaser's max-slippages query so
-    /// `open_transport` propagates the error rather than starting the funding
-    /// leg.
-    fn max_slippage_failing_querier() -> MockQuerier<Empty> {
-        let mut mock_querier = MockQuerier::<Empty>::default();
-        mock_querier.update_wasm(|query| {
-            let WasmQuery::Smart { contract_addr, msg } = query else {
-                unimplemented!("only smart queries are expected")
-            };
-            assert_eq!(LEASER, contract_addr.as_str());
-            if cosmwasm_std::from_json::<AccessCheck>(msg).is_ok() {
-                SystemResult::Ok(CwContractResult::Ok(
-                    cosmwasm_std::to_json_binary(&AccessGranted::Yes)
-                        .expect("the verdict should serialize"),
-                ))
-            } else {
-                let _: PositionLimits =
-                    cosmwasm_std::from_json(msg).expect("a max-slippages query");
-                SystemResult::Ok(CwContractResult::Err(
-                    "the leaser is unavailable".to_owned(),
-                ))
-            }
-        });
-        mock_querier
-    }
-
-    /// Answers every query the authorized open-failure and funding paths make:
-    /// the leaser's callback-permission grant and opening slippage bound, the
-    /// reserve's Lpn, and the LPP loan. The loan's interest was last paid at the
-    /// callback instant, so no interest is due and the reserve cover is skipped.
-    fn authorized_handler(query: &WasmQuery) -> QuerierResult {
-        let WasmQuery::Smart { contract_addr, msg } = query else {
-            unimplemented!("only smart queries are expected")
-        };
-        let response = match contract_addr.as_str() {
-            LEASER => {
-                if cosmwasm_std::from_json::<AccessCheck>(msg).is_ok() {
-                    cosmwasm_std::to_json_binary(&AccessGranted::Yes)
-                } else {
-                    let _: PositionLimits =
-                        cosmwasm_std::from_json(msg).expect("a max-slippages query");
-                    cosmwasm_std::to_json_binary(&max_slippages())
-                }
-            }
-            RESERVE => cosmwasm_std::to_json_binary(&currency::dto::<LpnCurrency, LpnCurrencies>()),
-            LPP => cosmwasm_std::to_json_binary(&Some(loan_response())),
-            other => unimplemented!("no query is expected against {other}"),
-        }
-        .expect("the response should serialize");
-        SystemResult::Ok(CwContractResult::Ok(response))
-    }
-
-    fn max_slippages() -> MaxSlippages {
-        MaxSlippages {
-            opening: MaxSlippage::unchecked(Percent100::from_percent(MAX_SLIPPAGE_PERCENT)),
-            liquidation: MaxSlippage::unchecked(Percent100::from_percent(MAX_SLIPPAGE_PERCENT)),
-        }
-    }
-
-    fn loan_response() -> LoanResponse<LpnCurrency> {
-        LoanResponse {
-            principal_due: Coin::new(PRINCIPAL),
-            annual_interest_rate: Percent100::from_percent(INTEREST_RATE_PERCENT),
-            interest_paid: testing::mock_env().block.time.into_instant(),
-        }
-    }
-
-    fn new_lease_contract() -> NewLeaseContract {
-        NewLeaseContract {
-            form: form(),
-            dex: connection_params(),
-            finalizer: Addr::unchecked("finalizer"),
-            remote_lease_controller: Addr::unchecked(CONTROLLER),
-            expected_instance_ordinal: INSTANCE_ORDINAL,
-        }
-    }
-
-    fn form() -> NewLeaseForm {
-        NewLeaseForm {
-            customer: Addr::unchecked("customer"),
-            currency: currency::dto::<LeaseC2, _>(),
-            max_ltd: None,
-            position_spec: PositionSpecDTO::new(
-                liability(),
-                Coin::<LpnCurrency>::new(1_000).into(),
-                Coin::<LpnCurrency>::new(100).into(),
-            ),
-            loan: LoanForm {
-                lpp: Addr::unchecked(LPP),
-                profit: Addr::unchecked("profit"),
-                annual_margin_interest: Percent100::from_permille(31),
-                due_period: Duration::from_secs(100),
-            },
-            reserve: Addr::unchecked(RESERVE),
-            time_alarms: Addr::unchecked("timealarms"),
-            market_price_oracle: Addr::unchecked("oracle"),
-        }
-    }
-
-    fn liability() -> Liability {
-        Liability::new(
-            Percent100::from_percent(65),
-            Percent100::from_percent(70),
-            Percent100::from_percent(73),
-            Percent100::from_percent(75),
-            Percent100::from_percent(78),
-            Percent100::from_percent(80),
-            Duration::from_days(20),
-        )
-    }
-
-    fn deps() -> (
-        LppGenericRef<LpnCurrency>,
-        OracleRef,
-        TimeAlarmsRef,
-        LeasesRef,
-    ) {
-        (
-            LppGenericRef::unchecked(LPP),
-            OracleRef::unchecked(Addr::unchecked("oracle")),
-            TimeAlarmsRef::unchecked("timealarms"),
-            LeasesRef::unchecked(Addr::unchecked(LEASER)),
-        )
-    }
-
-    fn connection_params() -> ConnectionParams {
-        ConnectionParams {
-            connection_id: "connection-0".to_owned(),
-            transfer_channel: Ics20Channel {
-                local_endpoint: "channel-0".to_owned(),
-                remote_endpoint: "channel-2048".to_owned(),
-            },
-        }
-    }
-
-    fn remote_lease_id() -> RemoteLeaseId {
-        RemoteLeaseId::new(REMOTE_LEASE_ID.to_owned()).expect("a base58 sample")
-    }
-
-    fn info(sender: &str) -> MessageInfo {
-        MessageInfo {
-            sender: Addr::unchecked(sender),
-            funds: vec![],
-        }
-    }
-}

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -339,6 +339,21 @@ mod tests {
         ));
     }
 
+    // The authorized ack clears the permission gate and reaches
+    // `on_open_lease_ack`, but `open_transport`'s max-slippages query fails, so
+    // the error propagates at that `?` instead of the funding leg starting.
+    #[test]
+    fn open_transport_query_failure_propagates() {
+        assert!(matches!(
+            deliver(
+                open_lease_ack(),
+                CONTROLLER,
+                &max_slippage_failing_querier()
+            ),
+            Err(ContractError::PositionLimitsQuery(_))
+        ));
+    }
+
     fn deliver(
         callback: RemoteLeaseCallback,
         sender: &str,
@@ -437,6 +452,33 @@ mod tests {
                 cosmwasm_std::to_json_binary(&AccessGranted::No)
                     .expect("the verdict should serialize"),
             ))
+        });
+        mock_querier
+    }
+
+    /// Grants the callback-permission check so the ack reaches
+    /// `on_open_lease_ack`, then fails the leaser's max-slippages query so
+    /// `open_transport` propagates the error rather than starting the funding
+    /// leg.
+    fn max_slippage_failing_querier() -> MockQuerier<Empty> {
+        let mut mock_querier = MockQuerier::<Empty>::default();
+        mock_querier.update_wasm(|query| {
+            let WasmQuery::Smart { contract_addr, msg } = query else {
+                unimplemented!("only smart queries are expected")
+            };
+            assert_eq!(LEASER, contract_addr.as_str());
+            if cosmwasm_std::from_json::<AccessCheck>(msg).is_ok() {
+                SystemResult::Ok(CwContractResult::Ok(
+                    cosmwasm_std::to_json_binary(&AccessGranted::Yes)
+                        .expect("the verdict should serialize"),
+                ))
+            } else {
+                let _: PositionLimits =
+                    cosmwasm_std::from_json(msg).expect("a max-slippages query");
+                SystemResult::Ok(CwContractResult::Err(
+                    "the leaser is unavailable".to_owned(),
+                ))
+            }
         });
         mock_querier
     }

--- a/tests/src/lease/remote_lease_callback.rs
+++ b/tests/src/lease/remote_lease_callback.rs
@@ -34,7 +34,7 @@ use crate::{
         remote_lease_controller_stub::{self as stub, ResponseMode, op_tag},
         test_case::app::App,
     },
-    lease::{LeaseCoin, LeaseCurrency, LpnCoin, LpnCurrency},
+    lease::{LeaseCoin, LeaseCurrency, LpnCoin, LpnCurrency, PaymentCurrency},
 };
 
 type LeaseTestCase = super::TestCase<Addr, Addr, Addr, Addr, Addr, Addr, Addr, Addr>;
@@ -145,6 +145,43 @@ fn non_swap_operation_ok_is_absorbed() {
         "unexpected-response-variant",
     );
     assert_swap_pending(&test_case, lease);
+}
+
+// Round-2 #644 backfill: a fully-opened, active lease has no in-flight remote
+// operation and no override for `on_remote_lease_callback`, so the lease
+// `Handler` default rejects the callback as an unsupported operation — even one
+// from the pinned controller. This pins today's contract; the reverting-ack
+// behaviour on a genuinely-late callback is a known soundness-review candidate.
+#[test]
+fn active_lease_rejects_remote_callback_as_unsupported() {
+    let mut test_case = super::create_test_case::<PaymentCurrency>();
+    let lease = super::open_lease(&mut test_case, super::DOWNPAYMENT, None);
+    assert!(
+        matches!(
+            super::state_query(&test_case, lease.clone()),
+            StateResponse::Opened { .. }
+        ),
+        "the lease must sit active before the callback"
+    );
+
+    let controller = controller_addr(&test_case);
+    let err = send_callback(
+        &mut test_case.app,
+        &lease,
+        controller,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationTimeout,
+        },
+    );
+
+    let contract_err = err
+        .downcast_ref::<ContractError>()
+        .expect("must surface as lease ContractError");
+    assert!(
+        matches!(contract_err, ContractError::UnsupportedOperation(_)),
+        "expected UnsupportedOperation, got {contract_err:?}"
+    );
 }
 
 fn drive_to_swap_pending() -> (LeaseTestCase, Addr) {

--- a/tests/src/lease/remote_lease_callback.rs
+++ b/tests/src/lease/remote_lease_callback.rs
@@ -147,7 +147,7 @@ fn non_swap_operation_ok_is_absorbed() {
     assert_swap_pending(&test_case, lease);
 }
 
-// Round-2 #644 backfill: a fully-opened, active lease has no in-flight remote
+// A fully-opened, active lease has no in-flight remote
 // operation and no override for `on_remote_lease_callback`, so the lease
 // `Handler` default rejects the callback as an unsupported operation — even one
 // from the pinned controller. This pins today's contract; the reverting-ack

--- a/tests/src/lease/remote_lease_open.rs
+++ b/tests/src/lease/remote_lease_open.rs
@@ -1,19 +1,25 @@
 //! Open-lifecycle E2E for the remote-lease lifecycle: happy path,
-//! `OperationErr` auto-refund, and late-ack absorber on the `OpenFailed`
-//! terminal. Targets the post-refactor query surface (`StateResponse::
-//! OpenFailed`, `OngoingTrx::OpenLease`) and the
-//! `wasm-remote-lease-open-failed` / `wasm-remote-lease-late-ack` events.
+//! `OperationErr` and `OperationTimeout` auto-refund, late-ack absorber on
+//! the `OpenFailed` terminal, and unauthorized-caller rejection at the
+//! in-flight `OpenLease` and terminal `OpenFailed` callback boundaries.
+//! Targets the post-refactor query surface (`StateResponse::OpenFailed`,
+//! `OngoingTrx::OpenLease`) and the `wasm-remote-lease-open-failed` /
+//! `wasm-remote-lease-late-ack` events.
 
 use crate::common::testing;
 use crate::common::{
     self, USER,
     remote_lease_controller_stub::{self as stub, ResponseMode, op_tag},
 };
+use access_control::error::Error as AccessError;
 use currencies::Lpn;
 use finance::coin::Coin;
-use lease::api::{
-    ExecuteMsg,
-    query::{StateResponse, opening::OngoingTrx as OpeningOngoingTrx},
+use lease::{
+    api::{
+        ExecuteMsg,
+        query::{StateResponse, opening::OngoingTrx as OpeningOngoingTrx},
+    },
+    error::ContractError,
 };
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
@@ -24,6 +30,10 @@ use sdk::cosmwasm_std::Addr;
 use super::{LeaseCoin, LeaseCurrency};
 
 const DOWNPAYMENT: LeaseCoin = LeaseCoin::new(10_000);
+
+/// The reason the `OpenLease` timeout arm records — mirrors the production
+/// `open_lease::TIMEOUT_REASON`.
+const TIMEOUT_REASON: &str = "timeout";
 
 #[test]
 fn open_lifecycle_happy_path() {
@@ -274,6 +284,194 @@ fn late_open_lease_ack_after_open_failed_is_absorbed() {
         } => assert_eq!(reason.as_str(), state_reason.as_str()),
         other => panic!("expected StateResponse::OpenFailed, got {other:?}"),
     }
+}
+
+#[test]
+fn open_failed_on_timeout_refunds_and_finalises() {
+    let mut test_case = super::create_test_case::<LeaseCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    let leaser = test_case.address_book.leaser().clone();
+    // Hold the lease pre-ack in `OpenLease` so the timeout below reaches the
+    // in-flight OpenLease operation rather than the auto-synthesised happy path.
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::OPEN_LEASE,
+        ResponseMode::Delayed,
+    );
+
+    let customer = testing::user(USER);
+    let balance_before = balance::<LeaseCurrency>(&test_case, &customer);
+
+    let response = test_case
+        .app
+        .execute(
+            customer.clone(),
+            leaser.clone(),
+            &leaser::msg::ExecuteMsg::OpenLease {
+                currency: currency::dto::<LeaseCurrency, _>(),
+                max_ltd: None,
+            },
+            &[common::cwcoin::<LeaseCurrency>(DOWNPAYMENT)],
+        )
+        .unwrap()
+        .unwrap_response();
+
+    let lease = lease_address_from(&response.events).expect("instantiate event carries the addr");
+
+    // The IBC layer reports the OpenLease packet was never acknowledged; the
+    // lease must refund and finalise exactly as it does on an `OperationErr`.
+    let timeout = RemoteLeaseCallback {
+        nonce: 0,
+        outcome: RemoteOperationOutcome::OperationTimeout,
+    };
+    let failed = test_case
+        .app
+        .execute(
+            controller.clone(),
+            lease.clone(),
+            &ExecuteMsg::RemoteLeaseCallback(timeout),
+            &[],
+        )
+        .expect("a timeout must be absorbed as an open failure")
+        .unwrap_response();
+
+    let event_reason = failed
+        .events
+        .iter()
+        .find(|event| event.ty == "wasm-ls-remote-lease-open-failed")
+        .and_then(|event| event.attributes.iter().find(|attr| attr.key == "reason"))
+        .map(|attr| attr.value.as_str())
+        .expect("a timeout must emit the open-failed event with a reason");
+    assert_eq!(TIMEOUT_REASON, event_reason);
+
+    let balance_after = balance::<LeaseCurrency>(&test_case, &customer);
+    assert_eq!(
+        balance_before, balance_after,
+        "downpayment must be refunded in full",
+    );
+
+    let leases = leases_of(&test_case, &leaser, &customer);
+    assert!(leases.is_empty(), "leaser must show no live lease");
+
+    match super::state_query(&test_case, lease) {
+        StateResponse::OpenFailed { reason } => assert_eq!(TIMEOUT_REASON, reason.as_str()),
+        other => panic!("expected StateResponse::OpenFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn open_lease_callback_from_stranger_rejected() {
+    let mut test_case = super::create_test_case::<LeaseCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    let leaser = test_case.address_book.leaser().clone();
+    // Hold the lease pre-ack in `OpenLease` so the stranger's callback lands on
+    // the in-flight OpenLease operation.
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::OPEN_LEASE,
+        ResponseMode::Delayed,
+    );
+
+    let customer = testing::user(USER);
+    let response = test_case
+        .app
+        .execute(
+            customer.clone(),
+            leaser.clone(),
+            &leaser::msg::ExecuteMsg::OpenLease {
+                currency: currency::dto::<LeaseCurrency, _>(),
+                max_ltd: None,
+            },
+            &[common::cwcoin::<LeaseCurrency>(DOWNPAYMENT)],
+        )
+        .unwrap()
+        .unwrap_response();
+
+    let lease = lease_address_from(&response.events).expect("instantiate event carries the addr");
+
+    let err = test_case
+        .app
+        .execute(
+            testing::user(USER),
+            lease.clone(),
+            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback {
+                nonce: 0,
+                outcome: RemoteOperationOutcome::OperationTimeout,
+            }),
+            &[],
+        )
+        .expect_err("a stranger's open-lease callback must be rejected");
+
+    let contract_err = err
+        .downcast_ref::<ContractError>()
+        .expect("must surface as lease ContractError");
+    assert!(
+        matches!(
+            contract_err,
+            ContractError::Unauthorized(AccessError::Unauthorized {})
+        ),
+        "expected ContractError::Unauthorized, got {contract_err:?}"
+    );
+}
+
+#[test]
+fn open_failed_late_ack_from_stranger_rejected() {
+    let mut test_case = super::create_test_case::<LeaseCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    let leaser = test_case.address_book.leaser().clone();
+    let reason = RemoteErrorMessage::new("solana side rejected").expect("within length cap");
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::OPEN_LEASE,
+        ResponseMode::Err(reason),
+    );
+
+    let customer = testing::user(USER);
+    let response = test_case
+        .app
+        .execute(
+            customer.clone(),
+            leaser.clone(),
+            &leaser::msg::ExecuteMsg::OpenLease {
+                currency: currency::dto::<LeaseCurrency, _>(),
+                max_ltd: None,
+            },
+            &[common::cwcoin::<LeaseCurrency>(DOWNPAYMENT)],
+        )
+        .unwrap()
+        .unwrap_response();
+
+    let lease = lease_address_from(&response.events).expect("instantiate event carries the addr");
+
+    // The Err mode already drove the lease to the `OpenFailed` terminal; a
+    // stranger's late ack is rejected by the same auth gate the in-flight
+    // states use, before the late-ack absorber can run.
+    let err = test_case
+        .app
+        .execute(
+            testing::user(USER),
+            lease.clone(),
+            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback {
+                nonce: 0,
+                outcome: RemoteOperationOutcome::OperationTimeout,
+            }),
+            &[],
+        )
+        .expect_err("a stranger's late ack must be rejected");
+
+    let contract_err = err
+        .downcast_ref::<ContractError>()
+        .expect("must surface as lease ContractError");
+    assert!(
+        matches!(
+            contract_err,
+            ContractError::Unauthorized(AccessError::Unauthorized {})
+        ),
+        "expected ContractError::Unauthorized, got {contract_err:?}"
+    );
 }
 
 fn balance<C>(test_case: &super::LeaseTestCase, account: &Addr) -> Coin<C>

--- a/tests/src/lease/remote_lease_open_unwind.rs
+++ b/tests/src/lease/remote_lease_open_unwind.rs
@@ -47,10 +47,21 @@
 //!   drain window the LPP loan accrues interest; after the unwind the loan is
 //!   CLOSED (`principal_due == 0` / loan absent), proving the reserve covered
 //!   the interest and the full principal was repaid.
+//! - `unwind_drain_callback_from_stranger_rejected` - a stranger's callback on
+//!   the in-flight unwind drain is rejected by the pinned-controller auth gate
+//!   (`SingleUserPermission`), and the drain stays `Unwinding`.
 
+use access_control::error::Error as AccessError;
 use currencies::Lpn;
+use dex::Error as DexError;
 use finance::{coin::Coin, duration::Duration};
-use lease::api::query::{StateResponse, opening::OngoingTrx as OpeningOngoingTrx};
+use lease::{
+    api::{
+        ExecuteMsg,
+        query::{StateResponse, opening::OngoingTrx as OpeningOngoingTrx},
+    },
+    error::ContractError,
+};
 use remote_lease::callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome};
 use sdk::cosmwasm_std::{Addr, Event};
 
@@ -286,6 +297,52 @@ fn unwind_over_nonzero_window_closes_lpp_loan() {
         loan_of(&test_case, &lease).is_none(),
         "the LPP loan must be CLOSED after the reserve-covered full repay",
     );
+}
+
+// === auth: a stranger's unwind-drain callback is rejected ===============
+
+/// A stranger's callback on the in-flight OpeningUnwind drain is rejected by
+/// the pinned-controller auth gate (`SingleUserPermission`), surfacing the
+/// same `DexError::Unauthorized` shape the paid-close drain does, and the
+/// in-flight drain leg stays `Unwinding`.
+#[test]
+fn unwind_drain_callback_from_stranger_rejected() {
+    let (mut test_case, lease, controller) = start_opening_leg_one_in_flight();
+
+    // hold the first drain transfer-out in flight
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::TRANSFER_OUT,
+        ResponseMode::Delayed,
+    );
+    inject_opening_error(&mut test_case, &controller, &lease, "leg one under floor");
+    assert_unwinding(&test_case, &lease);
+
+    let err = test_case
+        .app
+        .execute(
+            crate::common::testing::user(USER),
+            lease.clone(),
+            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback {
+                nonce: 0,
+                outcome: RemoteOperationOutcome::OperationTimeout,
+            }),
+            &[],
+        )
+        .expect_err("a stranger's unwind-drain callback must be rejected");
+
+    let contract_err = err
+        .downcast_ref::<ContractError>()
+        .expect("must surface as lease ContractError");
+    assert!(
+        matches!(
+            contract_err,
+            ContractError::DexError(DexError::Unauthorized(AccessError::Unauthorized {}))
+        ),
+        "expected DexError::Unauthorized, got {contract_err:?}"
+    );
+    assert_unwinding(&test_case, &lease);
 }
 
 // === drivers ============================================================

--- a/tests/src/lease/remote_lease_swap.rs
+++ b/tests/src/lease/remote_lease_swap.rs
@@ -517,7 +517,7 @@ fn opening_swap_pins_the_opening_bound() {
 // A decodable success ack whose output is a valid lease asset but not the
 // opening's output currency is absorbed at deliver-ack's currency guard, before
 // the amount is inspected. The behaviour already ships; this closes the arm's
-// integration gap (#644).
+// integration gap.
 #[test]
 fn opening_swap_out_currency_mismatch_absorbed() {
     const MISMATCHED_OUTPUT: u128 = 1_000_000;

--- a/tests/src/lease/remote_lease_swap.rs
+++ b/tests/src/lease/remote_lease_swap.rs
@@ -49,10 +49,10 @@
 //! - `opening_swap_out_currency_mismatch_absorbed` — a success ack in a valid
 //!   lease-asset currency that is not the opening's output currency trips the
 //!   deliver-ack currency guard and is absorbed (`out-currency-mismatch`); the
-//!   leg countdown does not advance (round-2 #644 backfill).
+//!   leg countdown does not advance.
 //! - `opening_swap_stale_nonce_timeout_absorbed` — a timeout callback carrying a
 //!   superseded nonce is absorbed (`nonce-mismatch`) before the timeout arm, so
-//!   the in-flight leg is neither re-emitted nor advanced (round-2 #644 backfill).
+//!   the in-flight leg is neither re-emitted nor advanced.
 
 use crate::common::testing;
 use currencies::{PaymentGroup, testing::LeaseC1};

--- a/tests/src/lease/remote_lease_swap.rs
+++ b/tests/src/lease/remote_lease_swap.rs
@@ -46,9 +46,16 @@
 //! - `heal_race_original_ack_absorbed` — a `Heal()` re-emits with a fresh
 //!   nonce; the original packet's late ack (old nonce) is absorbed while the
 //!   healed re-emission's ack (new nonce) credits exactly once (#636).
+//! - `opening_swap_out_currency_mismatch_absorbed` — a success ack in a valid
+//!   lease-asset currency that is not the opening's output currency trips the
+//!   deliver-ack currency guard and is absorbed (`out-currency-mismatch`); the
+//!   leg countdown does not advance (round-2 #644 backfill).
+//! - `opening_swap_stale_nonce_timeout_absorbed` — a timeout callback carrying a
+//!   superseded nonce is absorbed (`nonce-mismatch`) before the timeout arm, so
+//!   the in-flight leg is neither re-emitted nor advanced (round-2 #644 backfill).
 
 use crate::common::testing;
-use currencies::PaymentGroup;
+use currencies::{PaymentGroup, testing::LeaseC1};
 use currency::{CurrencyDef, MemberOf};
 use dex::MaxSlippage;
 use finance::{
@@ -505,6 +512,79 @@ fn opening_swap_pins_the_opening_bound() {
 
     assert_eq!(&opening_floor, swaps[1].min_out());
     assert_ne!(&liquidation_floor, swaps[1].min_out());
+}
+
+// A decodable success ack whose output is a valid lease asset but not the
+// opening's output currency is absorbed at deliver-ack's currency guard, before
+// the amount is inspected. The behaviour already ships; this closes the arm's
+// integration gap (#644).
+#[test]
+fn opening_swap_out_currency_mismatch_absorbed() {
+    const MISMATCHED_OUTPUT: u128 = 1_000_000;
+
+    let (mut test_case, lease, controller) = start_open(DOWNPAYMENT);
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+    // Consumed when the first swap leg is emitted, so its pending ack pays a
+    // lease-asset currency (LeaseC1) other than the opening's output (LeaseC2).
+    stub::set_next_swap_output(
+        &mut test_case.app,
+        &controller,
+        Coin::<LeaseC1>::new(MISMATCHED_OUTPUT).into(),
+    );
+
+    let _response = transfer_funds(&mut test_case, &lease, DOWNPAYMENT);
+    assert_eq!(2, opening_acks_left(&test_case, lease.clone()));
+
+    let absorbed = stub::deliver_pending_callback(&mut test_case.app, &controller, op_tag::SWAP);
+    expect_attribute(
+        &absorbed.events,
+        OPENING_SWAP_EVENT,
+        "absorbed",
+        "out-currency-mismatch",
+    );
+    assert_eq!(2, opening_acks_left(&test_case, lease.clone()));
+}
+
+// A timeout callback carrying a superseded nonce is rejected by the nonce gate
+// before the timeout retry arm, so the in-flight leg is neither re-emitted nor
+// advanced. The behaviour already ships; this closes the arm's integration gap.
+#[test]
+fn opening_swap_stale_nonce_timeout_absorbed() {
+    let (mut test_case, lease, controller) = start_open(DOWNPAYMENT);
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+
+    let _response = transfer_funds(&mut test_case, &lease, DOWNPAYMENT);
+    assert_eq!(2, opening_acks_left(&test_case, lease.clone()));
+
+    let in_flight = stub::recorded_swap_nonces(&test_case.app, &controller, &lease)
+        .last()
+        .copied()
+        .expect("the in-flight swap leg recorded a nonce");
+    let stale = in_flight - 1;
+    let absorbed = stub::inject_callback_with_nonce(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        stale,
+        RemoteOperationOutcome::OperationTimeout,
+    );
+    expect_attribute(
+        &absorbed.events,
+        OPENING_SWAP_EVENT,
+        "absorbed",
+        "nonce-mismatch",
+    );
+    assert_eq!(2, opening_acks_left(&test_case, lease.clone()));
 }
 
 fn set_opening_slippage(test_case: &mut LeaseTestCase, opening: Percent100) {

--- a/tests/src/lease/remote_lease_transfer_out.rs
+++ b/tests/src/lease/remote_lease_transfer_out.rs
@@ -41,7 +41,7 @@
 //!   authorises callbacks against the same pinned controller; a stranger
 //!   is rejected and the in-flight transfer stays put.
 //!
-//! Absorb-arm coverage (round-2 #644 backfill; the behaviour already ships):
+//! Absorb-arm coverage (the behaviour already ships):
 //!
 //! - `funds_arrival_absorbs_remote_error_callback` /
 //!   `funds_arrival_absorbs_remote_timeout_callback` /

--- a/tests/src/lease/remote_lease_transfer_out.rs
+++ b/tests/src/lease/remote_lease_transfer_out.rs
@@ -40,6 +40,27 @@
 //! - `drain_callback_from_stranger_rejected` — the in-flight drain
 //!   authorises callbacks against the same pinned controller; a stranger
 //!   is rejected and the in-flight transfer stays put.
+//!
+//! Absorb-arm coverage (round-2 #644 backfill; the behaviour already ships):
+//!
+//! - `funds_arrival_absorbs_remote_error_callback` /
+//!   `funds_arrival_absorbs_remote_timeout_callback` /
+//!   `funds_arrival_absorbs_stray_ok_callback` — once every transfer has
+//!   acknowledged the drain sits at `FundsArrival` (`ClosingTrx::TransferInFinish`),
+//!   which scheduled no remote operation; an error, a timeout, or a stray
+//!   success callback delivered now is absorbed with the generic
+//!   `wasm-remote-callback` event (`absorbed = error|timeout|response`), the
+//!   controller's ack commits, and the stage is unchanged.
+//! - `transfer_out_wrong_variant_ack_absorbed` — a decodable success ack for a
+//!   non-transfer-out operation, carrying the in-flight nonce, is rejected by
+//!   the transfer decode and absorbed (`unexpected-response-variant`).
+//! - `transfer_out_undecodable_ack_absorbed` — a success ack whose swap payload
+//!   names a ticker outside the registry fails the typed decode and is absorbed
+//!   (`undecodable-response`).
+//! - `transfer_out_stale_nonce_error_absorbed` /
+//!   `transfer_out_stale_nonce_timeout_absorbed` — an error or a timeout callback
+//!   carrying a superseded nonce is absorbed (`nonce-mismatch`) before the
+//!   error/timeout arm runs, leaving the in-flight transfer put.
 
 use crate::common::testing;
 use access_control::error::Error as AccessError;
@@ -55,7 +76,10 @@ use lease::{
 };
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback, RemoteOperationOutcome},
-    response::{TransferOutResponse, WireOperationResponse},
+    response::{
+        CloseLeaseResponse, Ticker, TransferOutResponse, WireCoin, WireOperationResponse,
+        WireSwapResponse,
+    },
 };
 use sdk::cosmwasm_std::{Addr, Event};
 
@@ -68,6 +92,14 @@ use super::{LeaseCoin, LeaseTestCase, PaymentCurrency, repay};
 
 const CLOSING_TRANSFER_OUT_EVENT: &str = "wasm-ls-close-transfer-out";
 const LATE_ACK_EVENT: &str = "wasm-ls-remote-lease-late-ack";
+/// The generic absorb event the drain's `FundsArrival` stage emits through the
+/// `Handler` defaults for any callback that reaches it — the arrival stage
+/// scheduled no remote operation, so every kind is absorbed with this event.
+const REMOTE_CALLBACK_ABSORB_EVENT: &str = "wasm-remote-callback";
+/// A nonce below the close-leg drain's first-emission nonce (`1`), so a callback
+/// stamped with it can never match the in-flight transfer and is absorbed as a
+/// stale duplicate.
+const STALE_NONCE: u64 = 0;
 
 #[test]
 fn transfer_out_single_coin_drain_acks() {
@@ -378,6 +410,255 @@ fn late_ack_from_stranger_rejected() {
         StateResponse::Closed(),
         super::state_query(&test_case, lease)
     );
+}
+
+#[test]
+fn funds_arrival_absorbs_remote_error_callback() {
+    let mut test_case = super::create_test_case::<PaymentCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+
+    // The default `Ok` mode acks the close transfer-out inline, so the drain
+    // already sits at the funds-arrival poll.
+    let (lease, expected_funds, _repay_response) = super::open_and_repay_fully(&mut test_case);
+    assert_closing(
+        expected_funds,
+        ClosingTrx::TransferInFinish,
+        &test_case,
+        &lease,
+    );
+
+    let reason = RemoteErrorMessage::new("late error at arrival").expect("within length cap");
+    let absorbed = stub::inject_callback(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(reason),
+        },
+    );
+    absorbed
+        .assert_event(&Event::new(REMOTE_CALLBACK_ABSORB_EVENT).add_attribute("absorbed", "error"));
+    assert_closing(
+        expected_funds,
+        ClosingTrx::TransferInFinish,
+        &test_case,
+        &lease,
+    );
+}
+
+#[test]
+fn funds_arrival_absorbs_remote_timeout_callback() {
+    let mut test_case = super::create_test_case::<PaymentCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+
+    let (lease, expected_funds, _repay_response) = super::open_and_repay_fully(&mut test_case);
+    assert_closing(
+        expected_funds,
+        ClosingTrx::TransferInFinish,
+        &test_case,
+        &lease,
+    );
+
+    let absorbed = stub::inject_callback(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationTimeout,
+        },
+    );
+    absorbed.assert_event(
+        &Event::new(REMOTE_CALLBACK_ABSORB_EVENT).add_attribute("absorbed", "timeout"),
+    );
+    assert_closing(
+        expected_funds,
+        ClosingTrx::TransferInFinish,
+        &test_case,
+        &lease,
+    );
+}
+
+#[test]
+fn funds_arrival_absorbs_stray_ok_callback() {
+    let mut test_case = super::create_test_case::<PaymentCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+
+    let (lease, expected_funds, _repay_response) = super::open_and_repay_fully(&mut test_case);
+    assert_closing(
+        expected_funds,
+        ClosingTrx::TransferInFinish,
+        &test_case,
+        &lease,
+    );
+
+    let absorbed = stub::inject_callback(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::TransferOut(
+                TransferOutResponse {},
+            )),
+        },
+    );
+    absorbed.assert_event(
+        &Event::new(REMOTE_CALLBACK_ABSORB_EVENT).add_attribute("absorbed", "response"),
+    );
+    assert_closing(
+        expected_funds,
+        ClosingTrx::TransferInFinish,
+        &test_case,
+        &lease,
+    );
+}
+
+#[test]
+fn transfer_out_wrong_variant_ack_absorbed() {
+    let mut test_case = super::create_test_case::<PaymentCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+
+    let (lease, expected_funds, _repay_response) = {
+        let controller = controller.clone();
+        super::open_and_repay_fully_then(&mut test_case, move |app| {
+            stub::set_response_mode(
+                app,
+                &controller,
+                op_tag::TRANSFER_OUT,
+                ResponseMode::Delayed,
+            );
+        })
+    };
+    assert_closing(expected_funds, ClosingTrx::TransferOut, &test_case, &lease);
+
+    // The injected callback is stamped with the in-flight transfer's nonce, so
+    // it clears the nonce gate and reaches the transfer decode, which rejects a
+    // decodable non-transfer-out response as the wrong variant.
+    let absorbed = stub::inject_callback(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::CloseLease(
+                CloseLeaseResponse {},
+            )),
+        },
+    );
+    absorbed.assert_event(
+        &Event::new(CLOSING_TRANSFER_OUT_EVENT)
+            .add_attribute("absorbed", "unexpected-response-variant"),
+    );
+    assert_closing(expected_funds, ClosingTrx::TransferOut, &test_case, &lease);
+}
+
+#[test]
+fn transfer_out_undecodable_ack_absorbed() {
+    let mut test_case = super::create_test_case::<PaymentCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+
+    let (lease, expected_funds, _repay_response) = {
+        let controller = controller.clone();
+        super::open_and_repay_fully_then(&mut test_case, move |app| {
+            stub::set_response_mode(
+                app,
+                &controller,
+                op_tag::TRANSFER_OUT,
+                ResponseMode::Delayed,
+            );
+        })
+    };
+    assert_closing(expected_funds, ClosingTrx::TransferOut, &test_case, &lease);
+
+    // A swap payload naming a ticker outside the currency registry passes the
+    // controller wire-shaped but fails the lease's typed decode outright — an
+    // undecodable payload, distinct from a decodable wrong variant.
+    let absorbed = stub::inject_callback(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationOk(WireOperationResponse::Swap(
+                WireSwapResponse {
+                    amount_out: WireCoin::new(42, Ticker::new("NOT_IN_REGISTRY")),
+                },
+            )),
+        },
+    );
+    absorbed.assert_event(
+        &Event::new(CLOSING_TRANSFER_OUT_EVENT).add_attribute("absorbed", "undecodable-response"),
+    );
+    assert_closing(expected_funds, ClosingTrx::TransferOut, &test_case, &lease);
+}
+
+#[test]
+fn transfer_out_stale_nonce_error_absorbed() {
+    let mut test_case = super::create_test_case::<PaymentCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+
+    let (lease, expected_funds, _repay_response) = {
+        let controller = controller.clone();
+        super::open_and_repay_fully_then(&mut test_case, move |app| {
+            stub::set_response_mode(
+                app,
+                &controller,
+                op_tag::TRANSFER_OUT,
+                ResponseMode::Delayed,
+            );
+        })
+    };
+    assert_closing(expected_funds, ClosingTrx::TransferOut, &test_case, &lease);
+
+    // The nonce gate runs before the error arm, so a superseded-nonce error is
+    // absorbed as a stale duplicate rather than as a remote error.
+    let reason = RemoteErrorMessage::new("stale error ack").expect("within length cap");
+    let absorbed = stub::inject_callback_with_nonce(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        STALE_NONCE,
+        RemoteOperationOutcome::OperationErr(reason),
+    );
+    absorbed.assert_event(
+        &Event::new(CLOSING_TRANSFER_OUT_EVENT).add_attribute("absorbed", "nonce-mismatch"),
+    );
+    assert_closing(expected_funds, ClosingTrx::TransferOut, &test_case, &lease);
+}
+
+#[test]
+fn transfer_out_stale_nonce_timeout_absorbed() {
+    let mut test_case = super::create_test_case::<PaymentCurrency>();
+    let controller = test_case.address_book.remote_lease_controller().clone();
+
+    let (lease, expected_funds, _repay_response) = {
+        let controller = controller.clone();
+        super::open_and_repay_fully_then(&mut test_case, move |app| {
+            stub::set_response_mode(
+                app,
+                &controller,
+                op_tag::TRANSFER_OUT,
+                ResponseMode::Delayed,
+            );
+        })
+    };
+    assert_closing(expected_funds, ClosingTrx::TransferOut, &test_case, &lease);
+
+    // The nonce gate runs before the timeout arm, so a superseded-nonce timeout
+    // is absorbed as a stale duplicate rather than re-emitting the transfer.
+    let absorbed = stub::inject_callback_with_nonce(
+        &mut test_case.app,
+        &controller,
+        &lease,
+        STALE_NONCE,
+        RemoteOperationOutcome::OperationTimeout,
+    );
+    absorbed.assert_event(
+        &Event::new(CLOSING_TRANSFER_OUT_EVENT).add_attribute("absorbed", "nonce-mismatch"),
+    );
+    assert_closing(expected_funds, ClosingTrx::TransferOut, &test_case, &lease);
 }
 
 fn assert_closing(

--- a/tests/src/lease/repay.rs
+++ b/tests/src/lease/repay.rs
@@ -1,7 +1,9 @@
 use std::slice;
 
 use crate::common::testing;
+use access_control::error::Error as AccessError;
 use currencies::PaymentGroup;
+use dex::Error as DexError;
 use finance::instant::Instant;
 use finance::{
     coin::CoinDTO,
@@ -13,11 +15,15 @@ use finance::{
     rational::Rational,
     zero::Zero,
 };
-use lease::api::{
-    ExecuteMsg,
-    query::{ClosePolicy, StateResponse, opened::Status, paid::ClosingTrx},
+use lease::{
+    api::{
+        ExecuteMsg,
+        query::{ClosePolicy, StateResponse, opened::Status, paid::ClosingTrx},
+    },
+    error::ContractError,
 };
 use platform::coin_legacy;
+use remote_lease::callback::{RemoteLeaseCallback, RemoteOperationOutcome};
 use sdk::{
     cosmwasm_std::{Addr, Event},
     cw_multi_test::AppResponse,
@@ -342,6 +348,86 @@ fn repay_funds_the_swap_before_swapping() {
     let _ = common::ibc::do_transfer(&mut test_case.app, lease.clone(), ica_addr, false, &funded)
         .unwrap_response();
     assert_swap_recorded(&test_case, &lease, payment);
+}
+
+/// The in-flight repay `BuyLpn` swap authorises callbacks via the leaser
+/// query (`Config.remote_lease_controller`); a stranger is rejected with the
+/// `DexError::Unauthorized` shape the dex leg surfaces, and the swap stays put.
+#[test]
+fn repay_swap_callback_from_stranger_rejected() {
+    use lease::api::query::opened::RepayTrx;
+
+    let mut test_case: LeaseTestCase = super::create_test_case::<PaymentCurrency>();
+    let (lease, _controller) = open_and_hold_repay_swap(&mut test_case);
+    assert_repay_trx(&test_case, &lease, RepayTrx::Swap);
+
+    let err = test_case
+        .app
+        .execute(
+            testing::user(USER),
+            lease.clone(),
+            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback {
+                nonce: 0,
+                outcome: RemoteOperationOutcome::OperationTimeout,
+            }),
+            &[],
+        )
+        .expect_err("a stranger's repay-swap callback must be rejected");
+
+    let contract_err = err
+        .downcast_ref::<ContractError>()
+        .expect("must surface as lease ContractError");
+    assert!(
+        matches!(
+            contract_err,
+            ContractError::DexError(DexError::Unauthorized(AccessError::Unauthorized {}))
+        ),
+        "expected DexError::Unauthorized, got {contract_err:?}"
+    );
+    assert_repay_trx(&test_case, &lease, RepayTrx::Swap);
+}
+
+/// The in-flight repay proceeds drain authorises callbacks against the pinned
+/// `LeaseDTO.remote_lease_controller` (`SingleUserPermission`); a stranger is
+/// rejected with the same `DexError::Unauthorized` shape, and the drain stays
+/// in its transfer-out.
+#[test]
+fn repay_proceeds_drain_callback_from_stranger_rejected() {
+    use lease::api::query::opened::RepayTrx;
+
+    let mut test_case: LeaseTestCase = super::create_test_case::<PaymentCurrency>();
+    let (lease, controller) = open_and_hold_repay_swap(&mut test_case);
+
+    // Ack the swap so the lease advances to the proceeds drain, which the
+    // `Delayed` TRANSFER_OUT mode then holds in flight.
+    let _swap_ack =
+        stub::deliver_pending_callback(&mut test_case.app, &controller, stub::op_tag::SWAP);
+    assert_repay_trx(&test_case, &lease, RepayTrx::TransferOut);
+
+    let err = test_case
+        .app
+        .execute(
+            testing::user(USER),
+            lease.clone(),
+            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback {
+                nonce: 0,
+                outcome: RemoteOperationOutcome::OperationTimeout,
+            }),
+            &[],
+        )
+        .expect_err("a stranger's proceeds-drain callback must be rejected");
+
+    let contract_err = err
+        .downcast_ref::<ContractError>()
+        .expect("must surface as lease ContractError");
+    assert!(
+        matches!(
+            contract_err,
+            ContractError::DexError(DexError::Unauthorized(AccessError::Unauthorized {}))
+        ),
+        "expected DexError::Unauthorized, got {contract_err:?}"
+    );
+    assert_repay_trx(&test_case, &lease, RepayTrx::TransferOut);
 }
 
 pub(crate) fn repay_partial<ProtocolsRegistry, Treasury, Profit, Reserve, Leaser, Lpp, Oracle>(
@@ -770,4 +856,52 @@ pub(crate) fn deliver_funds_arrival_alarm<
         .execute(time_alarms, lease, &ExecuteMsg::TimeAlarm {}, &[])
         .unwrap()
         .unwrap_response()
+}
+
+/// Open a lease and drive a partial repay to the in-flight `BuyLpn` swap leg,
+/// holding both the swap and the following proceeds drain via `Delayed`. The
+/// lease sits at `RepayTrx::Swap`; delivering the pending swap ack advances it
+/// to the held proceeds drain (`RepayTrx::TransferOut`).
+fn open_and_hold_repay_swap(test_case: &mut LeaseTestCase) -> (Addr, Addr) {
+    let downpayment = DOWNPAYMENT;
+    let amount = super::quote_borrow(test_case, downpayment).to_primitive();
+    let payment: PaymentCoin = Fraction::<PaymentCoin>::of(
+        &Ratio::new(common::coin(1), common::coin(2)),
+        super::create_payment_coin(amount),
+    );
+
+    let lease = super::open_lease(test_case, downpayment, None);
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        stub::op_tag::SWAP,
+        stub::ResponseMode::Delayed,
+    );
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        stub::op_tag::TRANSFER_OUT,
+        stub::ResponseMode::Delayed,
+    );
+
+    let _swap_response = send_repay(test_case, lease.clone(), payment);
+    (lease, controller)
+}
+
+#[track_caller]
+fn assert_repay_trx(
+    test_case: &LeaseTestCase,
+    lease: &Addr,
+    expected: lease::api::query::opened::RepayTrx,
+) {
+    use lease::api::query::opened::OngoingTrx;
+
+    match super::state_query(test_case, lease.clone()) {
+        StateResponse::Opened {
+            status: Status::InProgress(OngoingTrx::Repayment { in_progress, .. }),
+            ..
+        } => assert_eq!(expected, in_progress),
+        other => panic!("expected a repayment in progress, got {other:?}"),
+    }
 }

--- a/tests/src/lease/repay.rs
+++ b/tests/src/lease/repay.rs
@@ -15,6 +15,7 @@ use finance::{
     rational::Rational,
     zero::Zero,
 };
+use lease::api::query::opened::RepayTrx;
 use lease::{
     api::{
         ExecuteMsg,
@@ -355,11 +356,9 @@ fn repay_funds_the_swap_before_swapping() {
 /// `DexError::Unauthorized` shape the dex leg surfaces, and the swap stays put.
 #[test]
 fn repay_swap_callback_from_stranger_rejected() {
-    use lease::api::query::opened::RepayTrx;
-
     let mut test_case: LeaseTestCase = super::create_test_case::<PaymentCurrency>();
     let (lease, _controller) = open_and_hold_repay_swap(&mut test_case);
-    assert_repay_trx(&test_case, &lease, RepayTrx::Swap);
+    assert_repay_trx(RepayTrx::Swap, &test_case, &lease);
 
     let err = test_case
         .app
@@ -384,7 +383,7 @@ fn repay_swap_callback_from_stranger_rejected() {
         ),
         "expected DexError::Unauthorized, got {contract_err:?}"
     );
-    assert_repay_trx(&test_case, &lease, RepayTrx::Swap);
+    assert_repay_trx(RepayTrx::Swap, &test_case, &lease);
 }
 
 /// The in-flight repay proceeds drain authorises callbacks against the pinned
@@ -393,8 +392,6 @@ fn repay_swap_callback_from_stranger_rejected() {
 /// in its transfer-out.
 #[test]
 fn repay_proceeds_drain_callback_from_stranger_rejected() {
-    use lease::api::query::opened::RepayTrx;
-
     let mut test_case: LeaseTestCase = super::create_test_case::<PaymentCurrency>();
     let (lease, controller) = open_and_hold_repay_swap(&mut test_case);
 
@@ -402,7 +399,7 @@ fn repay_proceeds_drain_callback_from_stranger_rejected() {
     // `Delayed` TRANSFER_OUT mode then holds in flight.
     let _swap_ack =
         stub::deliver_pending_callback(&mut test_case.app, &controller, stub::op_tag::SWAP);
-    assert_repay_trx(&test_case, &lease, RepayTrx::TransferOut);
+    assert_repay_trx(RepayTrx::TransferOut, &test_case, &lease);
 
     let err = test_case
         .app
@@ -427,7 +424,7 @@ fn repay_proceeds_drain_callback_from_stranger_rejected() {
         ),
         "expected DexError::Unauthorized, got {contract_err:?}"
     );
-    assert_repay_trx(&test_case, &lease, RepayTrx::TransferOut);
+    assert_repay_trx(RepayTrx::TransferOut, &test_case, &lease);
 }
 
 pub(crate) fn repay_partial<ProtocolsRegistry, Treasury, Profit, Reserve, Leaser, Lpp, Oracle>(
@@ -890,11 +887,7 @@ fn open_and_hold_repay_swap(test_case: &mut LeaseTestCase) -> (Addr, Addr) {
 }
 
 #[track_caller]
-fn assert_repay_trx(
-    test_case: &LeaseTestCase,
-    lease: &Addr,
-    expected: lease::api::query::opened::RepayTrx,
-) {
+fn assert_repay_trx(expected: RepayTrx, test_case: &LeaseTestCase, lease: &Addr) {
     use lease::api::query::opened::OngoingTrx;
 
     match super::state_query(test_case, lease.clone()) {


### PR DESCRIPTION
Closes #644.

The remote-lease transport rework (#647/#649/#658/#698–#700) delivered most of #644's
scope through other issues, but three residuals were never closed out: the `OpenLease`
timeout path had no test at any level, unauthorized-caller rejection was exercised on only
half of the callback boundaries (one of the two auth-resolution paths), and the issue's
coverage acceptance criterion had never been measured. This backfills all three so the
callback surface is verifiably covered before the pre-audit hardening sweeps (#689) build
on it.

Tests only — zero production-code changes. 22 new tests:

- **Integration** (`tests/src/lease/`): `OpenLease` timeout → full refund → `OpenFailed`;
  stranger-rejection at the five previously untested boundaries — in-flight `OpenLease`,
  terminal `OpenFailed` late-ack (leaser-query auth path, plain `Unauthorized`), repay
  `BuyLpn` swap, opened proceeds drain, `OpeningUnwind` drain (pinned-controller auth path,
  `DexError::Unauthorized`); `FundsArrival` absorb arms (late error / timeout / stray ok —
  the dex trait-default absorbs); transfer-out absorbs (wrong-variant, undecodable,
  stale-nonce error + timeout); swap absorbs (out-currency mismatch, stale-nonce timeout);
  and a pin of today's contract for a controller callback landing on an active lease
  (typed `UnsupportedOperation`).
- **Unit** (`protocol/contracts/lease`, gated `internal.test.contract`): all four
  `OpenLease` callback arms + auth-reject + `open_transport` query-failure propagation;
  late-ack absorb/reject pairs on the `Closed` and `OpenFailed` terminals.

**Acceptance: coverage of the `RemoteLeaseCallback` handler surface ≥ 95% — measured
99.75%** (402/403 lines; llvm-cov union of the lease unit run and the integration run,
denominator = the lease-crate callback handlers plus the shared dex-package legs). The
sole uncovered line is the `buy_asset::start` error propagation after a successful
open-ack, which cannot be induced without a production change (the path takes no querier
and its only failure is an internal invariant the opening's fixed two-coin shape never
produces).

Gate on the CI-pinned toolchain: lease 140 unit tests green under both feature combos;
integration suite 211 green; fmt + clippy clean workspace-wide.

<details><summary>Correctness review report (12-item checklist, PASS)</summary>

# Diff Review Report

Branch: test/issue644-remote-lease-residual
Diff range: 0a8f0ab6b..HEAD
Files changed: 9 (3 production files — additions confined to `#[cfg(all(feature = "internal.test.contract", test))]` test modules; 6 integration-test files under `tests/src/lease/`)

## Boundary verification (tests-only, zero production-code change)
- `--numstat` confirms the three `protocol/contracts/lease/src/...` files are **additions only** (`79/0`, `104/0`, `361/0` — zero deletions). Every added hunk sits after the existing `impl` blocks, inside a `#[cfg(all(feature = "internal.test.contract", test))] mod tests { … }` block. No production line modified or removed.
- All deletions in the diff live in `tests/src/**` and are `use`-statement restructuring + module `//!` doc-comment updates. The "zero production-code changes" boundary holds firmly.

## Acceptance criteria check
- AC1 (OpenLease timeout → OpenFailed integration test): met — `remote_lease_open.rs::open_failed_on_timeout_refunds_and_finalises` holds the lease pre-ack via `ResponseMode::Delayed`, fires `OperationTimeout`, asserts the `wasm-ls-remote-lease-open-failed` event reason `"timeout"`, full downpayment refund, empty leaser list, and terminal `StateResponse::OpenFailed { reason: "timeout" }`. Verified `TIMEOUT_REASON = "timeout"` in production `open_lease.rs:38`.
- AC2 (unauthorized-caller rejection at OpenLease/OpenFailed/BuyLpn/OpeningUnwind/proceeds-drain, two auth shapes): met — plain `ContractError::Unauthorized` asserted at LeaseState boundaries (`open_lease_callback_from_stranger_rejected`, `open_failed_late_ack_from_stranger_rejected`), and `ContractError::DexError(DexError::Unauthorized(..))` at dex legs (`repay_swap_callback_from_stranger_rejected`, `repay_proceeds_drain_callback_from_stranger_rejected`, `unwind_drain_callback_from_stranger_rejected`). Shapes match production (`closed.rs` uses `SingleUserPermission` → `ContractError::Unauthorized`; `open_failed.rs` uses leaser `remote_lease_callback_permission` query).
- AC3 (unit backfill: open_lease 4 callback arms + auth, open_failed/closed late-ack absorb/reject pairs): met — `open_lease.rs` unit module covers all four `on_remote_lease_callback` arms (OpenLease ack → `State::BuyAsset`, unexpected-ok → `"unexpected operation response"`, error → echoed reason, timeout → `"timeout"`) plus auth-reject and `open_transport` query-failure propagation (`ContractError::PositionLimitsQuery`). `closed.rs` and `open_failed.rs` each carry the absorb/reject pair with `assert_eq!` on the exact `ls-remote-lease-late-ack` (`id` + `terminal`) response — verified byte-for-byte against production emitters.
- AC4 (round-2 coverage: FundsArrival absorb arms, transfer-out absorb arms, swap absorbs, default-handler UnsupportedOperation, open_transport query-failure): met — `transfer_out.rs` adds error/timeout/stray-ok FundsArrival absorbs (`wasm-remote-callback`, `absorbed=error|timeout|response`), wrong-variant (`unexpected-response-variant`), undecodable (`undecodable-response`), stale-nonce error+timeout (`nonce-mismatch`); `swap.rs` adds currency-mismatch (`out-currency-mismatch`) and stale-nonce timeout (`nonce-mismatch`); `remote_lease_callback.rs` pins `UnsupportedOperation` on an active lease. All absorb-reason constants confirmed present in production (`dex/src/impl_/remote_swap.rs`, `remote_transfer_out.rs`, `paid/remote_close.rs`, `dex/src/response.rs`).
- Acceptance: coverage ≥95% claim (99.75%) — not independently re-measured here; assertions verified as load-bearing (observable state transitions, absorb events, typed errors), which is the review lens the task requested for backfill tests.

## Checklist

1. **No debug prints, logging leftovers, or commented-out code** — PASS
   No `println!`/`dbg!`/`eprintln!`/`console.log`/`todo!`/`FIXME`/`TODO` in added lines. The five `unimplemented!("only smart queries are expected")` / `unimplemented!("no query is expected against {other}")` calls are loud guards inside test-mock queriers, not debug leftovers. `let _response`/`let _swap_ack`/`let _repay_response` are intentional discards. Comments are non-obvious why-comments (test-setup rationale), not commented-out code.

2. **No off-by-one errors in loops, slices, or ranges** — PASS
   No loops/slices added. `remote_lease_swap.rs` `let stale = in_flight - 1;` is intentional ("one below the in-flight nonce"); `in_flight` is the first in-flight swap leg's emission nonce (≥1, corroborated by `STALE_NONCE = 0` "below the first-emission nonce (1)" in `transfer_out.rs:99`), so no underflow and the stale nonce cannot collide with any emitted leg.

3. **All match/enum arms handled — no catch-all `_` that silently swallows new variants** — PASS
   Catch-all arms in test helpers (`_ => panic!(...)`, `other => panic!("... {other:?}")`) are assertion failures, not silent swallows. Production `on_remote_lease_callback` (read for context) enumerates all four outcome arms explicitly.

4. **Error paths return meaningful errors — no silent swallows, no bare `.unwrap()` in non-test code** — PASS
   Every line is test code (`tests/src/**` + `#[cfg(...test)]` modules); `unwrap`/`expect` are clippy-permitted there (`allow-unwrap-in-tests`). Error paths are asserted via typed `matches!`/`downcast_ref::<ContractError>()` — no swallowing.

5. **Boundary conditions: empty collections, zero/negative values, max values** — PASS
   Tests assert boundary outcomes: `leases.is_empty()`, exact full-refund equality (`balance_before == balance_after`), unchanged leg counts (`opening_acks_left == 2`), unchanged drain stage. Nonce-boundary (`in_flight - 1`, `STALE_NONCE = 0`) handled.

6. **Async: no held locks across `.await`, no missing `.await`** — PASS
   No async code (CosmWasm contract/test code is synchronous).

7. **No resource leaks: unclosed files, connections, transactions** — PASS
   Only `MockQuerier` and the multi-test `App` are constructed, owned locally, and dropped. No files/connections/DB transactions.

8. **SQL: parameterized queries only — no string interpolation** — PASS
   No SQL.

9. **New public functions/endpoints have test coverage** — PASS
   This IS the coverage backfill; no new production public functions are introduced. The pre-existing `RemoteLeaseCallback` handler surface (open_lease 4 arms, closed/open_failed late-ack, transfer-out/swap/funds-arrival absorbs, default UnsupportedOperation) now has direct unit + integration coverage.

10. **No logic inversions (`!=` vs `==`, `&&` vs `||`)** — PASS
    Assertion orientation verified against production: `State::BuyAsset` = `DexState<opening::buy_asset::DexState>` (the funding leg, `state/mod.rs:54,164-166`); reason strings `"timeout"` / `"unexpected operation response"` (`open_lease.rs:38,46`); late-ack event `id`+`terminal="closed"|"open_failed"` (`closed.rs:109-111`, `open_failed.rs:67-69`); auth shapes (plain `Unauthorized` at LeaseState, `DexError::Unauthorized` at dex legs); absorb reasons all confirmed as real production constants. Assertions are correctly oriented.

11. **Types: no unnecessary `.clone()`, no `String` where `&str` suffices** — PASS
    Clones are cheap `Addr` clones in test code, each reused across multiple calls (e.g., `lease.clone()`, `controller.clone()`), consistent with existing test-file style. No production hot-path concern; no `String` where `&str` fits.

12. **Concurrency: shared state properly guarded, no TOCTOU races** — PASS
    Single-threaded cw-multi-test harness; no shared mutable state or threads.

## Project-specific checks (nolus-money-market CLAUDE.md)
- No `unwrap()`/`expect()` outside tests — PASS (all in test modules).
- No `as` casts — PASS (uses `.into()`, `from_percent`, `from_seconds`).
- Feature-flag correctness — PASS: unit tests correctly gated `#[cfg(all(feature = "internal.test.contract", test))]`.
- Errors typed — PASS: assertions use `ContractError` / `DexError` / `AccessError` typed variants.
- Code Style rule 30 (no magic literals) — PASS: unnamed literals appear only inside `#[cfg(test)]` modules, explicitly permitted.
- Unit Test Guidelines (module ordering: consts → `#[test]` fns → helpers; test-through-public-API; group related tests; exercise all branches; respect `debug_assert`) — PASS: all three unit modules order correctly; tests exercise the `Handler`/`Contract` trait entry points and observable outputs (`next_state`, `response`, `state()` query), not private internals.
- Rule 17 (expected-values parameter first in assertion helpers) — **FAIL (LOW)**: `tests/src/lease/repay.rs:893` `fn assert_repay_trx(test_case, lease, expected)` places `expected` last; the sibling helper `assert_closing(expected_funds, …)` (`transfer_out.rs:664`) places expected first. The inner `assert_eq!(expected, in_progress)` is rule-17-correct; only the helper's parameter order deviates.

## Additional findings beyond the 12-item checklist
- `remote_lease_callback.rs::active_lease_rejects_remote_callback_as_unsupported` pins the current reverting-ack behavior and its own comment flags it as a "known soundness-review candidate." This is honest backfill of shipped behavior (verified: the `Handler` default returns `ContractError::UnsupportedOperation`, `handler.rs:23`); not a defect in this diff, but noting the flagged concern is carried forward, not resolved here.
- In the `open_failed.rs`/`open_lease.rs` reject unit tests, the mock querier returns `AccessGranted::No` unconditionally, so the `STRANGER` sender argument is decorative — the rejection is driven by the mocked leaser verdict, which correctly mirrors production's delegate-to-leaser auth. Acceptable; no sender-discrimination gap at this layer.

## Verdict
PASS — all 12 checklist items pass; both primary acceptance criteria met; production-code boundary (tests-only) verified intact. One LOW project-style deviation (rule 17 parameter order in `assert_repay_trx`) is advisory and does not block.
</details>

<details><summary>Security review report (CLEAR)</summary>

# Security Review Report

Branch: test/issue644-remote-lease-residual
Diff range: 0a8f0ab6b..HEAD

## Diff classification
- Files in diff: 9 (all test code)
  - 3 production-path files add ONLY `#[cfg(all(feature = "internal.test.contract", test))] mod tests` blocks: `protocol/contracts/lease/src/contract/state/closed.rs`, `.../open_failed.rs`, `.../opening/open_lease.rs`
  - 6 integration test files add `#[test]` functions: `tests/src/lease/{remote_lease_callback,remote_lease_open,remote_lease_open_unwind,remote_lease_swap,remote_lease_transfer_out,repay}.rs`
- Categories detected:
  - **Auth / access control** — present, but exercised, not modified (unauthorized-caller rejection tests)
  - **Smart contracts (CosmWasm)** — fires on file path only; **zero contract-logic changes** in the diff
  - **Untrusted input parsing** — only `from_json` inside test-controlled mock queriers; not a real input-surface change
  - Not present: HTTP/API, crypto/key handling, secrets/config, SQL/DB, dependencies (no manifest/lock change), network egress, concurrency

## Skills dispatched
- `differential-review` (always) — scoped to the diff
- Not dispatched (no triggering category, or would violate the diff-only scope):
  - `building-secure-contracts` (cosmos-vulnerability-scanner): CosmWasm category fires on path, but it is a repo-wide contract scanner and the diff carries **no production contract logic** to evaluate — out of scope by instruction
  - `sharp-edges` / `insecure-defaults`: no HTTP/API or config surface
  - `constant-time-analysis` / `zeroize-audit`: no crypto/key handling
  - `supply-chain-risk-auditor` + `cargo audit`: no manifest or lock-file change
  - `static-analysis:semgrep`: no genuine untrusted-input surface; repo-wide, out of scope

## Analysis performed
Production-boundary check, per-test assertion-quality audit, and stub-helper tracing:

1. **Production boundary holds.** All three `src/*.rs` hunks are entirely inside `#[cfg(all(feature = "internal.test.contract", test))] mod tests`. No production/contract logic changed. No manifest, lock, or config change. Zero production blast radius.

2. **Auth-rejection tests are load-bearing.** Every unauthorized-caller test asserts the exact typed error shape, not a wildcard:
   - LeaseState boundaries → `ContractError::Unauthorized(AccessError::Unauthorized {})`
   - dex legs (unwind drain, repay swap, proceeds drain) → `ContractError::DexError(DexError::Unauthorized(AccessError::Unauthorized {}))`
   The unwind/repay/swap variants additionally re-assert post-rejection state (`assert_unwinding`, `assert_repay_trx`), so a removed auth gate would fail the test on both the error shape and the state transition.

3. **Absorb-arm tests are load-bearing.** Each asserts a specific `absorbed` event attribute (`out-currency-mismatch`, `nonce-mismatch`, `unexpected-response-variant`, `undecodable-response`, `error|timeout|response`) **plus** that the stage/leg-countdown is unchanged. A removed guard would advance state and emit a different event, failing the assertion — none are vacuous.

4. **Nonce re-stamping verified.** The wrong-variant and undecodable tests pass `nonce: 0` in the literal, but `StubExecuteMsg::InjectCallback` (stub line 361-363) overrides it with the lease's `LAST_INFLIGHT_NONCE`, so the callback genuinely clears the nonce gate and reaches the typed decode — the tests exercise the arm they claim to. The stale-nonce tests correctly use `inject_callback_with_nonce` with an explicit sub-`1` nonce.

5. **Fixtures don't mask bugs.** `*::unchecked(...)` constructors (`MaxSlippage`, `LeasesRef`, `OracleRef`, `LppGenericRef`, `TimeAlarmsRef`), `Addr::unchecked`, and the `RemoteLeaseId` base58 sample (`StubPda1111...`) are standard test-fixture setup for the system under test (the callback handler), not the constructors themselves. No crypto operation, no real key material. No production validation is bypassed on the path under test.

## Findings

### CRITICAL (must fix before merge)
- None.

### HIGH (should fix before merge)
- None.

### MEDIUM (track as TODO)
- None.

### LOW / INFORMATIONAL
- `tests/src/lease/remote_lease_open.rs` — `open_lease_callback_from_stranger_rejected` and `open_failed_late_ack_from_stranger_rejected` assert the typed rejection error but, unlike their unwind/repay/swap siblings, do not re-assert that the lease stayed in its prior state after the rejection. Harmless because cw-multi-test rolls the tx back on `Err` so state cannot advance; adding a post-state re-assert would make them symmetric with the other auth tests. Source: differential-review. Quality nit, not a defect.
- Several `inject_callback` call sites pass `nonce: 0` as a placeholder that the stub re-stamps with the real in-flight nonce (`remote_lease_controller_stub.rs:361`). The literal is dead data and mildly misleading without knowing the helper; the helper doc comment already explains it. Source: differential-review. Cosmetic.
- `protocol/contracts/lease/src/contract/state/opening/open_lease.rs` unit test `callback_from_unauthorized_sender_rejected` matches `ContractError::Unauthorized(_)` (wildcard inner) where the integration tests pin `AccessError::Unauthorized {}`. Acceptable at the unit tier; tightening the inner match would match the integration precision. Source: differential-review.

## Coverage gaps
- **Auth / access control** has no dedicated automated scanner in the dispatch table (the table routes it to differential-review). This diff only *tests* auth rather than changing auth logic, so differential-review coverage is complete for the change — no manual gap of concern.
- **Smart contracts (CosmWasm):** the cosmos-vulnerability-scanner was intentionally not run — the diff contains no production contract logic, only test modules, and the scanner is repo-wide (out of the diff-only scope). If a reviewer wants consensus-safety assurance on the underlying handler behavior these tests pin, that is a separate, non-diff-scoped audit of the already-shipped production code, not of this PR.
- Manual review recommended for: nothing beyond the LOW nits above. The behavior under test ships already; this diff adds no runtime surface.

## Verdict
CLEAR — no findings above MEDIUM. All production-path hunks are `cfg(test)`-gated (zero production impact), auth-rejection and absorb-arm assertions are load-bearing (exact typed errors + unchanged-state re-asserts), the stub nonce re-stamping confirms the decode-path tests are non-vacuous, and no security-relevant category (crypto, deps, config, HTTP, SQL, network egress, concurrency) is touched.
</details>

<details><summary>Project-rule conformance report (PASS after 31afc34ee)</summary>

# Compliance audit (project-rule conformance)

Audited range: 0a8f0ab6b..08e0df6cb. Verdict at audit time: FAIL on a single rule — G16
(comment discipline: no task references in code): three module-doc lines carried a
"(round-2 #644 backfill)" provenance tag. **Resolved in 31afc34ee** (tags stripped, technical
prose kept; fmt + clippy re-verified, zero remaining matches). All other rules pass:

- Code Style 1-39: PASS or N/A across the board (rule 17 and rule 26 findings from the first
  audit pass confirmed fixed with no regression; rule 30 test-literal exception applies).
- Unit Test Guidelines 1-6: PASS (module ordering, grouping, all branches, public-API-only,
  debug_assert preconditions respected).
- Linting rules: PASS (unwrap only in tests; no suppressions; no deprecated items).
- Review-checklist additions: PASS (no `as` casts; feature gate `internal.test.contract`
  matches the established lease-contract pattern; errors matched as typed variants;
  no CLAUDE.md/docs in the branch).
- Commit conventions: PASS (conventional subjects <=70 chars, why-bodies, no attribution,
  all commits within size limits).

Non-violations noted by the auditor (left as-is deliberately): a test-local mock named
`authorized_handler` (borderline naming, mirrors the cosmwasm `update_wasm(handler)` idiom);
one `super::Response` reference (idiomatic, consistency-only); a pre-existing sibling
assertion fn in repay.rs with the same param-order/import pattern (predates this branch —
candidate for the #694 convention sweep).

</details>


## Review disposition (cortex round 1)

- Module-item ordering in the three lease test files and the mock-fn rename (`answer_authorized_queries`): **fixed in f81cf2978** (pure relocation — production impls byte-identical; lease gate re-run green).
- Active-lease callback pin (`remote_lease_callback.rs`, tagged BUG/SECURITY): **declined on this PR, tracked in #692.** The test pins current production behavior; the divergence from `docs/remote-lease-wire-contract.md` (revert instead of absorb in the default state handler, which can strand the relayer on a late/duplicate callback) is a production defect in scope for the pre-audit soundness sweep, not for this tests-only backfill. The pin test documents today's contract and will be updated by that fix.
