### PR TITLE
fix: absorb bad establishment acks in OpenProfit and add heal re-emit

### DIFF
--- a/protocol/contracts/profit/src/state/open_profit.rs
+++ b/protocol/contracts/profit/src/state/open_profit.rs
@@ -187,8 +187,11 @@ impl Handler for OpenProfit {
     /// The one operator recovery out of a wedged establishment: an absorbed bad
     /// ack consumed the one-shot `OpenProfit` packet without transitioning, so
     /// no further callback will arrive. Re-emitting the packet re-solicits the
-    /// acknowledgment. Permissionless, like the remote-swap heal — the
-    /// controller still authorises the callback it answers with.
+    /// acknowledgment. Permissionless, like the live-leg transfer-out heal
+    /// (the admin-gated heal is the parked slippage-anomaly terminal's, which
+    /// forfeits a pinned floor — re-emitting an establishment packet forfeits
+    /// nothing) — the controller still authorises the callback it answers
+    /// with, and the caller pays the gas.
     fn heal(
         self,
         _querier: QuerierWrapper<'_>,

--- a/protocol/contracts/profit/src/state/open_profit.rs
+++ b/protocol/contracts/profit/src/state/open_profit.rs
@@ -8,7 +8,10 @@ use dex::{
     Result as SwapDecision,
 };
 use finance::{duration::Duration, instant::Instant};
-use platform::{batch::Batch, message::Response as PlatformResponse};
+use platform::{
+    batch::{Batch, Emit, Emitter},
+    message::Response as PlatformResponse,
+};
 use remote_profit::{
     msg::{NolusReceiver, OpenProfitParams},
     response::{OpenProfitResponse, OperationResponse},
@@ -26,9 +29,17 @@ use super::{Config, State, StateEnum, idle::Idle};
 /// is governance-driven and deploys a new contract.
 const INSTANCE_ORDINAL: u16 = 0;
 
-/// A non-`OpenProfit` acknowledgment cannot have resolved the establishment
-/// packet — the only operation this state emits.
-const NON_OPEN_PROFIT_RESPONSE: &str = "non-open-profit operation response";
+/// The establishment event surfacing a bad-ack absorb or an operator heal, so
+/// monitoring can tell a wedged-then-recovered establishment apart from a
+/// normal cycle.
+const EVENT_TYPE_ESTABLISHMENT: &str = "profit-establishment";
+const EVENT_KEY_ABSORBED: &str = "absorbed";
+const EVENT_KEY_HEAL: &str = "heal";
+const EVENT_VALUE_REEMIT: &str = "re-emit";
+/// A decodable acknowledgment carrying a non-`OpenProfit` variant.
+const ABSORB_UNEXPECTED_VARIANT: &str = "unexpected-response-variant";
+/// An acknowledgment payload that does not decode into an operation response.
+const ABSORB_UNDECODABLE: &str = "undecodable-response";
 
 /// The establishment state.
 ///
@@ -97,6 +108,40 @@ impl OpenProfit {
             })
             .map_err(Into::into)
     }
+
+    /// Commit the acknowledgment (so the relayer stops redelivering) while
+    /// staying in the establishment state and surfacing `event`. Shared by the
+    /// bad-ack absorb and the operator heal re-emission.
+    fn stay_open(self, batch: Batch, event: Emitter) -> SwapDecision<Self> {
+        SwapDecision::Continue(Ok(DexResponse::<State>::from(
+            PlatformResponse::messages_with_event(batch, event),
+            State(StateEnum::OpenProfit(self)),
+        )))
+    }
+
+    /// Absorb a bad establishment acknowledgment — a decodable non-`OpenProfit`
+    /// variant or an undecodable payload. Erroring would revert the controller's
+    /// ack and loop the relayer on the same one-shot packet; absorbing commits
+    /// the ack and leaves the profit in `OpenProfit`, recoverable via
+    /// [`Handler::heal`].
+    fn absorb(self, reason: &str) -> SwapDecision<Self> {
+        let event = Emitter::of_type(EVENT_TYPE_ESTABLISHMENT).emit(EVENT_KEY_ABSORBED, reason);
+        self.stay_open(Batch::default(), event)
+    }
+
+    /// Re-emit the one-shot establishment packet to re-solicit the
+    /// acknowledgment, recovering a profit wedged in `OpenProfit` by an absorbed
+    /// bad ack.
+    fn reemit_establishment(self) -> SwapDecision<Self> {
+        match self.open_profit_msg() {
+            Ok(batch) => {
+                let event = Emitter::of_type(EVENT_TYPE_ESTABLISHMENT)
+                    .emit(EVENT_KEY_HEAL, EVENT_VALUE_REEMIT);
+                self.stay_open(batch, event)
+            }
+            Err(err) => SwapDecision::Finished(Err(err)),
+        }
+    }
 }
 
 impl Handler for OpenProfit {
@@ -119,6 +164,11 @@ impl Handler for OpenProfit {
         .map_err(DexError::Unauthorized)
     }
 
+    /// A decodable non-`OpenProfit` variant and an undecodable payload are both
+    /// absorbed rather than erroring: the establishment ack rides the callback
+    /// path, so an error would revert the controller's ack and loop the relayer
+    /// forever on the same malformed packet. A well-formed `OpenProfit` ack runs
+    /// the regular flow and lets any downstream failure propagate.
     fn on_remote_response(
         self,
         data: sdk::cosmwasm_std::Binary,
@@ -126,17 +176,27 @@ impl Handler for OpenProfit {
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> SwapDecision<Self> {
-        let decoded = cosmwasm_std::from_json::<OperationResponse>(data.as_slice())
-            .map_err(ContractError::from);
-        match decoded {
+        match cosmwasm_std::from_json::<OperationResponse>(data.as_slice()) {
             Ok(OperationResponse::OpenProfit(response)) => {
                 SwapDecision::Finished(self.learn_authority(&response, &env, querier))
             }
-            Ok(_other) => SwapDecision::Finished(Err(ContractError::unsupported_operation(
-                NON_OPEN_PROFIT_RESPONSE,
-            ))),
-            Err(err) => SwapDecision::Finished(Err(err)),
+            Ok(_other) => self.absorb(ABSORB_UNEXPECTED_VARIANT),
+            Err(_undecodable) => self.absorb(ABSORB_UNDECODABLE),
         }
+    }
+
+    /// The one operator recovery out of a wedged establishment: an absorbed bad
+    /// ack consumed the one-shot `OpenProfit` packet without transitioning, so
+    /// no further callback will arrive. Re-emitting the packet re-solicits the
+    /// acknowledgment. Permissionless, like the remote-swap heal — the
+    /// controller still authorises the callback it answers with.
+    fn heal(
+        self,
+        _querier: QuerierWrapper<'_>,
+        _env: Env,
+        _info: &MessageInfo,
+    ) -> SwapDecision<Self> {
+        self.reemit_establishment()
     }
 }
 
@@ -171,3 +231,178 @@ enum ControllerExecuteMsg {
 }
 
 impl ControllerInnerMessage for ControllerExecuteMsg {}
+
+#[cfg(all(feature = "internal.test.contract", test))]
+mod tests {
+    use dex::{Account, ConnectionParams, Handler, Ics20Channel, Result as SwapDecision};
+    use platform::response;
+    use remote_profit::response::{
+        OpenProfitResponse, OperationResponse, RemoteProfitId, TransferOutResponse,
+    };
+    use sdk::{
+        cosmwasm_ext::Response as CwResponse,
+        cosmwasm_std::{
+            self, Addr, Binary, Event, MessageInfo, QuerierWrapper,
+            testing::{self, MockQuerier},
+        },
+    };
+    use timealarms::stub::TimeAlarmsRef;
+
+    use crate::state::VaultConfig;
+
+    use super::{Config, OpenProfit, State};
+
+    /// A valid bech32 Nolus address so the establishment message the heal
+    /// re-emits builds its `NolusReceiver` successfully.
+    const DRAIN_VAULT: &str = "nolus1mf6ptkssddfmxvhdx0ech0k03ktp6kf9yk59renau2gvht3nq2gqkxgywu";
+    const CONTROLLER: &str = "controller";
+    const CADENCE_HOURS: u16 = 24;
+
+    /// A decodable non-`OpenProfit` acknowledgment is committed, not errored, and
+    /// leaves the profit in the establishment state so the relayer stops
+    /// redelivering.
+    #[test]
+    fn bad_variant_ack_is_absorbed_and_stays_open() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let (response, next) = continued(open().on_remote_response(
+            ack(&OperationResponse::TransferOut(TransferOutResponse {})),
+            NONCE,
+            querier,
+            testing::mock_env(),
+        ));
+
+        assert_eq!("OpenProfit", next.to_string());
+        assert_absorbed(super::ABSORB_UNEXPECTED_VARIANT, &response);
+    }
+
+    /// An undecodable acknowledgment payload is absorbed the same way.
+    #[test]
+    fn undecodable_ack_is_absorbed_and_stays_open() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let (response, next) = continued(open().on_remote_response(
+            Binary::from(b"not an operation response".as_slice()),
+            NONCE,
+            querier,
+            testing::mock_env(),
+        ));
+
+        assert_eq!("OpenProfit", next.to_string());
+        assert_absorbed(super::ABSORB_UNDECODABLE, &response);
+    }
+
+    /// An operator heal re-emits the one establishment packet and stays in the
+    /// establishment state, so a profit wedged by an absorbed bad ack recovers.
+    #[test]
+    fn heal_reemits_the_establishment_packet() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let (response, next) = continued(open().heal(querier, testing::mock_env(), &healer()));
+
+        assert_eq!("OpenProfit", next.to_string());
+        assert_eq!(1, response.messages.len());
+        assert_eq!(1, response.events.len());
+        assert_eq!(
+            Event::new(super::EVENT_TYPE_ESTABLISHMENT)
+                .add_attribute(super::EVENT_KEY_HEAL, super::EVENT_VALUE_REEMIT),
+            response.events[0]
+        );
+    }
+
+    /// The happy path is unchanged: a well-formed `OpenProfit` acknowledgment
+    /// learns the authority and transitions to `Idle`.
+    #[test]
+    fn open_profit_ack_transitions_to_idle() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let next = finished(open().on_remote_response(
+            ack(&OperationResponse::OpenProfit(OpenProfitResponse {
+                remote_profit_id: profit_id(),
+            })),
+            NONCE,
+            querier,
+            testing::mock_env(),
+        ));
+
+        assert_eq!("Idle", next.to_string());
+    }
+
+    const NONCE: u64 = 1;
+
+    fn assert_absorbed(reason: &str, response: &CwResponse) {
+        assert_eq!(0, response.messages.len());
+        assert_eq!(1, response.events.len());
+        assert_eq!(
+            Event::new(super::EVENT_TYPE_ESTABLISHMENT)
+                .add_attribute(super::EVENT_KEY_ABSORBED, reason),
+            response.events[0]
+        );
+    }
+
+    fn continued(res: SwapDecision<OpenProfit>) -> (CwResponse, State) {
+        match res {
+            SwapDecision::Continue(Ok(resp)) => (
+                response::response_only_messages(resp.response),
+                resp.next_state,
+            ),
+            SwapDecision::Continue(Err(err)) => panic!("expected a continuation, got error {err}"),
+            SwapDecision::Finished(_res) => panic!("expected a continuation, got a finish"),
+        }
+    }
+
+    fn finished(res: SwapDecision<OpenProfit>) -> State {
+        match res {
+            SwapDecision::Finished(Ok(resp)) => resp.next_state,
+            SwapDecision::Finished(Err(err)) => panic!("expected a finish, got error {err}"),
+            SwapDecision::Continue(_res) => panic!("expected a finish, got a continuation"),
+        }
+    }
+
+    fn open() -> OpenProfit {
+        OpenProfit::new(config())
+    }
+
+    fn config() -> Config {
+        Config::new(
+            CADENCE_HOURS,
+            Addr::unchecked("treasury"),
+            oracle_platform::OracleRef::unchecked(Addr::unchecked("oracle")),
+            TimeAlarmsRef::unchecked("timealarms"),
+            Account::funding(
+                Addr::unchecked("profit"),
+                ConnectionParams {
+                    connection_id: "connection-0".to_owned(),
+                    transfer_channel: Ics20Channel {
+                        local_endpoint: "channel-0".to_owned(),
+                        remote_endpoint: "channel-2048".to_owned(),
+                    },
+                },
+            ),
+            Addr::unchecked(CONTROLLER),
+            VaultConfig {
+                code_id: cosmwasm_std::from_json(b"3").expect("a valid code id"),
+                address: Addr::unchecked(DRAIN_VAULT),
+            },
+        )
+    }
+
+    fn healer() -> MessageInfo {
+        MessageInfo {
+            sender: Addr::unchecked(CONTROLLER),
+            funds: vec![],
+        }
+    }
+
+    fn ack(response: &OperationResponse) -> Binary {
+        cosmwasm_std::to_json_binary(response).expect("the response serializes")
+    }
+
+    fn profit_id() -> RemoteProfitId {
+        RemoteProfitId::new("So1RayProfit").expect("a base58 profit id")
+    }
+}

