### PR TITLE
fix: under-min-out swap acks consume the timeout retry budget

### DIFF
--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -227,32 +227,6 @@ where
         })
     }
 
-    /// An acknowledgment below the leg's pinned floor is a counterparty
-    /// contract violation - the remote side enforces the very `min_out`
-    /// this node emitted, persisted in `in_flight_min_out`. Validating
-    /// against the pinned value rather than a fresh oracle quote keeps the
-    /// check aligned with the promise actually made: price drift can
-    /// neither retroactively reclassify a compliant, already-executed swap
-    /// as underpaid nor admit an amount below the promised floor. The leg
-    /// is re-emitted instead of accepted or absorbed, mirroring the error
-    /// treatment: only the in-flight leg retries, the accumulated progress
-    /// stays intact.
-    fn deliver_ack(
-        self,
-        coin_out: CoinDTO<SwapTask::OutG>,
-        querier: QuerierWrapper<'_>,
-        env: Env,
-    ) -> HandlerResult<Self> {
-        if coin_out.currency() != self.total_out.currency() {
-            return self.absorb(ABSORB_CURRENCY_MISMATCH).into();
-        }
-        if coin_out.amount() < self.in_flight_min_out.amount() {
-            self.reemit_underpaid().into()
-        } else {
-            self.apply_ack(coin_out, querier, env)
-        }
-    }
-
     /// An acknowledgment overflowing the accumulated total comes from a
     /// counterparty in breach of the coin amount bounds and is absorbed
     /// like the other malformed payloads - an error would revert the
@@ -611,6 +585,53 @@ where
     Self: Into<SEnum>,
     SlippageAnomaly<SwapTask, SEnum>: Into<SEnum>,
 {
+    /// An acknowledgment below the leg's pinned floor is a counterparty
+    /// contract violation - the remote side enforces the very `min_out`
+    /// this node emitted, persisted in `in_flight_min_out`. Validating
+    /// against the pinned value rather than a fresh oracle quote keeps the
+    /// check aligned with the promise actually made: price drift can
+    /// neither retroactively reclassify a compliant, already-executed swap
+    /// as underpaid nor admit an amount below the promised floor. The leg
+    /// re-emits within the shared timeout retry budget and escalates into
+    /// the slippage-anomaly terminal past it, exactly as a timeout does, so
+    /// a counterparty returning persistently under-floor acks cannot drive
+    /// an unbounded re-emission loop; only the in-flight leg retries and the
+    /// accumulated progress stays intact.
+    fn deliver_ack(
+        self,
+        coin_out: CoinDTO<SwapTask::OutG>,
+        querier: QuerierWrapper<'_>,
+        env: Env,
+    ) -> HandlerResult<Self> {
+        if coin_out.currency() != self.total_out.currency() {
+            return self.absorb(ABSORB_CURRENCY_MISMATCH).into();
+        }
+        if coin_out.amount() < self.in_flight_min_out.amount() {
+            self.reemit_or_escalate_underpaid(querier, env)
+        } else {
+            self.apply_ack(coin_out, querier, env)
+        }
+    }
+
+    /// An under-floor OK-ack consumes the same retry budget as a timeout:
+    /// within budget it re-emits the in-flight leg, past budget it escalates
+    /// into the slippage-anomaly terminal per the spec's policy, exactly as
+    /// the timeout path does. Sharing the `timeouts` budget is what stops a
+    /// counterparty returning persistently under-floor acks from driving an
+    /// unbounded re-emission loop that never parks.
+    fn reemit_or_escalate_underpaid(
+        self,
+        querier: QuerierWrapper<'_>,
+        env: Env,
+    ) -> HandlerResult<Self> {
+        let bumped = self.with_incremented_timeouts();
+        if bumped.timeouts <= bumped.spec.timeout_retry_budget() {
+            bumped.reemit_underpaid().into()
+        } else {
+            bumped.escalate(querier, env)
+        }
+    }
+
     /// Escalate a leg whose timeout retry budget is spent, per the spec's
     /// policy: park the opened legs at the slippage-anomaly terminal, or
     /// re-emit the opening swap verbatim. An explicit error never reaches
@@ -1505,6 +1526,75 @@ mod tests {
             ),
             response
         );
