### PR TITLE
docs: correct remote-lease migrate, nonce and retry drift

### DIFF
--- a/protocol/docs/remote-lease-admin-runbook.md
+++ b/protocol/docs/remote-lease-admin-runbook.md
@@ -234,23 +234,28 @@ id. This two-tx coordination is enforced nowhere; do it deliberately.
 controller's `NewLeaseCode` is gated by `protocol_admin`. Line them up before you start —
 using the `protocol_admin` key for the `MigrateLeases` step will be rejected.
 
-### 3.4 Drain old-code leases first
+### 3.4 Drain only pre-v10 (v9) leases first
 
-The Lease contract's `migrate` returns `UnsupportedMigration` **unconditionally**
-(layouts are binary-incompatible; no escape hatch). After rotation, old-code leases can
-no longer emit packets (`UnauthorisedCaller`) and cannot be migrated — though they can
-still *finish* via callbacks (acks/timeouts do not re-check the code). **Drain every
-old-code lease to a terminal state before rotating.**
+The Lease contract's `migrate` is **gated on the storage version**, not refused
+unconditionally: a same-storage in-family upgrade runs the standard `update_software`
+(exactly as the leaser's `MigrateLeases` batch drives it), so an in-family old-code lease
+**can** be migrated in the batch and need not be drained. Only a pre-v10 (v9) record —
+whose layout is binary-incompatible with the remote-lease layout — is refused with
+`UnsupportedMigration` (no escape hatch). Those pre-v10 leases can no longer emit packets
+(`UnauthorisedCaller`) and cannot be migrated — though they can still *finish* via
+callbacks (acks/timeouts do not re-check the code). **Drain every pre-v10 (v9) lease to a
+terminal state before rotating.**
 
 ### 3.5 Procedure
 
-1. Drain all old-code leases to terminal (§3.4).
+1. Drain any pre-v10 (v9) leases to terminal (§3.4).
 2. Redeploy the Lease wasm; note the new code id.
 3. leaser `MigrateLeases { new_code_id, … }` — signed by the leaser **`ContractOwner`**
    (governance / wasm-admin), **not** `protocol_admin`. This rotates the leaser's own
-   `lease_code` and its LPP/Reserve references; it does **not** migrate remote leases (the
-   Lease `migrate` is unconditionally refused and §3.4 already drained them), so for this
-   protocol the step is leaser-side bookkeeping only.
+   `lease_code` and its LPP/Reserve references; for an in-family (same-storage) redeploy it
+   also migrates each remote lease via the standard `update_software`. Only pre-v10 (v9)
+   records are refused by the Lease `migrate` (§3.4 already drained those), so beyond the
+   in-family migrations the step is leaser-side bookkeeping.
 4. controller `NewLeaseCode { lease_code: <new id> }` — signed by `protocol_admin`.
 5. `QueryMsg::Config()` → confirm `lease_code_id == <new id>` (§3.2).
 
@@ -261,8 +266,9 @@ old-code lease to a terminal state before rotating.**
 - **Valid-but-wrong id** (resolves on-chain, but not the redeployed Lease) → passes the
   existence check and is persisted; the symptom is `UnauthorisedCaller` on lease ops.
   Re-issue `NewLeaseCode` with the correct id (no other state touched).
-- **Stranded old-code lease** → none after the fact; it must reach terminal via the
-  existing callback flows. It cannot be upgraded.
+- **Stranded pre-v10 (v9) lease** → none after the fact; it must reach terminal via the
+  existing callback flows. It cannot be upgraded (an in-family old-code lease, by contrast,
+  migrates in the batch — only the pre-v10 layout is refused).
 - `NewLeaseCode` on an uninstantiated/corrupted config → `Std` error (config stays unset).
 
 ---
@@ -283,8 +289,12 @@ lease's dex state machine.**
   ack so the relayer retries). Every content/protocol fault is **absorbed** as `Ok` + an
   event so the ack commits and the relayer loop unblocks.
 - **Lease** auto-recovers: on a swap leg, timeouts re-emit up to a per-operation budget
