### PR TITLE
fix: topology symbol override respects cycle detection

### DIFF
--- a/tools/topology/src/currency/ibc.rs
+++ b/tools/topology/src/currency/ibc.rs
@@ -30,3 +30,33 @@ impl Ibc {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Ibc;
+
+    #[test]
+    fn overriden_symbol_present() {
+        const SOURCE: &str =
+            r#"{"network": "NetA", "currency": "CUR", "override_symbol": "myovr"}"#;
+
+        let ibc = serde_json::from_str::<'_, Ibc>(SOURCE)
+            .expect("Ibc with an override symbol should deserialize!");
+
+        assert_eq!(
+            ibc.overriden_symbol().map(|id| id.as_ref()),
+            Some("myovr"),
+            "{ibc:?}"
+        );
+    }
+
+    #[test]
+    fn overriden_symbol_absent() {
+        const SOURCE: &str = r#"{"network": "NetA", "currency": "CUR"}"#;
+
+        let ibc = serde_json::from_str::<'_, Ibc>(SOURCE)
+            .expect("Ibc without an override symbol should deserialize!");
+
+        assert!(ibc.overriden_symbol().is_none(), "{ibc:?}");
+    }
+}

--- a/tools/topology/src/currency/ibc.rs
+++ b/tools/topology/src/currency/ibc.rs
@@ -2,35 +2,6 @@ use serde::Deserialize;
 
 use crate::{network, skippable::Skippable};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub(crate) struct Ibc {
-    network: network::Id,
-    currency: super::Id,
-    #[serde(default)]
-    override_symbol: Skippable<super::Id>,
-}
-
-impl Ibc {
-    #[inline]
-    pub const fn network(&self) -> &network::Id {
-        &self.network
-    }
-
-    #[inline]
-    pub const fn currency(&self) -> &super::Id {
-        &self.currency
-    }
-
-    #[inline]
-    pub const fn overriden_symbol(&self) -> Option<&super::Id> {
-        match self.override_symbol {
-            Skippable::Skipped => None,
-            Skippable::Some(ref symbol) => Some(symbol),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::Ibc;
@@ -58,5 +29,34 @@ mod tests {
             .expect("Ibc without an override symbol should deserialize!");
 
         assert!(ibc.overriden_symbol().is_none(), "{ibc:?}");
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub(crate) struct Ibc {
+    network: network::Id,
+    currency: super::Id,
+    #[serde(default)]
+    override_symbol: Skippable<super::Id>,
+}
+
+impl Ibc {
+    #[inline]
+    pub const fn network(&self) -> &network::Id {
+        &self.network
+    }
+
+    #[inline]
+    pub const fn currency(&self) -> &super::Id {
+        &self.currency
+    }
+
+    #[inline]
+    pub const fn overriden_symbol(&self) -> Option<&super::Id> {
+        match self.override_symbol {
+            Skippable::Skipped => None,
+            Skippable::Some(ref symbol) => Some(symbol),
+        }
     }
 }

--- a/tools/topology/src/currency_resolution.rs
+++ b/tools/topology/src/currency_resolution.rs
@@ -139,8 +139,8 @@ impl Topology {
         } else {
             overriden_symbol = overriden_symbol.or_else(|| ibc.overriden_symbol());
 
-            if overriden_symbol.is_none() {
-                if let Some(channel_id) = channels
+            if overriden_symbol.is_none()
+                && let Some(channel_id) = channels
                     .get(traversed_networks.last().unwrap_or_else(
                         #[inline]
                         || {
@@ -151,12 +151,11 @@ impl Topology {
                         },
                     ))
                     .and_then(|connected_networks| connected_networks.get(ibc.network()))
-                {
-                    dex_symbol.add_channel(channel_id);
-                }
-
-                traversed_networks.push(ibc.network());
+            {
+                dex_symbol.add_channel(channel_id);
             }
+
+            traversed_networks.push(ibc.network());
 
             networks
                 .get(ibc.network())

--- a/tools/topology/tests/currency_definitions/main.rs
+++ b/tools/topology/tests/currency_definitions/main.rs
@@ -119,6 +119,34 @@ fn snapshot() {
 }
 
 #[test]
+fn override_ibc_currency() {
+    let mut currencies =
+        currency_definitions_generator(include_str!("override_ibc_currency.json"), "Dex");
+
+    expect(
+        &mut currencies,
+        "HostC",
+        "chostc",
+        "chostc",
+        "transfer/channel-1/chostc",
+        "ibc/3F6F41139E8D08E9F1727144C2DF3AF942135B5AAE0477DB829DA3E57C33AA01",
+        2,
+    );
+
+    expect(
+        &mut currencies,
+        "OverC",
+        "transfer/channel-0/transfer/channel-2/myovr",
+        "ibc/030DD264FB3821719EAF5F7750204C1FF6E169F329B0855B60CF7FD563A28F53",
+        "myovr",
+        "myovr",
+        6,
+    );
+
+    expect_end(currencies);
+}
+
+#[test]
 fn with_intermediates() {
     let mut currencies =
         currency_definitions_generator(include_str!("with_intermediates.json"), "Dex");

--- a/tools/topology/tests/currency_definitions/override_ibc_currency.json
+++ b/tools/topology/tests/currency_definitions/override_ibc_currency.json
@@ -1,0 +1,55 @@
+{
+  "host_network": {
+    "name": "Host",
+    "currency": {
+      "id": "HOST_C",
+      "native": {
+        "name": "Host Currency",
+        "symbol": "chostc",
+        "decimal_digits": 2
+      }
+    }
+  },
+  "networks": {
+    "Dex": {
+      "currencies": {
+        "HostC": {
+          "ibc": {
+            "network": "Host",
+            "currency": "HOST_C"
+          }
+        },
+        "OverC": {
+          "ibc": {
+            "network": "Remote",
+            "currency": "REMOTE_C",
+            "override_symbol": "myovr"
+          }
+        }
+      }
+    },
+    "Remote": {
+      "currencies": {
+        "REMOTE_C": {
+          "native": {
+            "name": "Remote Currency",
+            "symbol": "uremotec",
+            "decimal_digits": 6
+          }
+        }
+      }
+    }
+  },
+  "channels": {
+    "Host": {
+      "Dex": "channel-0"
+    },
+    "Dex": {
+      "Host": "channel-1",
+      "Remote": "channel-2"
+    },
+    "Remote": {
+      "Dex": "channel-3"
+    }
+  }
+}

--- a/tools/topology/tests/validations/main.rs
+++ b/tools/topology/tests/validations/main.rs
@@ -48,6 +48,19 @@ fn ibc_currency_cycle() {
 }
 
 #[test]
+fn override_ibc_currency_cycle() {
+    let error = currency_definitions_error(include_str!("override_ibc_currency_cycle.json"), "Dex");
+
+    assert!(
+        matches!(
+            error,
+            error::CurrencyDefinitions::ResolveCurrency(error::ResolveCurrency::CycleCreated)
+        ),
+        "{error}"
+    );
+}
+
+#[test]
 fn non_existent_currency() {
     let error = currency_definitions_error(include_str!("non_existent_currency_1.json"), "Dex");
 

--- a/tools/topology/tests/validations/override_ibc_currency_cycle.json
+++ b/tools/topology/tests/validations/override_ibc_currency_cycle.json
@@ -1,0 +1,60 @@
+{
+  "host_network": {
+    "name": "Host",
+    "currency": {
+      "id": "HOST_C",
+      "native": {
+        "name": "Host Currency",
+        "symbol": "chostc",
+        "decimal_digits": 2
+      }
+    }
+  },
+  "networks": {
+    "Dex": {
+      "currencies": {
+        "HostC": {
+          "ibc": {
+            "network": "Host",
+            "currency": "HOST_C"
+          }
+        },
+        "CycleC": {
+          "ibc": {
+            "network": "NetA",
+            "currency": "CYC",
+            "override_symbol": "myovr"
+          }
+        }
+      }
+    },
+    "NetA": {
+      "currencies": {
+        "CYC": {
+          "ibc": {
+            "network": "NetB",
+            "currency": "CYC"
+          }
+        }
+      }
+    },
+    "NetB": {
+      "currencies": {
+        "CYC": {
+          "ibc": {
+            "network": "NetA",
+            "currency": "CYC"
+          }
+        }
+      }
+    }
+  },
+  "channels": {
+    "Host": {
+      "Dex": "channel-0"
+    },
+    "Dex": {
+      "Host": "channel-1"
+    }
+  }
+}


### PR DESCRIPTION
## Change

see above

## Testing

- validations::override_ibc_currency_cycle — cyclic IBC symbol override; confirmed HANGS (exit 124) on unfixed code, returns ResolveCurrency::CycleCreated and passes after fix
- currency_definitions::override_ibc_currency — valid (non-cyclic) IBC symbol override resolves; asserts host denom trace now includes both channel hops (transfer/channel-0/transfer/channel-2/myovr), the override subdenom 'myovr' is applied, and the host-local sibling resolves; passes after fix
- currency::ibc::tests::overriden_symbol_present — Ibc with override_symbol deserializes and overriden_symbol() returns Some("myovr"); new coverage for the previously-untested accessor
- currency::ibc::tests::overriden_symbol_absent — Ibc without override_symbol yields overriden_symbol() == None; new coverage

Gate: build, `fmt --check`, clippy on the CI-pinned 1.94 toolchain (`lint` + `lint-all`), full test run for the touched packages — all green.

## Independent review

Two independent fresh-context reviews (general-correctness checklist + a security-focused pass over the committed diff) returned **PASS** with zero blocking findings; security verdict: CLEAR.