+        assert_node(2, &coin_out(50), &coin_out(PINNED_FLOOR), &node);
+    }
+
+    /// Repeated under-floor OK-acks consume the same retry budget as
+    /// timeouts: each in-budget under-floor ack re-emits and advances the
+    /// counter, and the round past the budget parks at the slippage-anomaly
+    /// terminal carrying the pinned floor - a counterparty returning
+    /// persistently under-floor acks can no longer drive an unbounded
+    /// re-emission loop.
+    #[test]
+    fn repeated_underpaid_acks_spend_the_budget_and_park() {
+        const PINNED_FLOOR: Amount = 40;
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let mut spec = spec3();
+        spec.set_floor(PINNED_FLOOR);
+        let (_response, mut node) = continued(Node::start(spec, &testing::mock_env(), querier));
+
+        let budget = mock_budget();
+        for round in 1..=budget {
+            let nonce = node.in_flight_nonce;
+            let (_response, next) = continued(node.on_remote_response(
+                payload(&coin_out(PINNED_FLOOR - 1)),
+                nonce,
+                querier,
+                testing::mock_env(),
+            ));
+            node = next;
+            assert_eq!(round, node.timeouts);
+            assert_node(2, &coin_out(50), &coin_out(PINNED_FLOOR), &node);
+        }
+
+        let nonce = node.in_flight_nonce;
+        let (response, terminal) = parked(node.on_remote_response(
+            payload(&coin_out(PINNED_FLOOR - 1)),
+            nonce,
+            querier,
+            testing::mock_env(),
+        ));
+        assert_eq!(parked_response(), response);
+        assert_terminal(2, &coin_out(50), &coin_out(PINNED_FLOOR), &terminal);
+    }
+
+    /// An under-floor ack follows the spec's escalation policy past the
+    /// budget exactly as a timeout does: a `ReEmit` spec re-emits verbatim
+    /// instead of parking, keeping the opening swap's optimistic self-heal.
+    #[test]
+    fn repeated_underpaid_acks_reemit_past_budget_when_spec_reemits() {
+        const PINNED_FLOOR: Amount = 40;
+        let mock_querier = MockQuerier::default();
+        let querier = QuerierWrapper::new(&mock_querier);
+
+        let mut spec = spec3();
+        spec.set_reemit();
+        spec.set_floor(PINNED_FLOOR);
+        let (_response, mut node) = continued(Node::start(spec, &testing::mock_env(), querier));
+
+        let rounds = u16::from(mock_budget()) + 3;
+        for _ in 0..rounds {
+            let nonce = node.in_flight_nonce;
+            let (_response, next) = continued(node.on_remote_response(
+                payload(&coin_out(PINNED_FLOOR - 1)),
+                nonce,
+                querier,
+                testing::mock_env(),
+            ));
+            node = next;
+        }
         assert_node(2, &coin_out(50), &coin_out(PINNED_FLOOR), &node);
     }
 

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -592,11 +592,13 @@ where
     /// check aligned with the promise actually made: price drift can
     /// neither retroactively reclassify a compliant, already-executed swap
     /// as underpaid nor admit an amount below the promised floor. The leg
