### PR TITLE
chore(deps): bump rand to 0.8.6 in all affected lockfiles

### DIFF
--- a/platform/Cargo.lock
+++ b/platform/Cargo.lock
@@ -1170,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -1348,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -1377,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_chacha",
  "rand_core",


### PR DESCRIPTION
Clears GHSA-cq8v-f236-94qc — the three open low dependabot alerts (rand < 0.8.6, transitive via ark-std in the platform, protocol and tests graphs; tools carries no rand).

Lockfile-only: exactly the version + checksum pair per lockfile; no manifest change, no other dependency moves.

## Verification
- Old and new checksums both match the canonical crates.io values (0.8.5 pre-state untampered; 0.8.6 exact).
- rand 0.8.6 is a non-yanked release published via GitHub trusted-publishing (rust-random/rand).
- `cargo metadata --locked` passes on all four workspaces.
- `cargo audit` reports zero vulnerabilities on the bumped graphs (only the pre-existing `paste` unmaintained informational, out of scope here).

Part of #697.