### PR TITLE
fix: controller ack path never strands an acknowledged packet

### DIFF
--- a/protocol/contracts/lease/src/contract/state/open_failed.rs
+++ b/protocol/contracts/lease/src/contract/state/open_failed.rs
@@ -73,7 +73,7 @@ mod tests {
 
     fn open_failed() -> OpenFailed {
         OpenFailed::new(
-            RemoteErrorMessage::from_static("a prior open failure"),
+            RemoteErrorMessage::truncated("a prior open failure"),
             LeasesRef::unchecked(Addr::unchecked(LEASER)),
         )
     }

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -578,7 +578,7 @@ impl Contract for OpenLease {
                     self.on_open_failed(
                         querier,
                         &env,
-                        RemoteErrorMessage::from_static(UNEXPECTED_OPERATION_REASON),
+                        RemoteErrorMessage::truncated(UNEXPECTED_OPERATION_REASON),
                     )
                 }
                 RemoteOperationOutcome::OperationErr(reason) => {
@@ -587,7 +587,7 @@ impl Contract for OpenLease {
                 RemoteOperationOutcome::OperationTimeout => self.on_open_failed(
                     querier,
                     &env,
-                    RemoteErrorMessage::from_static(TIMEOUT_REASON),
+                    RemoteErrorMessage::truncated(TIMEOUT_REASON),
                 ),
             })
     }

--- a/protocol/contracts/lease/src/contract/state/opening/unwind.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/unwind.rs
@@ -197,7 +197,7 @@ impl RemoteTransferOutTask for OpeningUnwindTask {
                         lease_addr,
                         now,
                     },
-                    remote_lease::callback::RemoteErrorMessage::from_static(UNWIND_REASON),
+                    remote_lease::callback::RemoteErrorMessage::truncated(UNWIND_REASON),
                     querier,
                 )
             })

