### PR TITLE
fix: correct currency-distinctness claims in error and expect texts

### DIFF
--- a/protocol/packages/remote_lease/src/msg.rs
+++ b/protocol/packages/remote_lease/src/msg.rs
@@ -231,7 +231,7 @@ impl From<&OpenLeaseParams> for remote_lease_wire::msg::OpenLeaseParams {
             wire_ticker(typed.lpn_currency()),
             wire_ticker(typed.asset_currency()),
         )
-        .expect("typed OpenLeaseParams already upholds the pairwise-distinct invariant")
+        .expect("typed OpenLeaseParams already upholds the distinct lpn/asset-currency invariant")
     }
 }
 

--- a/protocol/packages/remote_lease_wire/src/error.rs
+++ b/protocol/packages/remote_lease_wire/src/error.rs
@@ -2,9 +2,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum Error {
-    #[error(
-        "the three remote-lease currencies (downpayment, lpn, asset) must be pairwise distinct"
-    )]
+    #[error("the remote-lease lpn and asset currencies must differ")]
     DuplicateLeaseCurrencies,
 
     #[error("swap input and output currencies must differ")]


### PR DESCRIPTION
## Change

Message-text-only correction of two overclaiming strings to match the real lpn!=asset invariant; no logic change.

## Testing

- (message/text-only change; existing suites green)

Gate: build, `fmt --check`, clippy on the CI-pinned 1.94 toolchain (`lint` + `lint-all`), full test run for the touched packages — all green.

## Independent review

Two independent fresh-context reviews (general-correctness checklist + a security-focused pass over the committed diff) returned **PASS** with zero blocking findings; security verdict: CLEAR.
