### PR TITLE
fix: clear the channel record on solicited close initiation

### DIFF
--- a/protocol/contracts/remote_lease/src/ibc.rs
+++ b/protocol/contracts/remote_lease/src/ibc.rs
@@ -137,7 +137,10 @@ pub fn ibc_channel_close(
                 Some(channel) if channel.state() == ChannelState::Closing => Ok(()),
                 _ => Err(Error::UnsolicitedChannelClose),
             })
-            .map(|()| IbcBasicResponse::new()),
+            .map(|()| {
+                Channel::clear(deps.storage);
+                IbcBasicResponse::new()
+            }),
         IbcChannelCloseMsg::CloseConfirm { .. } => {
             Channel::clear(deps.storage);
             Ok(IbcBasicResponse::new())

--- a/protocol/contracts/remote_lease/src/ibc/tests/handshake.rs
+++ b/protocol/contracts/remote_lease/src/ibc/tests/handshake.rs
@@ -341,7 +341,7 @@ fn connect_rejects_invalid_handshake_params() {
 }
 
 #[test]
-fn close_init_when_closing_accepted() {
+fn close_init_when_closing_clears_channel() {
     let mut deps = deps_with_config();
     persist_existing_closing_channel(deps.as_mut());
 
@@ -359,7 +359,7 @@ fn close_init_when_closing_accepted() {
     )
     .unwrap();
 
-    assert!(Channel::may_load(&deps.storage).unwrap().is_some());
+    assert!(Channel::may_load(&deps.storage).unwrap().is_none());
 }
 
 #[test]

--- a/protocol/contracts/remote_profit/src/ibc.rs
+++ b/protocol/contracts/remote_profit/src/ibc.rs
@@ -137,7 +137,10 @@ pub fn ibc_channel_close(
                 Some(channel) if channel.state() == ChannelState::Closing => Ok(()),
                 _ => Err(Error::UnsolicitedChannelClose),
             })
-            .map(|()| IbcBasicResponse::new()),
+            .map(|()| {
+                Channel::clear(deps.storage);
+                IbcBasicResponse::new()
+            }),
         IbcChannelCloseMsg::CloseConfirm { .. } => {
             Channel::clear(deps.storage);
             Ok(IbcBasicResponse::new())

--- a/protocol/contracts/remote_profit/src/ibc/tests/handshake.rs
+++ b/protocol/contracts/remote_profit/src/ibc/tests/handshake.rs
@@ -341,7 +341,7 @@ fn connect_rejects_invalid_handshake_params() {
 }
 
 #[test]
-fn close_init_when_closing_accepted() {
+fn close_init_when_closing_clears_channel() {
     let mut deps = deps_with_config();
     persist_existing_closing_channel(deps.as_mut());
 
@@ -359,7 +359,7 @@ fn close_init_when_closing_accepted() {
     )
     .unwrap();
 
-    assert!(Channel::may_load(&deps.storage).unwrap().is_some());
+    assert!(Channel::may_load(&deps.storage).unwrap().is_none());
 }
 
 #[test]

--- a/protocol/docs/remote-lease-admin-runbook.md
+++ b/protocol/docs/remote-lease-admin-runbook.md
@@ -159,15 +159,21 @@ lease-side `wasm-ls-close-remote-lease` events out-of-band until none remain in 
 
 ### 2.5 Verifying
 
-`Channel()` reports `state: "closing"` immediately, then `{"channel": null}` once the
-solicited `CloseInit` clears the record — an admin close no longer waits on the
-counterparty's `CloseConfirm`.
+On a solicited (admin) close, `Channel()` never externally reports `state: "closing"` —
+it goes straight from the open record to `{"channel": null}`. `CloseChannel` stores
+`Closing` and schedules the `IbcMsg::CloseChannel` (`schedule_execute_no_reply`) for the
+*same* transaction; the IBC module processes it before commit, so
+`ibc_channel_close(CloseInit)` clears the record in that same tx. The transient `Closing`
+state therefore exists only intra-tx — an external query would observe it solely if the
+clear did *not* happen (the old behavior). Verify success by polling `Channel()` until it
+returns `{"channel": null}`; an admin close does not wait on the counterparty's
+`CloseConfirm`.
 
 ### 2.6 Failure & recovery
 
 - **No channel** → `ChannelNotOpen`. **Already `Closing`** → `ChannelNotOperational`
   (this is idempotency protection — do **not** retry; the solicited `CloseInit` clears
-  the record shortly).
+  the record within the same transaction).
 - **Reopen after a solicited close** — the solicited `CloseInit` (the local close-init
   step the admin `CloseChannel` triggers) clears the record, so an admin close no longer
   lingers in `Closing` or blocks reopening: once `Channel()` reports `{"channel": null}`,

--- a/protocol/docs/remote-lease-admin-runbook.md
+++ b/protocol/docs/remote-lease-admin-runbook.md
@@ -164,8 +164,9 @@ it goes straight from the open record to `{"channel": null}`. `CloseChannel` sto
 `Closing` and schedules the `IbcMsg::CloseChannel` (`schedule_execute_no_reply`) for the
 *same* transaction; the IBC module processes it before commit, so
 `ibc_channel_close(CloseInit)` clears the record in that same tx. The transient `Closing`
-state therefore exists only intra-tx — an external query would observe it solely if the
-clear did *not* happen (the old behavior). Verify success by polling `Channel()` until it
+state therefore exists only intra-tx and is never externally observable in either
+direction: a failed `IbcMsg::CloseChannel` submessage reverts the whole transaction, so
+the record returns to its open state rather than sticking at `Closing`. Verify success by polling `Channel()` until it
 returns `{"channel": null}`; an admin close does not wait on the counterparty's
 `CloseConfirm`.
 

--- a/protocol/docs/remote-lease-admin-runbook.md
+++ b/protocol/docs/remote-lease-admin-runbook.md
@@ -133,8 +133,11 @@ counterparty_port_id, version, state: "open" }`.
 Moves the recorded channel `Open → Closing` (a one-way local soft-lock) and emits one
 `IbcMsg::CloseChannel`. Once `Closing`, the controller rejects **every** new outbound
 operation (`OpenLease`/`CloseLease`/`Swap`/`TransferOut`) with `ChannelNotOperational`.
-The record is removed only when the counterparty's `CloseConfirm` arrives. There are
-only two stored states — `Open` and `Closing`; "closed" means the record is gone.
+The **solicited** `CloseInit` — the local close-init step the admin `CloseChannel`
+triggers — now clears the record, so an admin close frees the slot without waiting on
+the counterparty's `CloseConfirm` (which still clears it on a counterparty-initiated
+close). There are only two stored states — `Open` and `Closing`; "closed" means the
+record is gone, and a fresh `OpenChannel()` can reopen.
 
 ### 2.3 Drain first — the invisible-lease window
 
@@ -156,17 +159,20 @@ lease-side `wasm-ls-close-remote-lease` events out-of-band until none remain in 
 
 ### 2.5 Verifying
 
-`Channel()` reports `state: "closing"` immediately, then `{"channel": null}` once
-`CloseConfirm` clears the record.
+`Channel()` reports `state: "closing"` immediately, then `{"channel": null}` once the
+solicited `CloseInit` clears the record — an admin close no longer waits on the
+counterparty's `CloseConfirm`.
 
 ### 2.6 Failure & recovery
 
 - **No channel** → `ChannelNotOpen`. **Already `Closing`** → `ChannelNotOperational`
-  (this is idempotency protection — do **not** retry; wait for `CloseConfirm`).
-- **Stuck/zombie `Closing`** (counterparty never confirms) — the channel stays `Closing`
-  indefinitely; there is **no controller-side timeout or force-clear**. Recovery is
-  purely at the relayer/IBC layer. While `Closing`, no outbound packets are possible and
-  `OpenChannel` is blocked (record still present).
+  (this is idempotency protection — do **not** retry; the solicited `CloseInit` clears
+  the record shortly).
+- **Reopen after a solicited close** — the solicited `CloseInit` (the local close-init
+  step the admin `CloseChannel` triggers) clears the record, so an admin close no longer
+  lingers in `Closing` or blocks reopening: once `Channel()` reports `{"channel": null}`,
+  a fresh `OpenChannel()` reopens the channel. A counterparty-initiated close clears via
+  `CloseConfirm` instead.
 - **Unsolicited counterparty `CloseInit`** on a healthy `Open` channel →
   `UnsolicitedChannelClose`. A relayer cannot force-close an `Open` channel; the operator
   must `CloseChannel()` first. (ADR 0001 §6.)
@@ -458,7 +464,7 @@ the instance **intact** (no brick).
 | `Unauthorized` | caller is not `protocol_admin` | send from the admin key |
 | `ChannelAlreadyExists` | channel already recorded | none needed; this is the idempotency guard |
 | `ChannelNotOpen` | `CloseChannel` with no recorded channel | nothing to close |
-| `ChannelNotOperational` | op while `Closing` | wait for `CloseConfirm`; do not retry |
+| `ChannelNotOperational` | op while `Closing` | wait for the close to clear the record; do not retry |
 | `UnsolicitedChannelClose` | counterparty `CloseInit` on a healthy channel | `CloseChannel()` first if intended |
 | `UnauthorisedCaller` (on lease ops) | `lease_code` points at the wrong id | re-issue `NewLeaseCode` with the correct id |
 | `IncompatibleStoredConfig`/`MalformedStoredConfig`, `UpdateSoftware` | migrate drift | fix the migration target; instance is intact |


### PR DESCRIPTION
## Change

BUG CONFIRMED before editing. Flow verification: admin `ExecuteMsg::CloseChannel` -> `contract::close_channel` calls `Channel::into_closing` (Open->Closing), stores, and emits `IbcMsg::CloseChannel`. That makes THIS controller the close initiator, so cosmwasm delivers `ibc_channel_close` with the `CloseInit` arm (never `CloseConfirm`, which fires only on the counterparty). The old `CloseInit` arm only asserted the channel was in `Closing` state and returned `Ok(())` WITHOUT removing the record; `Channel::clear` was reachable only from `CloseConfirm`. On a solicited/our-side close the record therefore stays `Closing` forever, and `ibc_channel_connect` (both OpenAck/OpenConfirm arms) rejects any reopen with `ChannelAlreadyExists` via the `Channel::may_load(..).Some(_) => Err(ChannelAlreadyExists)` guard -> channel un-reopenable by construction. The existing test `close_init_when_closing_accepted` even asserted `is_some()`, encoding the stuck-record behavior. Counterparty-initiated closes are unaffected (they arrive as `CloseConfirm`, already cleared) and the `Open`/no-channel cases still return `UnsolicitedChannelClose`.\n\nFIX: on the solicited `CloseInit` path, after the existing Closing-state guard passes, call `Channel::clear(deps.storage)` inside the terminal `.map`, so the record is removed and a fresh `OpenInit` handshake can reopen. Kept as a chained expression (`.map(|()| { Channel::clear(deps.storage); IbcBasicResponse::new() })`) to preserve the single-expression handler and match the sibling `CloseConfirm` arm's `Channel::clear` call verbatim. The `_ => Err(UnsolicitedChannelClose)` rejection for the non-Closing case is untouched. remote_profit/src/ibc.rs carried the byte-identical pattern (same line numbers) and got the identical fix.\n\nALTERNATIVES CONSIDERED: (1) clear the record inside `contract::close_channel` at solicit time instead of at CloseInit — rejected: the close can still fail/relay-abort, and the state machine intentionally keeps the record in `Closing` until the handshake close callback fires; clearing early would drop the `usable_or_err`/`ChannelNotOperational` guard that blocks outbound packets during close. (2) collapse both CloseInit-Closing and CloseConfirm into one clear-and-Ok arm — rejected: CloseInit must still reject the non-solicited (`Open`/absent) case with `UnsolicitedChannelClose`, which CloseConfirm does not; merging would lose that defense. Minimal per-arm clear is the tightest fix.

## Testing

- remote_lease_controller ibc::tests::handshake::close_init_when_closing_clears_channel (renamed from close_init_when_closing_accepted; assertion flipped is_some()->is_none()) — confirmed FAILED against unfixed code (assertion failed at handshake.rs:362), PASSED after fix
- remote_profit_controller ibc::tests::handshake::close_init_when_closing_clears_channel (same rename + assertion flip) — confirmed FAILED pre-fix / PASSED post-fix

Gate: build, `fmt --check`, clippy on the CI-pinned 1.94 toolchain (`lint` + `lint-all`), full test run for the touched packages — all green.

## Independent review

Two independent fresh-context reviews (general-correctness checklist + a security-focused pass over the committed diff) returned **PASS** with zero blocking findings; security verdict: CLEAR.
