### PR TITLE
fix: lease migrate allows in-family upgrades, still refuses pre-v10

### DIFF
--- a/platform/packages/versioning/src/release/mod.rs
+++ b/platform/packages/versioning/src/release/mod.rs
@@ -65,6 +65,12 @@ impl ProtocolPackageReleaseId {
     }
 }
 
+impl ProtocolPackageRelease {
+    pub const fn same_storage(&self, other: &Self) -> bool {
+        self.software.same_storage(&other.software)
+    }
+}
+
 impl UpdatablePackage for ProtocolPackageRelease {
     type VersionQuery = ProtocolPackage;
 

--- a/platform/packages/versioning/src/software/mod.rs
+++ b/platform/packages/versioning/src/software/mod.rs
@@ -44,6 +44,10 @@ impl PackageRelease {
         self.code.version()
     }
 
+    pub const fn same_storage(&self, other: &Self) -> bool {
+        self.code.same_storage(&other.code)
+    }
+
     fn check_software_update_allowed<F>(&self, to: &Self, storage_check: F) -> Result<(), Error>
     where
         F: FnOnce(&Self, &Package) -> Result<(), Error>,

--- a/protocol/contracts/lease/Cargo.toml
+++ b/protocol/contracts/lease/Cargo.toml
@@ -89,3 +89,6 @@ cosmwasm-std = { workspace = true, optional = true }
 enum_dispatch = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+versioning = { workspace = true, features = ["protocol_contract", "testing"] }

--- a/protocol/contracts/lease/src/contract/endpoins.rs
+++ b/protocol/contracts/lease/src/contract/endpoins.rs
@@ -15,7 +15,8 @@ use sdk::{
     },
 };
 use versioning::{
-    ProtocolMigrationMessage, ProtocolPackageRelease, VersionSegment, package_name, package_version,
+    ProtocolMigrationMessage, ProtocolPackageRelease, UpdatablePackage as _, VersionSegment,
+    package_name, package_version,
 };
 
 use crate::{
@@ -60,34 +61,33 @@ pub fn instantiate(
 pub fn migrate(
     deps: DepsMut<'_>,
     _env: Env,
-    _msg: ProtocolMigrationMessage<MigrateMsg>,
+    ProtocolMigrationMessage {
+        migrate_from,
+        to_release,
+        message: MigrateMsg {},
+    }: ProtocolMigrationMessage<MigrateMsg>,
 ) -> ContractResult<CwResponse> {
-    // The remote-lease feature reshaped the lease's persisted state end
-    // to end: `LeaseDTO` gained the non-optional Solana `remote_lease_id`
-    // and `remote_lease_controller`, opening and repay moved off the ICA
-    // onto the transfer-channel funding leg (`Account.host` became
-    // optional), and `State` gained the `OpeningUnwind` variant plus
-    // per-currency drain baselines. None of these shapes ever persisted in
-    // a released lease — the last released storage version is v9 (v0.8.x);
-    // every step above it is unreleased remote-lease work — so they
-    // collapse into a single v9 -> v10 step.
+    // A pre-v10 (v9) lease persisted a state shape the v10 layout cannot load:
+    // the remote-lease reshape made `remote_lease_id` / `remote_lease_controller`
+    // required, turned `Account.host` optional, and added the `OpeningUnwind`
+    // variant and per-currency drain baselines. Such a record has no meaningful
+    // `remote_lease_id` to synthesise, so it is refused outright. In-family
+    // upgrades (v10 -> v10.x -> v11) keep the storage version and run the
+    // standard software update the leaser's `migrate_leases` batch drives, as
+    // every sibling contract does.
     //
-    // A v9 lease cannot be deserialised under the v10 layout — a v9 record
-    // lacks the now-required `remote_lease_id` and `remote_lease_controller`
-    // fields — and it has no meaningful `remote_lease_id` to synthesise (its
-    // account is a DEX-chain ICA host, not a Solana PDA), so a real migration
-    // could only invent permanent sentinels. Remote-lease protocols are
-    // instantiated fresh (the leaser's `remote_lease_controller` binding is
-    // immutable, so an existing protocol cannot be retrofitted); an existing
-    // v9 lease is never pointed at this code. Reject any migrate attempt
-    // loudly rather than silently mis-loading state.
-    //
-    // Non-mainnet (devnet/testnet/local): drain all pre-v10 leases to a
-    // terminal state before upgrading the lease code — the layout is
-    // binary-incompatible and there is no `ExecuteMsg` escape hatch, so the
-    // drain is a prerequisite, not a recovery step. See
-    // `protocol/docs/remote-lease-callback-flow.md`.
-    Err(ContractError::UnsupportedMigration).inspect_err(platform_error::log(deps.api))
+    // The storage gate must precede `update_software`: that path checks code
+    // monotonicity first, so a real older-semver v9 lease would surface as
+    // `OlderPackageCode` instead of the deliberate `UnsupportedMigration`.
+    if migrate_from.same_storage(&CURRENT_RELEASE) {
+        migrate_from
+            .update_software(&CURRENT_RELEASE, &to_release)
+            .map_err(ContractError::UpdateSoftware)
+            .map(|()| response::empty_response())
+    } else {
+        Err(ContractError::UnsupportedMigration)
+    }
+    .inspect_err(platform_error::log(deps.api))
 }
 
 #[entry_point]
@@ -204,5 +204,60 @@ fn process_sudo(
         // The lease funds over the ICS-20 transfer channel and never registers
         // an ICA, so it can never receive an `OpenAck`.
         SudoMsg::OpenAck { .. } => Err(ContractError::unsupported_operation("open ica response")),
+    }
+}
+
+#[cfg(all(feature = "internal.test.contract", test))]
+mod tests {
+    use sdk::cosmwasm_std::testing::{mock_dependencies, mock_env};
+    use versioning::{
+        ProtocolMigrationMessage, ProtocolPackageRelease, ProtocolPackageReleaseId, ReleaseId,
+        VersionSegment, package_name, package_version,
+    };
+
+    use crate::{api::MigrateMsg, error::ContractError};
+
+    use super::{CONTRACT_STORAGE_VERSION, migrate};
+
+    #[test]
+    fn migrate_in_family_runs_update_software() {
+        let mut deps = mock_dependencies();
+        let res = migrate(
+            deps.as_mut(),
+            mock_env(),
+            migrate_msg(CONTRACT_STORAGE_VERSION),
+        )
+        .unwrap();
+        assert_eq!(0, res.messages.len());
+    }
+
+    #[test]
+    fn migrate_pre_v10_storage_rejected() {
+        const PRE_V10_STORAGE: VersionSegment = CONTRACT_STORAGE_VERSION - 1;
+
+        let mut deps = mock_dependencies();
+        let err = migrate(deps.as_mut(), mock_env(), migrate_msg(PRE_V10_STORAGE)).unwrap_err();
+        assert!(
+            matches!(err, ContractError::UnsupportedMigration),
+            "got {err:?}",
+        );
+    }
+
+    fn migrate_msg(from_storage: VersionSegment) -> ProtocolMigrationMessage<MigrateMsg> {
+        const SOFTWARE_ID: &str = env!("SOFTWARE_RELEASE_ID");
+        const PROTOCOL_ID: &str = env!("PROTOCOL_RELEASE_ID");
+
+        ProtocolMigrationMessage {
+            migrate_from: ProtocolPackageRelease::current(
+                package_name!(),
+                package_version!(),
+                from_storage,
+            ),
+            to_release: ProtocolPackageReleaseId::new(
+                ReleaseId::new_test(SOFTWARE_ID),
+                ReleaseId::new_test(PROTOCOL_ID),
+            ),
+            message: MigrateMsg {},
+        }
     }
 }

--- a/protocol/contracts/lease/src/contract/endpoins.rs
+++ b/protocol/contracts/lease/src/contract/endpoins.rs
@@ -27,6 +27,61 @@ use crate::{
 
 use super::state::{self, Response, State};
 
+#[cfg(all(feature = "internal.test.contract", test))]
+mod tests {
+    use sdk::cosmwasm_std::testing::{mock_dependencies, mock_env};
+    use versioning::{
+        ProtocolMigrationMessage, ProtocolPackageRelease, ProtocolPackageReleaseId, ReleaseId,
+        VersionSegment, package_name, package_version,
+    };
+
+    use crate::{api::MigrateMsg, error::ContractError};
+
+    use super::{CONTRACT_STORAGE_VERSION, migrate};
+
+    #[test]
+    fn migrate_in_family_runs_update_software() {
+        let mut deps = mock_dependencies();
+        let res = migrate(
+            deps.as_mut(),
+            mock_env(),
+            migrate_msg(CONTRACT_STORAGE_VERSION),
+        )
+        .unwrap();
+        assert_eq!(0, res.messages.len());
+    }
+
+    #[test]
+    fn migrate_pre_v10_storage_rejected() {
+        const PRE_V10_STORAGE: VersionSegment = CONTRACT_STORAGE_VERSION - 1;
+
+        let mut deps = mock_dependencies();
+        let err = migrate(deps.as_mut(), mock_env(), migrate_msg(PRE_V10_STORAGE)).unwrap_err();
+        assert!(
+            matches!(err, ContractError::UnsupportedMigration),
+            "got {err:?}",
+        );
+    }
+
+    fn migrate_msg(from_storage: VersionSegment) -> ProtocolMigrationMessage<MigrateMsg> {
+        const SOFTWARE_ID: &str = env!("SOFTWARE_RELEASE_ID");
+        const PROTOCOL_ID: &str = env!("PROTOCOL_RELEASE_ID");
+
+        ProtocolMigrationMessage {
+            migrate_from: ProtocolPackageRelease::current(
+                package_name!(),
+                package_version!(),
+                from_storage,
+            ),
+            to_release: ProtocolPackageReleaseId::new(
+                ReleaseId::new_test(SOFTWARE_ID),
+                ReleaseId::new_test(PROTOCOL_ID),
+            ),
+            message: MigrateMsg {},
+        }
+    }
+}
+
 const CONTRACT_STORAGE_VERSION: VersionSegment = 10;
 const CURRENT_RELEASE: ProtocolPackageRelease = ProtocolPackageRelease::current(
     package_name!(),
@@ -72,9 +127,13 @@ pub fn migrate(
     // required, turned `Account.host` optional, and added the `OpeningUnwind`
     // variant and per-currency drain baselines. Such a record has no meaningful
     // `remote_lease_id` to synthesise, so it is refused outright. In-family
-    // upgrades (v10 -> v10.x -> v11) keep the storage version and run the
-    // standard software update the leaser's `migrate_leases` batch drives, as
-    // every sibling contract does.
+    // upgrades are same-storage code bumps (v10 -> v10.x): they keep the storage
+    // version and run the standard software update the leaser's `migrate_leases`
+    // batch drives, as every sibling contract does. A future storage-layout bump
+    // (a v11 that reshapes the persisted state) is NOT in-family — it must add
+    // its own dedicated storage-migration arm here, and until that arm exists the
+    // `same_storage` gate deliberately refuses it rather than run
+    // `update_software` over an incompatible layout.
     //
     // The storage gate must precede `update_software`: that path checks code
     // monotonicity first, so a real older-semver v9 lease would surface as
@@ -204,60 +263,5 @@ fn process_sudo(
         // The lease funds over the ICS-20 transfer channel and never registers
         // an ICA, so it can never receive an `OpenAck`.
         SudoMsg::OpenAck { .. } => Err(ContractError::unsupported_operation("open ica response")),
-    }
-}
-
-#[cfg(all(feature = "internal.test.contract", test))]
-mod tests {
-    use sdk::cosmwasm_std::testing::{mock_dependencies, mock_env};
-    use versioning::{
-        ProtocolMigrationMessage, ProtocolPackageRelease, ProtocolPackageReleaseId, ReleaseId,
-        VersionSegment, package_name, package_version,
-    };
-
-    use crate::{api::MigrateMsg, error::ContractError};
-
-    use super::{CONTRACT_STORAGE_VERSION, migrate};
-
-    #[test]
-    fn migrate_in_family_runs_update_software() {
-        let mut deps = mock_dependencies();
-        let res = migrate(
-            deps.as_mut(),
-            mock_env(),
-            migrate_msg(CONTRACT_STORAGE_VERSION),
-        )
-        .unwrap();
-        assert_eq!(0, res.messages.len());
-    }
-
-    #[test]
-    fn migrate_pre_v10_storage_rejected() {
-        const PRE_V10_STORAGE: VersionSegment = CONTRACT_STORAGE_VERSION - 1;
-
-        let mut deps = mock_dependencies();
-        let err = migrate(deps.as_mut(), mock_env(), migrate_msg(PRE_V10_STORAGE)).unwrap_err();
-        assert!(
-            matches!(err, ContractError::UnsupportedMigration),
-            "got {err:?}",
-        );
-    }
-
-    fn migrate_msg(from_storage: VersionSegment) -> ProtocolMigrationMessage<MigrateMsg> {
-        const SOFTWARE_ID: &str = env!("SOFTWARE_RELEASE_ID");
-        const PROTOCOL_ID: &str = env!("PROTOCOL_RELEASE_ID");
-
-        ProtocolMigrationMessage {
-            migrate_from: ProtocolPackageRelease::current(
-                package_name!(),
-                package_version!(),
-                from_storage,
-            ),
-            to_release: ProtocolPackageReleaseId::new(
-                ReleaseId::new_test(SOFTWARE_ID),
-                ReleaseId::new_test(PROTOCOL_ID),
-            ),
-            message: MigrateMsg {},
-        }
     }
 }


### PR DESCRIPTION
## Change

Problem: lease `migrate()` returned `Err(UnsupportedMigration)` unconditionally. That correctly blocks loading a pre-v10 (v9) reshaped-node layout, but ALSO blocked every legitimate in-family upgrade (v10 -> v10.x -> v11) the leaser's `migrate_leases` batch drives and every sibling contract (oracle/lpp/profit) supports.

Fix: reintroduced the standard `update_software` path (sibling shape) GATED up-front on the persisted storage version. `migrate()` now destructures `ProtocolMigrationMessage { migrate_from, to_release, message }` and: if `migrate_from.same_storage(&CURRENT_RELEASE)` (in-family, storage still v10) runs `migrate_from.update_software(&CURRENT_RELEASE, &to_release).map_err(ContractError::UpdateSoftware).map(|()| response::empty_response())`; otherwise returns `ContractError::UnsupportedMigration`. Whole body is one `if/else` expression fed to `.inspect_err` (single point of return). `CONTRACT_STORAGE_VERSION` stays 10. Added `UpdatablePackage as _` import.

Key decision — gate ORDER + why versioning was touched: the storage gate must run BEFORE `update_software`, not rely on it. `update_software` checks code-monotonicity (`check_code_same_or_newer`) before its storage check, so a real older-semver v9 lease would fail as `OlderPackageCode` rather than the deliberate `UnsupportedMigration`, and comparing equal-name/version packages with differing storage even trips a `debug_assert` in `Package::eq`. Short-circuiting on `same_storage` first avoids both. Reading the storage version required a public accessor that did not exist — `ProtocolPackageRelease` exposed only `update_software`/`update_software_and_storage`. Added two purely-additive `pub const fn same_storage` methods (ProtocolPackageRelease -> SoftwarePackageRelease, both delegating to the pre-existing pub `Package::same_storage`). Zero blast radius: additive only, no existing signature/behavior changed.

Alternatives rejected: (a) `update_software` alone (lease-only, no gate) — returns `UpdateSoftware(...)` for pre-v10 instead of the explicit `UnsupportedMigration` refusal, and mis-fires on real v9 via `OlderPackageCode`. (b) run `update_software` then remap the storage-mismatch variant to `UnsupportedMigration` — incorrect for real v9 (OlderPackageCode fires first) and structurally inverts intent.

Scope note for reviewer: the change deliberately touches the shared `versioning` platform crate beyond the nominal lease-only scope — unavoidable because the storage gate needs a public storage accessor the crate didn't expose. Suggest a compliance pass given the shared-crate touch.

Deploy context (unchanged by this PR): remote-lease deploys only as a fresh protocol instance gated on ibc-solray#486 + hermes-lite per-delivery re-quote; no existing v9 lease is ever pointed at this code, so the pre-v10 refusal is defense-in-depth.

## Testing

- lease contract::endpoins::tests::migrate_in_family_runs_update_software — confirmed FAILED against old reject-all body (unwrap panic on Err(UnsupportedMigration)), PASSES with fix (Ok, 0 messages)
- lease contract::endpoins::tests::migrate_pre_v10_storage_rejected — asserts ContractError::UnsupportedMigration for migrate_from storage v9; PASSES with fix, short-circuits on same_storage before update_software so it never trips the Package::eq debug_assert

Gate: build, `fmt --check`, clippy on the CI-pinned 1.94 toolchain (`lint` + `lint-all`), full test run for the touched packages — all green.

## Independent review

Two independent fresh-context reviews (general-correctness checklist + a security-focused pass over the committed diff) returned **PASS** with zero blocking findings; security verdict: CLEAR.