-    /// re-emits within the shared timeout retry budget and escalates into
-    /// the slippage-anomaly terminal past it, exactly as a timeout does, so
-    /// a counterparty returning persistently under-floor acks cannot drive
-    /// an unbounded re-emission loop; only the in-flight leg retries and the
-    /// accumulated progress stays intact.
+    /// re-emits within the shared timeout retry budget and escalates per the
+    /// spec's slippage policy past it, exactly as a timeout does: a Park-spec
+    /// leg (liquidation/close/repay) freezes at the slippage-anomaly terminal,
+    /// bounding the re-emission loop, while a ReEmit-spec leg (opening swap)
+    /// keeps re-emitting the pinned floor verbatim as its optimistic self-heal.
+    /// Either way only the in-flight leg retries and the accumulated progress
+    /// stays intact.
     fn deliver_ack(
         self,
         coin_out: CoinDTO<SwapTask::OutG>,
@@ -615,10 +617,11 @@ where
 
     /// An under-floor OK-ack consumes the same retry budget as a timeout:
     /// within budget it re-emits the in-flight leg, past budget it escalates
-    /// into the slippage-anomaly terminal per the spec's policy, exactly as
-    /// the timeout path does. Sharing the `timeouts` budget is what stops a
-    /// counterparty returning persistently under-floor acks from driving an
-    /// unbounded re-emission loop that never parks.
+    /// per the spec's slippage policy, exactly as the timeout path does - a
+    /// Park spec freezes at the slippage-anomaly terminal, a ReEmit spec
+    /// (opening swap) re-emits verbatim. Sharing the `timeouts` budget bounds
+    /// the re-emission loop for Park-spec legs; a ReEmit leg still re-emits
+    /// unbounded, exactly as it does on repeated timeouts.
     fn reemit_or_escalate_underpaid(
         self,
         querier: QuerierWrapper<'_>,

--- a/protocol/packages/dex/src/impl_/remote_swap.rs
+++ b/protocol/packages/dex/src/impl_/remote_swap.rs
@@ -592,11 +592,14 @@ where
     /// check aligned with the promise actually made: price drift can
     /// neither retroactively reclassify a compliant, already-executed swap
     /// as underpaid nor admit an amount below the promised floor. The leg
-    /// re-emits within the shared timeout retry budget and escalates per the
-    /// spec's slippage policy past it, exactly as a timeout does: a Park-spec
-    /// leg (liquidation/close/repay) freezes at the slippage-anomaly terminal,
-    /// bounding the re-emission loop, while a ReEmit-spec leg (opening swap)
-    /// keeps re-emitting the pinned floor verbatim as its optimistic self-heal.
+    /// re-emits within the shared timeout retry budget — always verbatim,
+    /// re-promising the pinned floor (unlike an in-budget liquidation
+    /// timeout, which re-quotes the floor from the live oracle) — and past
+    /// budget escalates per the spec's slippage policy exactly as a timeout
+    /// does: a Park-spec leg (liquidation/close/repay) freezes at the
+    /// slippage-anomaly terminal, bounding the re-emission loop, while a
+    /// ReEmit-spec leg (opening swap) keeps re-emitting the pinned floor
+    /// verbatim as its optimistic self-heal.
     /// Either way only the in-flight leg retries and the accumulated progress
     /// stays intact.
     fn deliver_ack(
@@ -616,12 +619,14 @@ where
     }
 
     /// An under-floor OK-ack consumes the same retry budget as a timeout:
-    /// within budget it re-emits the in-flight leg, past budget it escalates
-    /// per the spec's slippage policy, exactly as the timeout path does - a
-    /// Park spec freezes at the slippage-anomaly terminal, a ReEmit spec
-    /// (opening swap) re-emits verbatim. Sharing the `timeouts` budget bounds
-    /// the re-emission loop for Park-spec legs; a ReEmit leg still re-emits
-    /// unbounded, exactly as it does on repeated timeouts.
+    /// within budget it re-emits the in-flight leg — verbatim, never
+    /// re-quoting the floor the way an in-budget liquidation timeout does —
+    /// and past budget it escalates per the spec's slippage policy, exactly
+    /// as the timeout path does: a Park spec freezes at the slippage-anomaly
+    /// terminal, a ReEmit spec (opening swap) re-emits verbatim. Sharing the
+    /// `timeouts` budget bounds the re-emission loop for Park-spec legs; a
+    /// ReEmit leg still re-emits unbounded, exactly as it does on repeated
+    /// timeouts.
     fn reemit_or_escalate_underpaid(
         self,
         querier: QuerierWrapper<'_>,


### PR DESCRIPTION
## Change

THE BUG: in protocol/packages/dex/src/impl_/remote_swap.rs, deliver_ack routed an under-floor OK-ack (coin_out below the pinned in_flight_min_out) to reemit_underpaid, which bumped the nonce and re-scheduled the leg but incremented NEITHER counter. Because escalate()/park() are gated only on the timeouts/errors counters, a counterparty returning persistently under-floor OK-acks drove an unbounded re-emission loop that never reached the slippage-anomaly park terminal.

THE FIX: the under-floor OK-ack path now consumes the SAME retry budget as the timeout path. A new private dispatch reemit_or_escalate_underpaid(self, querier, env) mirrors on_remote_timeout exactly: it calls with_incremented_timeouts(), and if bumped.timeouts <= bumped.spec.timeout_retry_budget() it re-emits as before (reemit_underpaid — nonce bump, verbatim pinned floor, anomaly event, optimistic self-heal preserved); past budget it calls escalate(), which parks at SlippageAnomaly carrying the last pinned floor for a Park-policy spec (liquidation/close/repay) or re-emits verbatim for a ReEmit-policy spec (opening swap) — identical to the timeout past-budget behavior. No new counter, no new terminal: the existing timeouts budget + park machinery is reused so behavior is symmetric with timeouts. No fund movement on this branch — total_out and the in-flight coin are untouched until a valid apply_ack, exactly as before.

STRUCTURAL NOTE (why the diff moves deliver_ack): deliver_ack lived in an impl block whose bounds are `Self: Handler + Into<SEnum>`, which cannot name escalate/park (those require the extra `SlippageAnomaly<SwapTask,SEnum>: Into<SEnum>` bound). Adding that bound to deliver_ack's original block would cascade-break enter_from and WithOutputTask::on, which call start/schedule_and_continue without it. So deliver_ack (and the new dispatch) were relocated into the existing escalate/park impl block (same bounds as the Handler impl), where the bound is satisfiable — the established cross-block call pattern already used by escalate→reemit_in_flight and on_remote_timeout→escalate. deliver_ack is only called from on_remote_response (Handler block, which satisfies those bounds), so the move is safe. Its doc-comment was updated to describe the new budget-and-park behavior.

ALTERNATIVE CONSIDERED — retry-forever as intentional self-heal: leave the under-floor path re-emitting unboundedly (as today), treating a counterparty that under-pays as a transient condition the operator monitors via the emitted anomaly events and resolves with heal. REJECTED: it leaves a permanent unbounded-loop hole with no terminal, asymmetric with both the timeout path (budget→escalate) and the error path (park), and it defeats the slippage-anomaly park terminal that exists precisely to freeze legs a counterparty will not honor. Budget+park gives parity across all three failure signals (timeout, error, under-floor ack) and still preserves the optimistic self-heal within budget.

## Testing

- repeated_underpaid_acks_spend_the_budget_and_park — repeated under-floor OK-acks: each in-budget round re-emits and advances node.timeouts, the round past the budget parks at SlippageAnomaly carrying the pinned floor. CONFIRMED failed on unmodified code (assert_eq!(round, node.timeouts): left=1 right=0), passes after the fix.

Gate: build, `fmt --check`, clippy on the CI-pinned 1.94 toolchain (`lint` + `lint-all`), full test run for the touched packages — all green.

## Independent review

Two independent fresh-context reviews (general-correctness checklist + a security-focused pass over the committed diff) returned **PASS** with zero blocking findings; security verdict: CLEAR.
