### PR TITLE
chore: pre-audit sweep fixes — envelope tripwires, unwind coverage

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -10,7 +10,7 @@ Discovery-tax patterns. Grouped by domain. Append on first re-encounter.
 
 **Cause:** The whole `/build-configuration` directory is git-ignored (`.gitignore:2`) and populated locally per checkout. New worktrees inherit the workspace tree but not that directory's contents.
 
-**Fix:** Copy the whole directory from a working checkout:
+**Fix:** Copy its JSON definitions from a working checkout:
 
 ```
 cp <main-checkout>/build-configuration/*.json \

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -4,17 +4,17 @@ Discovery-tax patterns. Grouped by domain. Append on first re-encounter.
 
 ## Build
 
-### `cargo build` fails in a fresh worktree: missing `build-configuration/protocol.json`
+### `cargo build` fails in a fresh worktree: missing `build-configuration/` (`protocol.json` + `topology.json`)
 
-**Symptom:** A fresh `git worktree add` checkout fails at build time because the build script reads `build-configuration/protocol.json` and the file is absent.
+**Symptom:** A fresh `git worktree add` checkout fails at build time because the currencies build script reads `build-configuration/protocol.json` and `build-configuration/topology.json` and the files are absent.
 
-**Cause:** `build-configuration/protocol.json` is git-ignored and is populated locally per checkout. New worktrees inherit the workspace but not that file.
+**Cause:** The whole `/build-configuration` directory is git-ignored (`.gitignore:2`) and populated locally per checkout. New worktrees inherit the workspace tree but not that directory's contents.
 
-**Fix:** Copy it from a working checkout:
+**Fix:** Copy the whole directory from a working checkout:
 
 ```