-  then park at the slippage-anomaly terminal; under-floor errors escalate per policy;
-  underpaid acks re-emit with a bumped nonce. **Liquidation** swap legs re-quote their
+  then park at the slippage-anomaly terminal; an under-floor (underpaid) OK-ack spends that
+  **same** budget — re-emitting the leg with a bumped nonce while within budget, then
+  escalating once it is spent (park the opened legs at the slippage-anomaly terminal, or
+  re-emit for a ReEmit-spec opening leg), exactly as a timeout does — so a persistently
+  under-paying counterparty parks (needing a `lease_admin` `Heal`), it does not loop
+  forever. **Liquidation** swap legs re-quote their
   floor from the live oracle on each in-budget timeout re-emission — bounded by
   `MaxSlippages.liquidation`, tracking the price both down and up, clamped to `>= 1` —
   so a stale floor cannot strand a liquidation as the market moves; the opening, repay,
@@ -335,9 +345,11 @@ practice). On callback, a superseded packet's late ack carries a lower nonce and
 absorbed as `nonce-mismatch`, never double-credited. So `Heal` is **safe to repeat
 regardless of timing** — you need not wait for the original timeout.
 
-**Caveat:** only `Swap` carries a real nonce; `OpenLease`/`CloseLease`/`TransferOut` use
-nonce `0` and rely on the IBC at-most-once single-packet property instead of nonce
-matching. The opening/repay **funding** transfers (the ICS-20 transfers to the
+**Caveat:** `Swap` and the multi-leg `TransferOut` drain (#671) each carry a real
+per-emission nonce (so a drain `Heal` is likewise safe to repeat — the drain nonce closes
+the same duplicate-ack window); only `OpenLease`/`CloseLease` use nonce `0` and rely on
+the IBC at-most-once single-packet property instead of nonce matching. The
+opening/repay **funding** transfers (the ICS-20 transfers to the
 `LeaseAuthority`) likewise carry no per-emission nonce yet: a `Heal` issued while the
 original funding packet is still resolvable can solicit a *duplicate* success-ack and
 advance the funding `acks-left` countdown one step early. The residual is bounded and

--- a/protocol/docs/remote-lease-callback-flow.md
+++ b/protocol/docs/remote-lease-callback-flow.md
@@ -37,7 +37,7 @@ flowchart TD
         ExecEntry["contract::endpoins::execute → state.on_remote_lease_callback"]:::lease
         Auth["Handler::authz_remote_callback<br/>LeasesRef::remote_lease_callback_permission<br/>← leaser query CheckRemoteLeaseCallbackPermission"]:::lease
         Classify["deliver_remote_callback:<br/>OperationOk → on_remote_response(bytes) · OperationErr → on_remote_error · OperationTimeout → on_remote_timeout"]:::lease
-        RemoteLeg["RemoteSwap leg (overrides on_remote_*):<br/>decode_response — typed, registry-validating — credits the in-flight leg<br/>absorbed with event on undecodable-response / unexpected-response-variant /<br/>out-currency-mismatch / output-overflow; under-min-out re-emits the leg"]:::ok
+        RemoteLeg["RemoteSwap leg (overrides on_remote_*):<br/>decode_response — typed, registry-validating — credits the in-flight leg<br/>absorbed with event on undecodable-response / unexpected-response-variant /<br/>out-currency-mismatch / output-overflow; under-min-out re-emits within the shared timeout retry budget, then parks at the slippage-anomaly terminal"]:::ok
         DrainLeg["RemoteTransferOut leg (overrides on_remote_*):<br/>decode_response — variant check only, the payload carries no data —<br/>advances the acks_left countdown; absorbed with event on<br/>undecodable-response / unexpected-response-variant / remote-error<br/>(an error ack is NOT auto-retried — recovery is the operator heal)"]:::ok
         DefaultLeg["any non-overriding state (default on_remote_*):<br/>absorb with `remote-callback` event — never advance any ack countdown.<br/>The remote-lease path's callback legs all override on_remote_*; this is the safety fallback"]:::ok
         ExecEntry --> Auth -->|granted| Classify
@@ -276,10 +276,14 @@ wire-shaped `OperationResponse` (#637), and the `RemoteSwap` leg's
 `decode_response` parses the typed, registry-validating twin from those
 bytes — a registry miss is absorbed as `undecodable-response` rather
 than erred. The drain leg decodes the same way but its `TransferOut`
-variant carries no payload — the decode is a pure variant check, so the
-acknowledgment's only information is positional (the `acks_left`
-countdown), an even weaker correlation than the swap leg's pinned-floor
-cross-check. The close leg needs no decode at all: as a plain state
+variant carries no payload — the decode is a pure variant check. The
+acknowledgment is nonce-correlated all the same: each drain emission
+rides a per-emission `nonce` on the envelope (#671), so a callback is
+credited to the exact emission and a differing nonce is absorbed as
+`nonce-mismatch` — the same correctness pillars as the swap leg, not a
+weaker positional-only correlation. The `acks_left` countdown tracks the
+transfer positionally; the nonce disambiguates which emission a callback
+belongs to. The close leg needs no decode at all: as a plain state
 (like `OpenLease`) it receives the already-typed callback and matches
 on the `CloseLease` variant, whose response is empty — a single
 in-flight operation, correlated by the state itself.


### PR DESCRIPTION
## Change

Five corrections to the two remote-lease operator docs, each verified against the code:

- **admin-runbook §3.4–3.6** — the migrate procedure described the old unconditional `UnsupportedMigration` reject ('drain every old-code lease'); rewritten to the storage-gated model: same-storage (v10) in-family upgrades run the standard `update_software` via the leaser batch, only pre-v10 records are refused.
- **admin-runbook §4.5** — `TransferOut` was still listed in the nonce-0 operation group; it has carried a strictly-monotonic per-emission nonce since #671.
- **admin-runbook §4.2** — 'underpaid acks re-emit with a bumped nonce' (unbounded) replaced with the shared-timeout-budget-then-park behavior.
- **callback-flow, drain decoder paragraph** — 'only information is positional … even weaker correlation' predates the #671 nonce; corrected to the nonce-gated model.
- **callback-flow, flow diagram** — the under-min-out edge now shows re-emission within the shared retry budget with the park terminal, not an unbounded loop.

## Merge order

Two corrections describe behavior landing in **#714** (retry budget) and **#715** (storage-gated migrate) — merge those first; the remaining three are true on main today (#671 shipped).

## Scope

Documentation only; no code. Hunks are disjoint from the doc edits carried on the #715/#716 branches.

## Automated-review response (2026-07-04)

The "doc contradicts code" findings (migrate-gating in §3.4–3.6, retry-budget in §4.2 / callback-flow mermaid) were reviewed against a **stale base**: this docs-only branch describes the end-state that PRs #714 (under-min-out retry budget → `reemit_or_escalate_underpaid`) and #715 (storage-gated `migrate`, `same_storage`) ship, but its tree predated their merge. Rebased onto current `main` — which now carries both — the docs match the code exactly (`endpoins.rs` has the `same_storage` gate; `remote_swap.rs` has the budget/escalate path). The mermaid/prose precision notes (blanket "then parks", DrainLeg nonce omission) are the terse-summary axis-conflation refuted earlier: the retry budget is finite for every leg class; only the past-budget *escalation* diverges by Park vs ReEmit spec, which the surrounding prose states. Branch labeled `no-auto-review`; disposition record is this body.


### Round 2 at the rebased head — both inapplicable
- **wire-contract nonce "stale"** — the quoted text ("TransferOut rides a zero nonce for now") does not exist in the current docs tree; wire-contract.md line 64 correctly states TransferOut adopted the per-emission nonce in #671. Reviewer read a pre-drift-fix docs snapshot.
- **mermaid DrainLeg omits nonce** — the diagram omits nonce mechanics for both legs by design (RemoteSwap's node likewise); the nonce is carried in the prose and the dedicated "Correlation nonce" section. Diagram-summary vs prose-detail is intended, not a contradiction.