--- a/protocol/contracts/remote_lease/src/ibc.rs
+++ b/protocol/contracts/remote_lease/src/ibc.rs
@@ -203,7 +203,7 @@ fn ack_to_outcome(ack: StdAck) -> RemoteOperationOutcome {
         StdAck::Success(data) => cosmwasm_std::from_json::<WireOperationResponse>(&data)
             .map(RemoteOperationOutcome::OperationOk)
             .unwrap_or_else(|_err| {
-                RemoteOperationOutcome::OperationErr(RemoteErrorMessage::from_static(
+                RemoteOperationOutcome::OperationErr(RemoteErrorMessage::truncated(
                     UNDECODABLE_ACK_REASON,
                 ))
             }),

--- a/protocol/contracts/remote_lease/src/ibc.rs
+++ b/protocol/contracts/remote_lease/src/ibc.rs
@@ -29,6 +29,11 @@ const VERSION_TRANSFER_KEY: &str = "+transfer=";
 // Diagnostic bound on the counterparty-authored version echoed into the
 // handshake error — a legitimate version is ~45 characters.
 const COUNTERPARTY_VERSION_ECHO_MAX_CHARS: usize = 64;
+// Synthetic `OperationErr` reason surfaced when a counterparty `StdAck::Success`
+// payload does not decode to our wire response. Absorbing it — rather than
+// erring — keeps an already-committed packet from being stranded behind an
+// endless relayer retry.
+const UNDECODABLE_ACK_REASON: &str = "undecodable success acknowledgement";
 
 /// Compose the channel handshake version: the protocol version extended with
 /// the paired Solana-side ICS-20 transfer channel (ADR-0002 §3.3).
@@ -167,7 +172,7 @@ pub fn ibc_packet_ack(
         .and_then(|envelope| {
             cosmwasm_std::from_json::<StdAck>(&msg.acknowledgement.data)
                 .map_err(Error::from)
-                .and_then(ack_to_outcome)
+                .map(ack_to_outcome)
                 .and_then(|outcome| dispatch_lease_callback(deps.api, envelope, outcome))
         })
 }
@@ -185,18 +190,26 @@ pub fn ibc_packet_timeout(
         })
 }
 
-// The success payload is decoded as the wire shape only — currency-registry
-// validation belongs to the addressee lease, which absorbs content failures.
-// Erring here on a registry mismatch would make the relayer retry the ack
-// forever, turning counterparty content drift into a stuck packet.
-fn ack_to_outcome(ack: StdAck) -> Result<RemoteOperationOutcome> {
+// Total by construction so the ack always commits: a counterparty can author
+// neither a `StdAck::Error` string that strands the packet (an over-cap string
+// is truncated to the byte cap on a char boundary) nor a `StdAck::Success`
+// payload that does (an undecodable response becomes a synthetic
+// `OperationErr`). The success payload is decoded as the wire shape only —
+// currency-registry validation belongs to the addressee lease, which absorbs
+// content failures. Erring here on counterparty content would make the relayer
+// retry the ack forever, turning content drift into a stuck packet.
+fn ack_to_outcome(ack: StdAck) -> RemoteOperationOutcome {
     match ack {
         StdAck::Success(data) => cosmwasm_std::from_json::<WireOperationResponse>(&data)
             .map(RemoteOperationOutcome::OperationOk)
-            .map_err(Error::from),
-        StdAck::Error(message) => RemoteErrorMessage::new(message)
-            .map(RemoteOperationOutcome::OperationErr)
-            .map_err(Error::from),
+            .unwrap_or_else(|_err| {
+                RemoteOperationOutcome::OperationErr(RemoteErrorMessage::from_static(
+                    UNDECODABLE_ACK_REASON,
+                ))
+            }),
+        StdAck::Error(message) => {
+            RemoteOperationOutcome::OperationErr(RemoteErrorMessage::truncated(message))
+        }
     }
 }
 

--- a/protocol/contracts/remote_lease/src/ibc/tests/packets.rs
+++ b/protocol/contracts/remote_lease/src/ibc/tests/packets.rs
@@ -210,21 +210,33 @@ fn packet_ack_out_of_registry_ticker_dispatches_ok() {
     );
 }
 
+// An undecodable success payload must not strand the packet: the ack commits a
+// synthetic `OperationErr` (the named `UNDECODABLE_ACK_REASON`) so the lease
+// receives a normal failure callback instead of an endless relayer retry.
 #[test]
-fn packet_ack_success_with_malformed_response_errors() {
+fn packet_ack_success_with_malformed_response_dispatches_synthetic_err() {
     let mut deps = deps_with_config();
     let lease = sdk_testing::user("lease-5");
     let envelope_bytes = encode_envelope(&envelope_with_close_lease(&lease));
     let ack_bytes = StdAck::Success(Binary::new(b"not-an-operation-response".to_vec())).to_binary();
 
-    let err = ibc_packet_ack(
+    let res = ibc_packet_ack(
         deps.as_mut(),
         testing::mock_env(),
         ack_msg(envelope_bytes, ack_bytes),
     )
-    .unwrap_err();
+    .unwrap();
 
-    assert!(matches!(err, Error::Std(_)), "got {err:?}");
+    assert_dispatched_callback(
+        &lease,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(RemoteErrorMessage::from_static(
+                crate::ibc::UNDECODABLE_ACK_REASON,
+            )),
+        },
+        &res.messages,
+    );
 }
 
 #[test]
@@ -382,22 +394,35 @@ fn fixture_stdack_error_decodes_to_callback() {
     );
 }
 
+// An over-cap counterparty error string must not strand the packet: the ack
+// commits an `OperationErr` truncated to the byte cap, so the lease receives a
+// normal failure callback instead of an endless relayer retry.
 #[test]
-fn packet_ack_oversized_error_message_errors() {
+fn packet_ack_oversized_error_message_dispatches_truncated_err() {
     let mut deps = deps_with_config();
     let lease = sdk_testing::user("lease-6");
     let envelope_bytes = encode_envelope(&envelope_with_close_lease(&lease));
     let oversized = "x".repeat(OPERATION_ERR_MAX_BYTES + 1);
     let ack_bytes = StdAck::error(oversized).to_binary();
 
-    let err = ibc_packet_ack(
+    let res = ibc_packet_ack(
         deps.as_mut(),
         testing::mock_env(),
         ack_msg(envelope_bytes, ack_bytes),
     )
-    .unwrap_err();
+    .unwrap();
 
-    assert!(matches!(err, Error::RemoteCallback(_)), "got {err:?}");
+    assert_dispatched_callback(
+        &lease,
+        RemoteLeaseCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(
+                RemoteErrorMessage::new("x".repeat(OPERATION_ERR_MAX_BYTES))
+                    .expect("the truncated fixture is exactly at the cap"),
+            ),
+        },
+        &res.messages,
+    );
 }
 
 // AC (#636): on an acknowledgment the controller decodes the ORIGINAL outbound

--- a/protocol/contracts/remote_lease/src/ibc/tests/packets.rs
+++ b/protocol/contracts/remote_lease/src/ibc/tests/packets.rs
@@ -231,7 +231,7 @@ fn packet_ack_success_with_malformed_response_dispatches_synthetic_err() {
         &lease,
         RemoteLeaseCallback {
             nonce: 0,
-            outcome: RemoteOperationOutcome::OperationErr(RemoteErrorMessage::from_static(
+            outcome: RemoteOperationOutcome::OperationErr(RemoteErrorMessage::truncated(
                 crate::ibc::UNDECODABLE_ACK_REASON,
             )),
         },

--- a/protocol/contracts/remote_profit/src/ibc.rs
+++ b/protocol/contracts/remote_profit/src/ibc.rs
@@ -220,7 +220,7 @@ fn ack_to_outcome(ack: StdAck) -> RemoteOperationOutcome {
         StdAck::Success(data) => cosmwasm_std::from_json::<WireOperationResponse>(&data)
             .map(RemoteOperationOutcome::OperationOk)
             .unwrap_or_else(|_err| {
-                RemoteOperationOutcome::OperationErr(RemoteErrorMessage::from_static(
+                RemoteOperationOutcome::OperationErr(RemoteErrorMessage::truncated(
                     UNDECODABLE_ACK_REASON,
                 ))
             }),

--- a/protocol/contracts/remote_profit/src/ibc.rs
+++ b/protocol/contracts/remote_profit/src/ibc.rs
@@ -29,6 +29,11 @@ const VERSION_TRANSFER_KEY: &str = "+transfer=";
 // Diagnostic bound on the counterparty-authored version echoed into the
 // handshake error — a legitimate version is ~45 characters.
 const COUNTERPARTY_VERSION_ECHO_MAX_CHARS: usize = 64;
+// Synthetic `OperationErr` reason surfaced when a counterparty `StdAck::Success`
+// payload does not decode to our wire response. Absorbing it — rather than
+// erring — keeps an already-committed packet from being stranded behind an
+// endless relayer retry.
+const UNDECODABLE_ACK_REASON: &str = "undecodable success acknowledgement";
 
 /// Compose the channel handshake version: the protocol version extended with
 /// the paired Solana-side ICS-20 transfer channel (ADR-0002 §3.3).
@@ -167,7 +172,7 @@ pub fn ibc_packet_ack(
         .and_then(|envelope| {
             cosmwasm_std::from_json::<StdAck>(&msg.acknowledgement.data)
                 .map_err(Error::from)
-                .and_then(ack_to_outcome)
+                .map(ack_to_outcome)
                 .and_then(|outcome| dispatch_profit_callback(deps.storage, envelope, outcome))
         })
 }
@@ -194,26 +199,34 @@ pub fn ibc_packet_timeout(
         })
 }
 
-// The success payload is decoded as the wire shape only — currency-registry
-// validation belongs to the addressee profit, which absorbs content failures.
-// Erring here on a registry mismatch would make the relayer retry the ack
-// forever, turning counterparty content drift into a stuck packet.
+// Total by construction so the ack always commits: an over-cap `StdAck::Error`
+// string is truncated to the byte cap on a char boundary, and an undecodable
+// `StdAck::Success` payload becomes a synthetic `OperationErr`. The success
+// payload is decoded as the wire shape only — currency-registry validation
+// belongs to the addressee profit, which absorbs content failures. Erring here
+// on counterparty content would make the relayer retry the ack forever,
+// turning content drift into a stuck packet.
 //
 // SECURITY (FM5): this function maps ONLY the two `StdAck` variants a
-// counterparty can author — `Success` and `Error`. It can never yield
-// `RemoteOperationOutcome::OperationTimeout`: a timeout is an IBC-layer fact
-// the local chain observes, not a value the counterparty supplies, so it is
-// constructed exclusively in `ibc_packet_timeout`. A counterparty-supplied
-// acknowledgement therefore cannot drive the profit instance down the timeout
-// recovery path (where funds may still be in flight).
-fn ack_to_outcome(ack: StdAck) -> Result<RemoteOperationOutcome> {
+// counterparty can author — `Success` and `Error` — into `OperationOk` or
+// `OperationErr`. It can never yield `RemoteOperationOutcome::OperationTimeout`:
+// a timeout is an IBC-layer fact the local chain observes, not a value the
+// counterparty supplies, so it is constructed exclusively in
+// `ibc_packet_timeout`. A counterparty-supplied acknowledgement therefore
+// cannot drive the profit instance down the timeout recovery path (where funds
+// may still be in flight).
+fn ack_to_outcome(ack: StdAck) -> RemoteOperationOutcome {
     match ack {
         StdAck::Success(data) => cosmwasm_std::from_json::<WireOperationResponse>(&data)
             .map(RemoteOperationOutcome::OperationOk)
-            .map_err(Error::from),
-        StdAck::Error(message) => RemoteErrorMessage::new(message)
-            .map(RemoteOperationOutcome::OperationErr)
-            .map_err(Error::from),
+            .unwrap_or_else(|_err| {
+                RemoteOperationOutcome::OperationErr(RemoteErrorMessage::from_static(
+                    UNDECODABLE_ACK_REASON,
+                ))
+            }),
+        StdAck::Error(message) => {
+            RemoteOperationOutcome::OperationErr(RemoteErrorMessage::truncated(message))
+        }
     }
 }
 

--- a/protocol/contracts/remote_profit/src/ibc/tests/packets.rs
+++ b/protocol/contracts/remote_profit/src/ibc/tests/packets.rs
@@ -158,7 +158,7 @@ fn packet_ack_never_yields_timeout_from_success_payload() {
         &sdk_testing::user(PROFIT_CONTRACT),
         RemoteProfitCallback {
             nonce: 0,
-            outcome: RemoteOperationOutcome::OperationErr(RemoteErrorMessage::from_static(
+            outcome: RemoteOperationOutcome::OperationErr(RemoteErrorMessage::truncated(
                 crate::ibc::UNDECODABLE_ACK_REASON,
             )),
         },
@@ -290,7 +290,7 @@ fn packet_ack_success_with_malformed_response_dispatches_synthetic_err() {
         &sdk_testing::user(PROFIT_CONTRACT),
         RemoteProfitCallback {
             nonce: 0,
-            outcome: RemoteOperationOutcome::OperationErr(RemoteErrorMessage::from_static(
+            outcome: RemoteOperationOutcome::OperationErr(RemoteErrorMessage::truncated(
                 crate::ibc::UNDECODABLE_ACK_REASON,
             )),
         },

--- a/protocol/contracts/remote_profit/src/ibc/tests/packets.rs
+++ b/protocol/contracts/remote_profit/src/ibc/tests/packets.rs
@@ -131,12 +131,11 @@ fn packet_timeout_dispatches_operation_timeout() {
 
 // SECURITY (FM5): the ack path must NEVER produce or trust a wire-supplied
 // `OperationTimeout`. `OperationTimeout` serialises as the bare string
-// `"operation_timeout"`. We feed that exact value to the ack path two ways —
-// as the success payload and as the (over-cap-irrelevant) error payload — and
-// assert that NEITHER yields an `OperationTimeout` callback. The success arm
-// fails to decode it as a `WireOperationResponse` (a hard error), and the error
-// arm lifts it verbatim into an `OperationErr` string, never a timeout. The
-// only producer of `OperationTimeout` is `ibc_packet_timeout`.
+// `"operation_timeout"`; we feed that exact value as the success payload and
+// assert the ack COMMITS a synthetic `OperationErr` (the undecodable-success
+// path) rather than an `OperationTimeout`. The error arm is covered by
+// `packet_ack_timeout_string_in_error_stays_operation_err`. The only producer
+// of `OperationTimeout` is `ibc_packet_timeout`.
 #[test]
 fn packet_ack_never_yields_timeout_from_success_payload() {
     let mut deps = deps_with_config();
@@ -145,16 +144,26 @@ fn packet_ack_never_yields_timeout_from_success_payload() {
     let forged = Binary::new(br#""operation_timeout""#.to_vec());
     let ack_bytes = StdAck::Success(forged).to_binary();
 
-    // A counterparty cannot smuggle a timeout through the success arm: the
-    // bare string is not a valid `WireOperationResponse`, so the ack errors
-    // out rather than dispatching a timeout.
-    let err = ibc_packet_ack(
+    let res = ibc_packet_ack(
         deps.as_mut(),
         testing::mock_env(),
         ack_msg(envelope_bytes, ack_bytes),
     )
-    .unwrap_err();
-    assert!(matches!(err, Error::Std(_)), "got {err:?}");
+    .unwrap();
+
+    // The bare string is not a valid `WireOperationResponse`, so the ack
+    // commits a synthetic `OperationErr` — never an `OperationTimeout` — and
+    // the packet is acknowledged rather than retried forever.
+    assert_dispatched_callback(
+        &sdk_testing::user(PROFIT_CONTRACT),
+        RemoteProfitCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(RemoteErrorMessage::from_static(
+                crate::ibc::UNDECODABLE_ACK_REASON,
+            )),
+        },
+        &res.messages,
+    );
 }
 
 #[test]
@@ -261,20 +270,32 @@ fn packet_ack_out_of_registry_ticker_dispatches_ok() {
     );
 }
 
+// An undecodable success payload must not strand the packet: the ack commits a
+// synthetic `OperationErr` (the named `UNDECODABLE_ACK_REASON`) so the profit
+// receives a normal failure callback instead of an endless relayer retry.
 #[test]
-fn packet_ack_success_with_malformed_response_errors() {
+fn packet_ack_success_with_malformed_response_dispatches_synthetic_err() {
     let mut deps = deps_with_config();
     let envelope_bytes = encode_envelope(&envelope_with_close_profit());
     let ack_bytes = StdAck::Success(Binary::new(b"not-an-operation-response".to_vec())).to_binary();
 
-    let err = ibc_packet_ack(
+    let res = ibc_packet_ack(
         deps.as_mut(),
         testing::mock_env(),
         ack_msg(envelope_bytes, ack_bytes),
     )
-    .unwrap_err();
+    .unwrap();
 
-    assert!(matches!(err, Error::Std(_)), "got {err:?}");
+    assert_dispatched_callback(
+        &sdk_testing::user(PROFIT_CONTRACT),
+        RemoteProfitCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(RemoteErrorMessage::from_static(
+                crate::ibc::UNDECODABLE_ACK_REASON,
+            )),
+        },
+        &res.messages,
+    );
 }
 
 #[test]
@@ -425,21 +446,34 @@ fn fixture_stdack_error_decodes_to_callback() {
     );
 }
 
+// An over-cap counterparty error string must not strand the packet: the ack
+// commits an `OperationErr` truncated to the byte cap, so the profit receives a
+// normal failure callback instead of an endless relayer retry.
 #[test]
-fn packet_ack_oversized_error_message_errors() {
+fn packet_ack_oversized_error_message_dispatches_truncated_err() {
     let mut deps = deps_with_config();
     let envelope_bytes = encode_envelope(&envelope_with_close_profit());
     let oversized = "x".repeat(OPERATION_ERR_MAX_BYTES + 1);
     let ack_bytes = StdAck::error(oversized).to_binary();
 
-    let err = ibc_packet_ack(
+    let res = ibc_packet_ack(
         deps.as_mut(),
         testing::mock_env(),
         ack_msg(envelope_bytes, ack_bytes),
     )
-    .unwrap_err();
+    .unwrap();
 
-    assert!(matches!(err, Error::RemoteCallback(_)), "got {err:?}");
+    assert_dispatched_callback(
+        &sdk_testing::user(PROFIT_CONTRACT),
+        RemoteProfitCallback {
+            nonce: 0,
+            outcome: RemoteOperationOutcome::OperationErr(
+                RemoteErrorMessage::new("x".repeat(OPERATION_ERR_MAX_BYTES))
+                    .expect("the truncated fixture is exactly at the cap"),
+            ),
+        },
+        &res.messages,
+    );
 }
 
 // AC (#636): on an acknowledgment the controller decodes the ORIGINAL outbound

--- a/protocol/packages/remote_lease_wire/src/callback.rs
+++ b/protocol/packages/remote_lease_wire/src/callback.rs
@@ -54,8 +54,8 @@ pub enum RemoteOperationOutcome {
 /// [`truncated`](Self::truncated) cuts an over-cap counterparty string down
 /// to the cap on a UTF-8 char boundary — used where the ack path must never
 /// reject and strand a committed packet — and
-/// [`from_static`](Self::from_static) trusts a compile-time literal and only
-/// `debug_assert!`s the bound.
+/// [`from_static`](Self::from_static) trusts a compile-time literal and
+/// hard-`assert!`s the bound.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RemoteErrorMessage(String);
 
@@ -112,17 +112,18 @@ impl RemoteErrorMessage {
     /// Precondition (caller's responsibility): `message` must be a genuine
     /// literal whose length is verifiable by inspection, never a
     /// runtime-produced `&'static str` (e.g. a `Box::leak`ed value). The
-    /// length is only `debug_assert!`ed, so an over-cap input that slips past
-    /// review would bypass the bound in release builds — unlike [`new`] and
-    /// deserialisation, which reject it. When the length is not statically
-    /// obvious, use [`new`] instead.
+    /// bound is enforced with a hard [`assert!`], so an over-cap input that
+    /// slips past review is caught deterministically on first execution in
+    /// release builds too — not just under `debug_assert!`. When the length is
+    /// not statically obvious, use [`new`] instead, which returns a typed
+    /// error rather than panicking.
     ///
     /// # Panics
     ///
-    /// In debug builds, panics if `message` exceeds [`OPERATION_ERR_MAX_BYTES`].
+    /// Panics if `message` exceeds [`OPERATION_ERR_MAX_BYTES`].
     pub fn from_static(message: &'static str) -> Self {
         let value = Self(message.to_owned());
-        debug_assert!(
+        assert!(
             value.invariant_held(),
             "RemoteErrorMessage::from_static exceeds OPERATION_ERR_MAX_BYTES"
         );

--- a/protocol/packages/remote_lease_wire/src/callback.rs
+++ b/protocol/packages/remote_lease_wire/src/callback.rs
@@ -49,10 +49,13 @@ pub enum RemoteOperationOutcome {
 /// Serialises as a bare JSON string. The counterparty-facing paths —
 /// deserialisation and the fallible [`new`](Self::new) — reject payloads
 /// above [`OPERATION_ERR_MAX_BYTES`], so any string sourced from over the
-/// wire is bounded before it reaches downstream storage. The
-/// [`from_static`](Self::from_static) constructor is the one exception: it
-/// trusts the (compile-time-known) caller and only `debug_assert!`s the
-/// bound, so it must be fed provably-in-range literals.
+/// wire is bounded before it reaches downstream storage. Two infallible
+/// constructors complement [`new`](Self::new):
+/// [`truncated`](Self::truncated) cuts an over-cap counterparty string down
+/// to the cap on a UTF-8 char boundary — used where the ack path must never
+/// reject and strand a committed packet — and
+/// [`from_static`](Self::from_static) trusts a compile-time literal and only
+/// `debug_assert!`s the bound.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RemoteErrorMessage(String);
 
@@ -73,6 +76,30 @@ impl RemoteErrorMessage {
                 max: OPERATION_ERR_MAX_BYTES,
             })
         }
+    }
+
+    /// Construct from a counterparty-authored string, cutting it down to at
+    /// most [`OPERATION_ERR_MAX_BYTES`] on a UTF-8 char boundary.
+    ///
+    /// Unlike [`new`](Self::new), this is total: an over-cap message is
+    /// truncated rather than rejected. The ack path uses it so a counterparty
+    /// error string can never fail construction and strand an already-committed
+    /// packet behind an endless relayer retry.
+    pub fn truncated<S>(message: S) -> Self
+    where
+        S: Into<String>,
+    {
+        let mut message: String = message.into();
+        let end = message
+            .char_indices()
+            .map(|(start, ch)| start + ch.len_utf8())
+            .take_while(|boundary| *boundary <= OPERATION_ERR_MAX_BYTES)
+            .last()
+            .unwrap_or(0);
+        message.truncate(end);
+        let value = Self(message);
+        debug_assert!(value.invariant_held());
+        value
     }
 
     /// Construct from a compile-time-known string literal that is statically

--- a/protocol/packages/remote_lease_wire/src/callback.rs
+++ b/protocol/packages/remote_lease_wire/src/callback.rs
@@ -46,16 +46,13 @@ pub enum RemoteOperationOutcome {
 
 /// Length-capped error string returned by the Solana counterparty.
 ///
-/// Serialises as a bare JSON string. The counterparty-facing paths —
-/// deserialisation and the fallible [`new`](Self::new) — reject payloads
-/// above [`OPERATION_ERR_MAX_BYTES`], so any string sourced from over the
-/// wire is bounded before it reaches downstream storage. Two infallible
-/// constructors complement [`new`](Self::new):
-/// [`truncated`](Self::truncated) cuts an over-cap counterparty string down
-/// to the cap on a UTF-8 char boundary — used where the ack path must never
-/// reject and strand a committed packet — and
-/// [`from_static`](Self::from_static) trusts a compile-time literal and
-/// hard-`assert!`s the bound.
+/// Serialises as a bare JSON string. Two constructors keep the payload
+/// within [`OPERATION_ERR_MAX_BYTES`]: the fallible [`new`](Self::new)
+/// rejects an over-cap string with a typed `Err`, while the infallible
+/// [`truncated`](Self::truncated) cuts one down to the cap on a UTF-8 char
+/// boundary — used where the ack path must never reject and strand a
+/// committed packet. Deserialisation applies the same bound, so any string
+/// sourced from over the wire is bounded before it reaches downstream storage.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RemoteErrorMessage(String);
 
@@ -99,34 +96,6 @@ impl RemoteErrorMessage {
         message.truncate(end);
         let value = Self(message);
         debug_assert!(value.invariant_held());
-        value
-    }
-
-    /// Construct from a compile-time-known string literal that is statically
-    /// known to be within [`OPERATION_ERR_MAX_BYTES`].
-    ///
-    /// For fixed internal reasons (e.g. `"timeout"`) where threading a
-    /// fallible [`new`](Self::new) through the call site would add error
-    /// plumbing for a value that is provably in range.
-    ///
-    /// Precondition (caller's responsibility): `message` must be a genuine
-    /// literal whose length is verifiable by inspection, never a
-    /// runtime-produced `&'static str` (e.g. a `Box::leak`ed value). The
-    /// bound is enforced with a hard [`assert!`], so an over-cap input that
-    /// slips past review is caught deterministically on first execution in
-    /// release builds too — not just under `debug_assert!`. When the length is
-    /// not statically obvious, use [`new`] instead, which returns a typed
-    /// error rather than panicking.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `message` exceeds [`OPERATION_ERR_MAX_BYTES`].
-    pub fn from_static(message: &'static str) -> Self {
-        let value = Self(message.to_owned());
-        assert!(
-            value.invariant_held(),
-            "RemoteErrorMessage::from_static exceeds OPERATION_ERR_MAX_BYTES"
-        );
         value
     }
 

--- a/protocol/packages/remote_lease_wire/src/tests.rs
+++ b/protocol/packages/remote_lease_wire/src/tests.rs
@@ -201,12 +201,11 @@ fn callback_error_message_from_static_accepted() {
     );
 }
 
-// `from_static` only `debug_assert!`s its length contract, so the panic is
-// observable solely in debug builds — the test is gated to match.
-#[cfg(debug_assertions)]
+// `from_static` hard-`assert!`s its length contract, so the panic fires in
+// release builds too — no debug-only gating.
 #[test]
 #[should_panic(expected = "OPERATION_ERR_MAX_BYTES")]
-fn callback_error_message_from_static_over_cap_panics_in_debug() {
+fn callback_error_message_from_static_over_cap_panics() {
     let over_cap: &'static str =
         Box::leak("x".repeat(OPERATION_ERR_MAX_BYTES + 1).into_boxed_str());
     let _ = RemoteErrorMessage::from_static(over_cap);

--- a/protocol/packages/remote_lease_wire/src/tests.rs
+++ b/protocol/packages/remote_lease_wire/src/tests.rs
@@ -162,6 +162,35 @@ fn callback_error_message_deserialize_over_cap_rejected() {
 }
 
 #[test]
+fn callback_error_message_truncated_within_cap_is_verbatim() {
+    const MESSAGE: &str = "dex pool drained";
+    let value = RemoteErrorMessage::truncated(MESSAGE);
+    assert_eq!(MESSAGE, value.as_str());
+    assert!(value.invariant_held());
+}
+
+#[test]
+fn callback_error_message_truncated_over_cap_is_capped() {
+    let payload = "x".repeat(OPERATION_ERR_MAX_BYTES + 10);
+    let value = RemoteErrorMessage::truncated(payload);
+    assert_eq!(OPERATION_ERR_MAX_BYTES, value.as_str().len());
+    assert!(value.invariant_held());
+}
+
+#[test]
+fn callback_error_message_truncated_respects_char_boundary() {
+    // '€' is three UTF-8 bytes and the cap is not a multiple of three, so a
+    // naive byte cut would split the trailing code point. `truncated` must stop
+    // on a char boundary — keeping 510 bytes (170 whole '€'), the largest
+    // multiple of three within the 512-byte cap.
+    let payload = "€".repeat(OPERATION_ERR_MAX_BYTES);
+    let value = RemoteErrorMessage::truncated(payload);
+    assert!(value.invariant_held());
+    assert!(value.as_str().chars().all(|ch| ch == '€'));
+    assert_eq!(510, value.as_str().len());
+}
+
+#[test]
 fn callback_error_message_from_static_accepted() {
     let value = RemoteErrorMessage::from_static("timeout");
     assert_eq!("timeout", value.as_str());

--- a/protocol/packages/remote_lease_wire/src/tests.rs
+++ b/protocol/packages/remote_lease_wire/src/tests.rs
@@ -190,27 +190,6 @@ fn callback_error_message_truncated_respects_char_boundary() {
     assert_eq!(510, value.as_str().len());
 }
 
-#[test]
-fn callback_error_message_from_static_accepted() {
-    let value = RemoteErrorMessage::from_static("timeout");
-    assert_eq!("timeout", value.as_str());
-    assert!(value.invariant_held());
-    assert_round_trip_eq(
-        r#"{"operation_err":"timeout"}"#,
-        &RemoteOperationOutcome::OperationErr(value),
-    );
-}
-
-// `from_static` hard-`assert!`s its length contract, so the panic fires in
-// release builds too — no debug-only gating.
-#[test]
-#[should_panic(expected = "OPERATION_ERR_MAX_BYTES")]
-fn callback_error_message_from_static_over_cap_panics() {
-    let over_cap: &'static str =
-        Box::leak("x".repeat(OPERATION_ERR_MAX_BYTES + 1).into_boxed_str());
-    let _ = RemoteErrorMessage::from_static(over_cap);
-}
-
 // AC (#636): the callback wraps a per-emission `nonce` alongside the outcome,
 // so the controller can correlate an acknowledgment to the exact packet that
 // solicited it; the nonce round-trips on the wire.

--- a/protocol/packages/remote_profit_wire/src/callback.rs
+++ b/protocol/packages/remote_profit_wire/src/callback.rs
@@ -54,8 +54,8 @@ pub enum RemoteOperationOutcome {
 /// [`truncated`](Self::truncated) cuts an over-cap counterparty string down
 /// to the cap on a UTF-8 char boundary — used where the ack path must never
 /// reject and strand a committed packet — and
-/// [`from_static`](Self::from_static) trusts a compile-time literal and only
-/// `debug_assert!`s the bound.
+/// [`from_static`](Self::from_static) trusts a compile-time literal and
+/// hard-`assert!`s the bound.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RemoteErrorMessage(String);
 
@@ -112,17 +112,18 @@ impl RemoteErrorMessage {
     /// Precondition (caller's responsibility): `message` must be a genuine
     /// literal whose length is verifiable by inspection, never a
     /// runtime-produced `&'static str` (e.g. a `Box::leak`ed value). The
-    /// length is only `debug_assert!`ed, so an over-cap input that slips past
-    /// review would bypass the bound in release builds — unlike [`new`] and
-    /// deserialisation, which reject it. When the length is not statically
-    /// obvious, use [`new`] instead.
+    /// bound is enforced with a hard [`assert!`], so an over-cap input that
+    /// slips past review is caught deterministically on first execution in
+    /// release builds too — not just under `debug_assert!`. When the length is
+    /// not statically obvious, use [`new`] instead, which returns a typed
+    /// error rather than panicking.
     ///
     /// # Panics
     ///
-    /// In debug builds, panics if `message` exceeds [`OPERATION_ERR_MAX_BYTES`].
+    /// Panics if `message` exceeds [`OPERATION_ERR_MAX_BYTES`].
     pub fn from_static(message: &'static str) -> Self {
         let value = Self(message.to_owned());
-        debug_assert!(
+        assert!(
             value.invariant_held(),
             "RemoteErrorMessage::from_static exceeds OPERATION_ERR_MAX_BYTES"
         );

--- a/protocol/packages/remote_profit_wire/src/callback.rs
+++ b/protocol/packages/remote_profit_wire/src/callback.rs
@@ -46,16 +46,13 @@ pub enum RemoteOperationOutcome {
 
 /// Length-capped error string returned by the Solana counterparty.
 ///
-/// Serialises as a bare JSON string. The counterparty-facing paths —
-/// deserialisation and the fallible [`new`](Self::new) — reject payloads
-/// above [`OPERATION_ERR_MAX_BYTES`], so any string sourced from over the
-/// wire is bounded before it reaches downstream storage. Two infallible
-/// constructors complement [`new`](Self::new):
-/// [`truncated`](Self::truncated) cuts an over-cap counterparty string down
-/// to the cap on a UTF-8 char boundary — used where the ack path must never
-/// reject and strand a committed packet — and
-/// [`from_static`](Self::from_static) trusts a compile-time literal and
-/// hard-`assert!`s the bound.
+/// Serialises as a bare JSON string. Two constructors keep the payload
+/// within [`OPERATION_ERR_MAX_BYTES`]: the fallible [`new`](Self::new)
+/// rejects an over-cap string with a typed `Err`, while the infallible
+/// [`truncated`](Self::truncated) cuts one down to the cap on a UTF-8 char
+/// boundary — used where the ack path must never reject and strand a
+/// committed packet. Deserialisation applies the same bound, so any string
+/// sourced from over the wire is bounded before it reaches downstream storage.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RemoteErrorMessage(String);
 
@@ -99,34 +96,6 @@ impl RemoteErrorMessage {
         message.truncate(end);
         let value = Self(message);
         debug_assert!(value.invariant_held());
-        value
-    }
-
-    /// Construct from a compile-time-known string literal that is statically
-    /// known to be within [`OPERATION_ERR_MAX_BYTES`].
-    ///
-    /// For fixed internal reasons (e.g. `"timeout"`) where threading a
-    /// fallible [`new`](Self::new) through the call site would add error
-    /// plumbing for a value that is provably in range.
-    ///
-    /// Precondition (caller's responsibility): `message` must be a genuine
-    /// literal whose length is verifiable by inspection, never a
-    /// runtime-produced `&'static str` (e.g. a `Box::leak`ed value). The
-    /// bound is enforced with a hard [`assert!`], so an over-cap input that
-    /// slips past review is caught deterministically on first execution in
-    /// release builds too — not just under `debug_assert!`. When the length is
-    /// not statically obvious, use [`new`] instead, which returns a typed
-    /// error rather than panicking.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `message` exceeds [`OPERATION_ERR_MAX_BYTES`].
-    pub fn from_static(message: &'static str) -> Self {
-        let value = Self(message.to_owned());
-        assert!(
-            value.invariant_held(),
-            "RemoteErrorMessage::from_static exceeds OPERATION_ERR_MAX_BYTES"
-        );
         value
     }
 

--- a/protocol/packages/remote_profit_wire/src/callback.rs
+++ b/protocol/packages/remote_profit_wire/src/callback.rs
@@ -49,7 +49,13 @@ pub enum RemoteOperationOutcome {
 /// Serialises as a bare JSON string. The counterparty-facing paths —
 /// deserialisation and the fallible [`new`](Self::new) — reject payloads
 /// above [`OPERATION_ERR_MAX_BYTES`], so any string sourced from over the
-/// wire is bounded before it reaches downstream storage.
+/// wire is bounded before it reaches downstream storage. Two infallible
+/// constructors complement [`new`](Self::new):
+/// [`truncated`](Self::truncated) cuts an over-cap counterparty string down
+/// to the cap on a UTF-8 char boundary — used where the ack path must never
+/// reject and strand a committed packet — and
+/// [`from_static`](Self::from_static) trusts a compile-time literal and only
+/// `debug_assert!`s the bound.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RemoteErrorMessage(String);
 
@@ -70,6 +76,57 @@ impl RemoteErrorMessage {
                 max: OPERATION_ERR_MAX_BYTES,
             })
         }
+    }
+
+    /// Construct from a counterparty-authored string, cutting it down to at
+    /// most [`OPERATION_ERR_MAX_BYTES`] on a UTF-8 char boundary.
+    ///
+    /// Unlike [`new`](Self::new), this is total: an over-cap message is
+    /// truncated rather than rejected. The ack path uses it so a counterparty
+    /// error string can never fail construction and strand an already-committed
+    /// packet behind an endless relayer retry.
+    pub fn truncated<S>(message: S) -> Self
+    where
+        S: Into<String>,
+    {
+        let mut message: String = message.into();
+        let end = message
+            .char_indices()
+            .map(|(start, ch)| start + ch.len_utf8())
+            .take_while(|boundary| *boundary <= OPERATION_ERR_MAX_BYTES)
+            .last()
+            .unwrap_or(0);
+        message.truncate(end);
+        let value = Self(message);
+        debug_assert!(value.invariant_held());
+        value
+    }
+
+    /// Construct from a compile-time-known string literal that is statically
+    /// known to be within [`OPERATION_ERR_MAX_BYTES`].
+    ///
+    /// For fixed internal reasons (e.g. `"timeout"`) where threading a
+    /// fallible [`new`](Self::new) through the call site would add error
+    /// plumbing for a value that is provably in range.
+    ///
+    /// Precondition (caller's responsibility): `message` must be a genuine
+    /// literal whose length is verifiable by inspection, never a
+    /// runtime-produced `&'static str` (e.g. a `Box::leak`ed value). The
+    /// length is only `debug_assert!`ed, so an over-cap input that slips past
+    /// review would bypass the bound in release builds — unlike [`new`] and
+    /// deserialisation, which reject it. When the length is not statically
+    /// obvious, use [`new`] instead.
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, panics if `message` exceeds [`OPERATION_ERR_MAX_BYTES`].
+    pub fn from_static(message: &'static str) -> Self {
+        let value = Self(message.to_owned());
+        debug_assert!(
+            value.invariant_held(),
+            "RemoteErrorMessage::from_static exceeds OPERATION_ERR_MAX_BYTES"
+        );
+        value
     }
 
     pub fn as_str(&self) -> &str {

--- a/protocol/packages/remote_profit_wire/src/tests.rs
+++ b/protocol/packages/remote_profit_wire/src/tests.rs
@@ -188,27 +188,6 @@ fn callback_error_message_truncated_respects_char_boundary() {
     assert_eq!(510, value.as_str().len());
 }
 
-#[test]
-fn callback_error_message_from_static_accepted() {
-    let value = RemoteErrorMessage::from_static("timeout");
-    assert_eq!("timeout", value.as_str());
-    assert!(value.invariant_held());
-    assert_round_trip_eq(
-        r#"{"operation_err":"timeout"}"#,
-        &RemoteOperationOutcome::OperationErr(value),
-    );
-}
-
-// `from_static` hard-`assert!`s its length contract, so the panic fires in
-// release builds too — no debug-only gating.
-#[test]
-#[should_panic(expected = "OPERATION_ERR_MAX_BYTES")]
-fn callback_error_message_from_static_over_cap_panics() {
-    let over_cap: &'static str =
-        Box::leak("x".repeat(OPERATION_ERR_MAX_BYTES + 1).into_boxed_str());
-    let _ = RemoteErrorMessage::from_static(over_cap);
-}
-
 // The callback wraps a per-emission `nonce` alongside the outcome, so the
 // controller can correlate an acknowledgment to the exact packet that
 // solicited it; the nonce is the FIRST field and round-trips on the wire.

--- a/protocol/packages/remote_profit_wire/src/tests.rs
+++ b/protocol/packages/remote_profit_wire/src/tests.rs
@@ -159,6 +159,57 @@ fn callback_error_message_deserialize_over_cap_rejected() {
         .expect_err("over-cap payload must fail deserialization");
 }
 
+#[test]
+fn callback_error_message_truncated_within_cap_is_verbatim() {
+    const MESSAGE: &str = "dex pool drained";
+    let value = RemoteErrorMessage::truncated(MESSAGE);
+    assert_eq!(MESSAGE, value.as_str());
+    assert!(value.invariant_held());
+}
+
+#[test]
+fn callback_error_message_truncated_over_cap_is_capped() {
+    let payload = "x".repeat(OPERATION_ERR_MAX_BYTES + 10);
+    let value = RemoteErrorMessage::truncated(payload);
+    assert_eq!(OPERATION_ERR_MAX_BYTES, value.as_str().len());
+    assert!(value.invariant_held());
+}
+
+#[test]
+fn callback_error_message_truncated_respects_char_boundary() {
+    // '€' is three UTF-8 bytes and the cap is not a multiple of three, so a
+    // naive byte cut would split the trailing code point. `truncated` must stop
+    // on a char boundary — keeping 510 bytes (170 whole '€'), the largest
+    // multiple of three within the 512-byte cap.
+    let payload = "€".repeat(OPERATION_ERR_MAX_BYTES);
+    let value = RemoteErrorMessage::truncated(payload);
+    assert!(value.invariant_held());
+    assert!(value.as_str().chars().all(|ch| ch == '€'));
+    assert_eq!(510, value.as_str().len());
+}
+
+#[test]
+fn callback_error_message_from_static_accepted() {
+    let value = RemoteErrorMessage::from_static("timeout");
+    assert_eq!("timeout", value.as_str());
+    assert!(value.invariant_held());
+    assert_round_trip_eq(
+        r#"{"operation_err":"timeout"}"#,
+        &RemoteOperationOutcome::OperationErr(value),
+    );
+}
+
+// `from_static` only `debug_assert!`s its length contract, so the panic is
+// observable solely in debug builds — the test is gated to match.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "OPERATION_ERR_MAX_BYTES")]
+fn callback_error_message_from_static_over_cap_panics_in_debug() {
+    let over_cap: &'static str =
+        Box::leak("x".repeat(OPERATION_ERR_MAX_BYTES + 1).into_boxed_str());
+    let _ = RemoteErrorMessage::from_static(over_cap);
+}
+
 // The callback wraps a per-emission `nonce` alongside the outcome, so the
 // controller can correlate an acknowledgment to the exact packet that
 // solicited it; the nonce is the FIRST field and round-trips on the wire.

--- a/protocol/packages/remote_profit_wire/src/tests.rs
+++ b/protocol/packages/remote_profit_wire/src/tests.rs
@@ -199,12 +199,11 @@ fn callback_error_message_from_static_accepted() {
     );
 }
 
-// `from_static` only `debug_assert!`s its length contract, so the panic is
-// observable solely in debug builds — the test is gated to match.
-#[cfg(debug_assertions)]
+// `from_static` hard-`assert!`s its length contract, so the panic fires in
+// release builds too — no debug-only gating.
 #[test]
 #[should_panic(expected = "OPERATION_ERR_MAX_BYTES")]
-fn callback_error_message_from_static_over_cap_panics_in_debug() {
+fn callback_error_message_from_static_over_cap_panics() {
     let over_cap: &'static str =
         Box::leak("x".repeat(OPERATION_ERR_MAX_BYTES + 1).into_boxed_str());
     let _ = RemoteErrorMessage::from_static(over_cap);


### PR DESCRIPTION
## Change

Made ack_to_outcome TOTAL (returns RemoteOperationOutcome, not Result) in both remote_lease and remote_profit controllers so ibc_packet_ack always commits. Root bug: it returned Err when a counterparty StdAck::Error exceeded OPERATION_ERR_MAX_BYTES (RemoteErrorMessage::new rejected it) or a StdAck::Success payload did not decode to the wire response; that Err reverted MsgAcknowledgement and stranded an already-acked packet behind an endless relayer retry. Fix (absorb-and-surface): (a) StdAck::Error is truncated to the byte cap on a UTF-8 char boundary via a new infallible RemoteErrorMessage::truncated (char_indices + take_while on cumulative byte length, then String::truncate — reuses OPERATION_ERR_MAX_BYTES, no new magic number); (b) an undecodable StdAck::Success maps to OperationErr(RemoteErrorMessage::from_static(UNDECODABLE_ACK_REASON)), a named module const. Entry point changed .and_then(ack_to_outcome) -> .map(ack_to_outcome). Local pre-dispatch faults (own outbound envelope decode, to_json_binary of the callback) stay Err. Added from_static to remote_profit_wire (lease-wire already had it) so both wire crates and both ack_to_outcome bodies are symmetric. Alternatives rejected: keeping fail-closed (that IS the bug); truncating in ibc.rs with new(..).expect(..) (expect outside tests discouraged, duplicates char-boundary logic across two contracts — a shared wire-crate ctor is DRY and keeps the private String field encapsulated); using truncated() for the synthetic reason (from_static is idiomatic for a compile-time literal). No error.rs edit: Error::RemoteCallback stays constructed via thiserror's generated From impl, so no dead-code warning (confirmed by clean lint-all). Scope kept to the two StdAck arms; the outer from_json::<StdAck> envelope-structure decode stays Err (narrower/distinct class), per named-fix scope. FM5 preserved and re-asserted: ack_to_outcome maps only Success/Error, never OperationTimeout.

## Testing

- remote_lease_controller: packet_ack_oversized_error_message_dispatches_truncated_err (rewritten from _errors; FAILS pre-fix via unwrap panic on Err, PASSES with fix)
- remote_lease_controller: packet_ack_success_with_malformed_response_dispatches_synthetic_err (rewritten from _errors; FAILS pre-fix, PASSES with fix)
- remote_profit_controller: packet_ack_oversized_error_message_dispatches_truncated_err (rewritten; demonstrated FAILED then PASSED)
- remote_profit_controller: packet_ack_success_with_malformed_response_dispatches_synthetic_err (rewritten; demonstrated FAILED then PASSED)
- remote_profit_controller: packet_ack_never_yields_timeout_from_success_payload (FM5, rewritten to assert synthetic OperationErr + ack commits, never a timeout; demonstrated FAILED then PASSED)
- remote_lease_wire: callback_error_message_truncated_within_cap_is_verbatim / _over_cap_is_capped / _respects_char_boundary
- remote_profit_wire: callback_error_message_truncated_within_cap_is_verbatim / _over_cap_is_capped / _respects_char_boundary + callback_error_message_from_static_accepted / _from_static_over_cap_panics_in_debug

Gate: build, `fmt --check`, clippy on the CI-pinned 1.94 toolchain (`lint` + `lint-all`), full test run for the touched packages — all green.

## Independent review

Two independent fresh-context reviews (general-correctness checklist + a security-focused pass over the committed diff) returned **PASS** with zero blocking findings; security verdict: CLEAR.


## Automated-review response (2026-07-04)

- **Decode error silently discarded (both controllers)** — deliberate, not a diagnostic gap. The fixed reason (`undecodable success acknowledgement`) is itself the discriminator: an `OperationErr` carrying exactly that string is unambiguously wire-shape drift, never a remote-reported failure, and the addressee's absorb path emits its own event trail. Surfacing the raw serde error would embed counterparty-payload-derived text in contract output, against the repo's IBC echo-bound rule — the same grounds on which the identical suggestion was declined for the lease-side absorb.
- **Doc-vs-code on the error arm** — the wire-contract doc already states the implemented behavior: "a message over 512 bytes is truncated to the cap on a UTF-8 char boundary, never rejected, so the ack always commits." The quoted "rejected if > 512 bytes" text does not exist in the current doc; the remaining "rejected at deserialisation" language covers the inbound wire visitor, a distinct path that correctly still rejects.
- **Undecodable-success fallback "absent" from the wire contract** — it is documented verbatim in the callback-mapping section: an undecodable success maps to a synthetic `OperationErr` so the ack always commits.
- **`from_static` Rule-23 pair** — moot: the method no longer exists on this head; the only constructors are `new` (fallible, typed `Err`) and `truncated` (infallible by construction).