--- a/protocol/contracts/profit/src/state/open_profit.rs
+++ b/protocol/contracts/profit/src/state/open_profit.rs
@@ -134,11 +134,10 @@ impl OpenProfit {
     /// bad ack.
     fn reemit_establishment(self) -> SwapDecision<Self> {
         match self.open_profit_msg() {
-            Ok(batch) => {
-                let event = Emitter::of_type(EVENT_TYPE_ESTABLISHMENT)
-                    .emit(EVENT_KEY_HEAL, EVENT_VALUE_REEMIT);
-                self.stay_open(batch, event)
-            }
+            Ok(batch) => self.stay_open(
+                batch,
+                Emitter::of_type(EVENT_TYPE_ESTABLISHMENT).emit(EVENT_KEY_HEAL, EVENT_VALUE_REEMIT),
+            ),
             Err(err) => SwapDecision::Finished(Err(err)),
         }
     }
@@ -257,6 +256,7 @@ mod tests {
     const DRAIN_VAULT: &str = "nolus1mf6ptkssddfmxvhdx0ech0k03ktp6kf9yk59renau2gvht3nq2gqkxgywu";
     const CONTROLLER: &str = "controller";
     const CADENCE_HOURS: u16 = 24;
+    const NONCE: u64 = 1;
 
     /// A decodable non-`OpenProfit` acknowledgment is committed, not errored, and
     /// leaves the profit in the establishment state so the relayer stops
@@ -313,6 +313,22 @@ mod tests {
         );
     }
 
+    /// A heal whose config cannot build the establishment packet reverts the
+    /// heal transaction rather than absorbing, so the profit is left untouched
+    /// for a later retry — a synchronous heal error reverts only the heal tx.
+    #[test]
+    fn heal_with_unbuildable_packet_reverts() {
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let unhealable = OpenProfit::new(config_with_vault("not-a-nolus-address"));
+
+        assert!(matches!(
+            unhealable.heal(querier, testing::mock_env(), &healer()),
+            SwapDecision::Finished(Err(_))
+        ));
+    }
+
     /// The happy path is unchanged: a well-formed `OpenProfit` acknowledgment
     /// learns the authority and transitions to `Idle`.
     #[test]
@@ -331,8 +347,6 @@ mod tests {
 
         assert_eq!("Idle", next.to_string());
     }
-
-    const NONCE: u64 = 1;
 
     fn assert_absorbed(reason: &str, response: &CwResponse) {
         assert_eq!(0, response.messages.len());
@@ -368,6 +382,10 @@ mod tests {
     }
 
     fn config() -> Config {
+        config_with_vault(DRAIN_VAULT)
+    }
+
+    fn config_with_vault(vault: &str) -> Config {
         Config::new(
             CADENCE_HOURS,
             Addr::unchecked("treasury"),
@@ -386,7 +404,7 @@ mod tests {
             Addr::unchecked(CONTROLLER),
             VaultConfig {
                 code_id: cosmwasm_std::from_json(b"3").expect("a valid code id"),
-                address: Addr::unchecked(DRAIN_VAULT),
+                address: Addr::unchecked(vault),
             },
         )
     }

--- a/protocol/contracts/remote_profit/src/contract.rs
+++ b/protocol/contracts/remote_profit/src/contract.rs
@@ -33,14 +33,17 @@ use crate::{
 
 const CONTRACT_STORAGE_VERSION: VersionSegment = 0;
 
-/// Envelope nonce for the single-packet operations that have no duplicate-
-/// callback window to close.
+/// Envelope nonce for the single-packet operations that carry no
+/// per-emission correlation.
 ///
-/// `OpenProfit`/`CloseProfit` solicit exactly one callback, so a superseded-
-/// packet race cannot arise and they ride a zero nonce. `Swap` (#636) and the
-/// multi-leg `TransferOut` drain (#671) instead carry a real per-emission nonce
-/// the profit assigns, so a packet superseded by a re-emission or heal is
-/// rejected.
+/// `OpenProfit`/`CloseProfit` ride a zero nonce. A heal re-emission of the
+/// establishment can leave a superseded packet in flight; its eventual
+/// callback (ack, error, or timeout) lands after the transition and is
+/// absorbed by the receiving state — `Idle` authorizes the controller and
+/// swallows it with an event — so the acknowledgment always commits. `Swap`
+/// (#636) and the multi-leg `TransferOut` drain (#671) instead carry a real
+/// per-emission nonce the profit assigns, so a superseded packet is rejected
+/// by nonce-mismatch while a leg is still in flight.
 const NO_NONCE: u64 = 0;
 const CURRENT_RELEASE: ProtocolPackageRelease = ProtocolPackageRelease::current(
     package_name!(),


### PR DESCRIPTION
## Change

Bug: `OpenProfit::on_remote_response` returned `SwapDecision::Finished(Err(..))` for the `Ok(_other)` (decodable non-`OpenProfit` variant) and `Err(_decode)` (undecodable) arms. Those faults ride the controller callback path, so the `Err` reverts the controller's `ibc_packet_ack`, causing the relayer to redeliver the same malformed establishment ack forever.

Alternatives considered:
1. Err-and-loop (status quo) — never strands state, but relayer loops indefinitely on a malformed ack. Rejected: not operable.
2. Absorb-only — return Ok on the fault arms so the ack commits. Rejected: it WEDGES the profit permanently. The establishment `OpenProfit` packet is one-shot and now consumed; no further callback arrives, and OpenProfit had no heal path, so the contract is stuck pre-Idle with no recovery.
3. Absorb + heal (chosen) — the only shape satisfying both "never strand the relayer" AND "operator-recoverable". On the two fault arms, ABSORB: stay in OpenProfit, emit a named-const `profit-establishment` event (`absorbed=unexpected-response-variant`/`undecodable-response`), return Ok so the ack commits — mirroring dex `remote_swap.rs`'s `absorb`/`emit_absorbed` shape. AND add a `Handler::heal` override that RE-EMITS the establishment `OpenProfit` packet (via the existing `open_profit_msg`, emitting `heal=re-emit`), mirroring how the dex remote-swap leg re-emits its in-flight op on heal. Result: no relayer loop, and `ExecuteMsg::Heal` (permissionless at the contract entry, like the remote-swap heal — the controller still authorises the callback it answers) re-solicits the acknowledgment. Well-formed `OpenProfit` acks are unchanged: learn authority, transition to Idle. Introduced a private `stay_open` shared by absorb and heal to build the stay-in-OpenProfit Continue response. Removed the now-unused `NON_OPEN_PROFIT_RESPONSE` const. No storage/wire change.

## Testing

- bad_variant_ack_is_absorbed_and_stays_open (failed pre-fix: 'expected a continuation, got a finish' -> passes)
- undecodable_ack_is_absorbed_and_stays_open (failed pre-fix: 'expected a continuation, got a finish' -> passes)
- heal_reemits_the_establishment_packet (failed pre-fix: 'handle heal is not supported in OpenProfit' -> passes)
- open_profit_ack_transitions_to_idle (regression guard: passed before and after; asserts happy-path Idle transition unchanged)

Gate: build, `fmt --check`, clippy on the CI-pinned 1.94 toolchain (`lint` + `lint-all`), full test run for the touched packages — all green.

## Independent review

Two independent fresh-context reviews (general-correctness checklist + a security-focused pass over the committed diff) returned **PASS** with zero blocking findings; security verdict: CLEAR.


## Automated-review response (2026-07-03)

Three findings fixed in follow-up commits (test const ordering, indent flatten, heal-revert-path coverage). The remaining four, verified against code:

- **Missing nonce guard on the heal re-emit** — the mechanism as stated (double-transition in `OpenProfit`) does not exist: the first valid ack transitions to `Idle` and `learn_authority` runs exactly once. The real superseded-packet window the heal creates is handled by composition with the settled-state absorb change (#708) — **merge order: #708 lands before or together with this PR**; on this branch alone `Idle` still rejects the superseded callback: `Idle` authorizes the pinned controller and absorbs the late callback with an event, so the superseded packet's ack/timeout always commits. Nonce 0 cannot collide — `Idle` holds nothing in flight, and the swap/drain legs open at nonce ≥ 1. The `NO_NONCE` doc comment is updated to state the actual invariant. A per-emission establishment nonce remains a possible hardening but adds no safety the absorb does not already provide.
- **Silent swallow of decode error** — deliberate: mirrors the remote-swap absorb (`remote_swap.rs`, `ABSORB_UNDECODABLE`), and surfacing the raw serde text would echo a counterparty-authored payload unbounded, against the IBC echo-bound convention.
- **Permissionless heal** — the codebase-wide heal convention (dex swap/transfer heals identically ignore the sender); authorization lives on the callback that answers the re-emission, gated to `Config.remote_profit_controller`. The heal only re-emits at the caller's own gas cost.
- **Unrecoverable error path on heal re-emit** — the `Err` arm is unreachable in production (the drain-vault address is validated before `OpenProfit` is entered and the config is immutable in that state), and if hit reverts only the retryable heal transaction, no ack. Now covered by a test.



## Automated-review response, round 3 (2026-07-04)

- **"Missing entry-point validation on heal" / "remote-swap heal is operator-gated"** — conflates the two dex heals. The live-leg heals are permissionless (`remote_transfer_out.rs` heal ignores the sender; `ExecuteMsg::Heal` carries no access check by design); only the parked slippage-anomaly terminal's heal is admin-gated, because resolving it forfeits a pinned floor. Re-emitting an establishment packet forfeits nothing and grants nothing — the caller pays the gas, and the callback that answers is gated to the pinned controller. The doc comment now names the live-leg referent explicitly.
- **"Idle authorizes" mechanism imprecise** — `idle.rs` carries Idle's own `authz_remote_callback` override authorizing the pinned controller; the state machine invokes exactly that before delivery, and the absorb is Idle's inherited handler behavior. The comment is accurate at doc-comment altitude.
- Remaining listed items are the prior round's threads, already dispositioned above and resolved. This PR now carries the `no-auto-review` label — the disposition record lives here in the body.