-cp <main-checkout>/build-configuration/protocol.json \
-   <new-worktree>/build-configuration/protocol.json
+cp <main-checkout>/build-configuration/*.json \
+   <new-worktree>/build-configuration/
 ```
 
 Then re-run `SOFTWARE_RELEASE_ID=dev-release cargo build`.

--- a/platform/packages/finance/src/instant.rs
+++ b/platform/packages/finance/src/instant.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 const NANOS_PER_SECOND: u64 = 1_000_000_000;
+const SECONDS_PER_DAY: u64 = 86_400;
 
 /// Wall-clock instant denominated in nanoseconds since the Unix epoch.
 ///
@@ -44,7 +45,7 @@ impl Instant {
     }
 
     pub const fn plus_days(&self, days: u64) -> Self {
-        self.plus_seconds(days * 86_400)
+        self.plus_seconds(days * SECONDS_PER_DAY)
     }
 }
 

--- a/protocol/contracts/lease/src/contract/state/opening/unwind.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/unwind.rs
@@ -263,17 +263,22 @@ fn decode_response(payload: &[u8]) -> dex::DexResult<()> {
 mod tests {
     use currencies::{
         Lpn,
-        testing::{PaymentC1, PaymentC2},
+        testing::{LeaseC2, PaymentC1, PaymentC2},
     };
     use currency::CurrencyDef;
     use dex::RemoteTransferOutTask;
     use finance::{
-        coin::{Amount, Coin},
+        coin::{Amount, Coin, CoinDTO},
         duration::Duration,
         percent::Percent100,
     };
     use lpp::stub::LppRef as LppGenericRef;
-    use sdk::cosmwasm_std::{Addr, Coin as CwCoin, Empty, QuerierWrapper, testing::MockQuerier};
+    use remote_lease::response::{
+        CloseLeaseResponse, OpenLeaseResponse, OperationResponse, RemoteLeaseId, SwapResponse,
+    };
+    use sdk::cosmwasm_std::{
+        self, Addr, Coin as CwCoin, Empty, QuerierWrapper, testing::MockQuerier,
+    };
     use timealarms::stub::TimeAlarmsRef;
 
     use crate::{
@@ -290,6 +295,24 @@ mod tests {
     const LEASE: &str = "lease";
     const DOWNPAYMENT: Amount = 1_000;
     const PRINCIPAL: Amount = 4_000;
+
+    #[test]
+    fn decode_rejects_non_transfer_out_responses() {
+        let amount_out: CoinDTO<currencies::PaymentGroup> = Coin::<LeaseC2>::new(1000).into();
+        let unexpected = [
+            OperationResponse::OpenLease(OpenLeaseResponse {
+                remote_lease_id: remote_lease_id(),
+            }),
+            OperationResponse::CloseLease(CloseLeaseResponse {}),
+            OperationResponse::Swap(SwapResponse { amount_out }),
+        ];
+        unexpected.into_iter().for_each(|payload| {
+            assert!(matches!(
+                decode(&payload),
+                Err(dex::Error::UnexpectedResponseVariant(_reason))
+            ));
+        });
+    }
 
     /// The baseline is persisted, not `#[serde(skip)]`: it must survive every
     /// callback's serde round-trip, since a baseline reset to a post-arrival
@@ -377,6 +400,12 @@ mod tests {
         assert_eq!(Ok(true), received(&task, &both));
     }
 
+    fn decode(payload: &OperationResponse) -> dex::DexResult<()> {
+        cosmwasm_std::to_json_vec(payload)
+            .map_err(dex::Error::remote_swap_client)
+            .and_then(|payload| super::decode_response(&payload))
+    }
+
     fn received(task: &OpeningUnwindTask, querier: &MockQuerier<Empty>) -> Result<bool, String> {
         task.all_received(&Addr::unchecked(LEASE), QuerierWrapper::new(querier))
             .map_err(|err| err.to_string())
@@ -461,5 +490,10 @@ mod tests {
             time_alarms: Addr::unchecked("timealarms"),
             market_price_oracle: Addr::unchecked("oracle"),
         }
+    }
+
+    fn remote_lease_id() -> RemoteLeaseId {
+        RemoteLeaseId::new(String::from("StubPda11111111111111111111111111111"))
+            .expect("a base58 sample")
     }
 }

--- a/protocol/packages/remote_lease/src/envelope.rs
+++ b/protocol/packages/remote_lease/src/envelope.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "stub")]
+use sdk::cosmwasm_std::{Addr, Api, StdResult};
+
 pub use remote_lease_wire::envelope::LeaseAddrOnWire;
 use remote_lease_wire::version::ProtocolVersion;
 
@@ -41,18 +44,12 @@ pub struct PacketEnvelope {
 /// logic.
 #[cfg(feature = "stub")]
 pub trait NolusLeaseAddr {
-    fn into_validated(
-        self,
-        api: &dyn sdk::cosmwasm_std::Api,
-    ) -> sdk::cosmwasm_std::StdResult<sdk::cosmwasm_std::Addr>;
+    fn into_validated(self, api: &dyn Api) -> StdResult<Addr>;
 }
 
 #[cfg(feature = "stub")]
 impl NolusLeaseAddr for LeaseAddrOnWire {
-    fn into_validated(
-        self,
-        api: &dyn sdk::cosmwasm_std::Api,
-    ) -> sdk::cosmwasm_std::StdResult<sdk::cosmwasm_std::Addr> {
+    fn into_validated(self, api: &dyn Api) -> StdResult<Addr> {
         api.addr_validate(self.as_str())
     }
 }

--- a/protocol/packages/remote_lease/src/tests.rs
+++ b/protocol/packages/remote_lease/src/tests.rs
@@ -427,6 +427,38 @@ fn protocol_version_round_trip_pinned() {
 }
 
 // ---------------------------------------------------------------------------
+// 9. Cross-crate typed↔wire envelope byte-equality (drift tripwire)
+//
+// The typed `PacketEnvelope` (decoded in production) and the wire
+// `PacketEnvelope` (consumed by the Solana counterpart) each declare their own
+// field list and serde attributes. For every `Operation` variant, the
+// semantically-equivalent typed and wire envelopes must serialize
+// byte-identically, and the wire bytes must decode into the typed envelope.
+// Any drift in either side's field order, field name, or serde attribute
+// breaks these.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn envelope_open_lease_typed_matches_wire() {
+    assert_typed_wire_envelopes_match(Operation::OpenLease(sample_open_lease_params()));
+}
+
+#[test]
+fn envelope_close_lease_typed_matches_wire() {
+    assert_typed_wire_envelopes_match(Operation::CloseLease(CloseLeaseParams {}));
+}
+
+#[test]
+fn envelope_swap_typed_matches_wire() {
+    assert_typed_wire_envelopes_match(Operation::Swap(sample_swap_params()));
+}
+
+#[test]
+fn envelope_transfer_out_typed_matches_wire() {
+    assert_typed_wire_envelopes_match(Operation::TransferOut(sample_transfer_out_params()));
+}
+
+// ---------------------------------------------------------------------------
 // helpers — expected value first per project rule 17
 // ---------------------------------------------------------------------------
 
@@ -440,6 +472,34 @@ where
     let decoded: T =
         serde_json::from_str(&encoded).expect("decoding the freshly-encoded value must succeed");
     assert_eq!(value, &decoded);
+}
+
+fn assert_typed_wire_envelopes_match(operation: Operation) {
+    const LEASE: &str = "nolus1leaseaddr";
+    const NONCE: u64 = 7;
+
+    let wire = remote_lease_wire::envelope::PacketEnvelope {
+        lease: LeaseAddrOnWire::new(LEASE),
+        operation: remote_lease_wire::msg::Operation::from(&operation),
+        version: ProtocolVersion,
+        nonce: NONCE,
+    };
+    let typed = PacketEnvelope {
+        lease: LeaseAddrOnWire::new(LEASE),
+        operation,
+        version: ProtocolVersion,
+        nonce: NONCE,
+    };
+
+    let wire_json = serde_json::to_string(&wire).expect("the wire envelope must serialize");
+    assert_eq!(
+        wire_json,
+        serde_json::to_string(&typed).expect("the typed envelope must serialize"),
+    );
+
+    let decoded: PacketEnvelope =
+        serde_json::from_str(&wire_json).expect("wire bytes must decode into the typed envelope");
+    assert_eq!(typed, decoded);
 }
 
 fn sample_open_lease_params() -> OpenLeaseParams {

--- a/protocol/packages/remote_profit/src/tests.rs
+++ b/protocol/packages/remote_profit/src/tests.rs
@@ -393,6 +393,38 @@ fn protocol_version_round_trip_pinned() {
 }
 
 // ---------------------------------------------------------------------------
+// 9. Cross-crate typed↔wire envelope byte-equality (drift tripwire)
+//
+// The typed `PacketEnvelope` (decoded in production) and the wire
+// `PacketEnvelope` (consumed by the Solana counterpart) each declare their own
+// field list and serde attributes. For every `Operation` variant, the
+// semantically-equivalent typed and wire envelopes must serialize
+// byte-identically, and the wire bytes must decode into the typed envelope.
+// Any drift in either side's field order, field name, or serde attribute
+// breaks these.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn envelope_open_profit_typed_matches_wire() {
+    assert_typed_wire_envelopes_match(Operation::OpenProfit(sample_open_profit_params()));
+}
+
+#[test]
+fn envelope_swap_typed_matches_wire() {
+    assert_typed_wire_envelopes_match(Operation::Swap(sample_swap_params()));
+}
+
+#[test]
+fn envelope_transfer_out_typed_matches_wire() {
+    assert_typed_wire_envelopes_match(Operation::TransferOut(sample_transfer_out_params()));
+}
+
+#[test]
+fn envelope_close_profit_typed_matches_wire() {
+    assert_typed_wire_envelopes_match(Operation::CloseProfit(CloseProfitParams {}));
+}
+
+// ---------------------------------------------------------------------------
 // helpers — expected value first per project rule 17
 // ---------------------------------------------------------------------------
 
@@ -406,6 +438,31 @@ where
     let decoded: T =
         serde_json::from_str(&encoded).expect("decoding the freshly-encoded value must succeed");
     assert_eq!(value, &decoded);
+}
+
+fn assert_typed_wire_envelopes_match(operation: Operation) {
+    const NONCE: u64 = 7;
+
+    let wire = remote_profit_wire::envelope::PacketEnvelope {
+        operation: remote_profit_wire::msg::Operation::from(&operation),
+        version: ProtocolVersion,
+        nonce: NONCE,
+    };
+    let typed = PacketEnvelope {
+        operation,
+        version: ProtocolVersion,
+        nonce: NONCE,
+    };
+
+    let wire_json = serde_json::to_string(&wire).expect("the wire envelope must serialize");
+    assert_eq!(
+        wire_json,
+        serde_json::to_string(&typed).expect("the typed envelope must serialize"),
+    );
+
+    let decoded: PacketEnvelope =
+        serde_json::from_str(&wire_json).expect("wire bytes must decode into the typed envelope");
+    assert_eq!(typed, decoded);
 }
 
 /// A real bech32 Nolus account address (32-byte witness), valid checksum.


### PR DESCRIPTION
Fix batch from the pre-audit sweeps #694 / #695 / #696 (epic #689). No production behaviour change.

## style (#694)
- `finance::instant`: name the seconds-per-day factor (`SECONDS_PER_DAY`) — the sibling factor `NANOS_PER_SECOND` was already named (rule 30).
- `remote_lease::envelope`: import `Addr`/`Api`/`StdResult` in the `stub`-gated trait instead of five inline full paths (rule 26).

## test (#695 / #696)
- **Cross-crate envelope equality tripwire** (both crate pairs, lease + profit): for every `Operation` variant, assert the typed `PacketEnvelope` and the wire `PacketEnvelope` serialize byte-identically, and that wire bytes decode into the typed envelope — the production inbound direction. Complements `tests/cross_surface.rs` (#626), which pins typed→wire at the bare-Operation level and a single envelope variant; the additions cover the envelope layer per-variant plus the reverse decode direction. Any drift in either side's field order, field name, or serde attribute now fails a test.
- **`opening/unwind.rs`**: cover the `decode_response` reject arm (`decode_rejects_non_transfer_out_responses`), mirroring the equivalent test the three sibling drains already ship.

## Verification
- Quality gate green on both touched workspaces (build, fmt --check, lint, tests), platform + protocol.
- Independent review: generic 12-item checklist 12/12 PASS; security review CLEAR (no findings above informational); project-rule conformance walked rule-by-rule, PASS.

Part of #689.

## Design note — tripwire serializer identity

The review flagged the envelope byte-equality tests for using `serde_json` while the production IBC path uses `cosmwasm_std::to_json_vec` / `from_json`. Those are the same serializer by identity, not by coincidence: in the pinned cosmwasm-std 3.0.4, `serde.rs` re-exports serde_json directly — `to_json_vec` is `serde_json::to_vec`, `from_json` is `serde_json::from_slice` (the file's own header comment says so). There is no second serializer whose key ordering or enum tagging could diverge. Two further points: the tests compare the typed and wire struct shapes under a common serializer, so any serializer choice cancels out of the equality; and the crate's entire pre-existing pin suite (`assert_round_trip_eq`, `tests/cross_surface.rs`) uses `serde_json` under the same reasoning. Switching the unit tests to the `sdk` re-export is not viable regardless — `sdk` is an optional dependency gated behind the `stub` feature, and the feature-less test combination must keep compiling.