### PR TITLE
chore(lint): admit the Solana target cfg in the SYNC-block check-cfg

### DIFF
--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -21,7 +21,7 @@ keyword-idents = { level = "deny", priority = 1 }
 nonstandard-style = { level = "deny", priority = 1 }
 refining-impl-trait = { level = "deny", priority = 1 }
 rust-2018-idioms = { level = "deny", priority = 1 }
-unexpected_cfgs = { level = "forbid", priority = 1, check-cfg = ["cfg(test)"] }
+unexpected_cfgs = { level = "forbid", priority = 1, check-cfg = ["cfg(test)", 'cfg(target_os, values("solana"))'] }
 unfulfilled_lint_expectations = { level = "forbid", priority = 1 }
 unused = "deny"
 warnings = "deny"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -21,7 +21,7 @@ keyword-idents = { level = "deny", priority = 1 }
 nonstandard-style = { level = "deny", priority = 1 }
 refining-impl-trait = { level = "deny", priority = 1 }
 rust-2018-idioms = { level = "deny", priority = 1 }
-unexpected_cfgs = { level = "forbid", priority = 1, check-cfg = ["cfg(test)"] }
+unexpected_cfgs = { level = "forbid", priority = 1, check-cfg = ["cfg(test)", 'cfg(target_os, values("solana"))'] }
 unfulfilled_lint_expectations = { level = "forbid", priority = 1 }
 unused = "deny"
 warnings = "deny"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -31,7 +31,7 @@ keyword-idents = { level = "deny", priority = 1 }
 nonstandard-style = { level = "deny", priority = 1 }
 refining-impl-trait = { level = "deny", priority = 1 }
 rust-2018-idioms = { level = "deny", priority = 1 }
-unexpected_cfgs = { level = "forbid", priority = 1, check-cfg = ["cfg(test)"] }
+unexpected_cfgs = { level = "forbid", priority = 1, check-cfg = ["cfg(test)", 'cfg(target_os, values("solana"))'] }
 unfulfilled_lint_expectations = { level = "forbid", priority = 1 }
 unused = "deny"
 warnings = "deny"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -23,7 +23,7 @@ keyword-idents = { level = "deny", priority = 1 }
 nonstandard-style = { level = "deny", priority = 1 }
 refining-impl-trait = { level = "deny", priority = 1 }
 rust-2018-idioms = { level = "deny", priority = 1 }
-unexpected_cfgs = { level = "forbid", priority = 1, check-cfg = ["cfg(test)"] }
+unexpected_cfgs = { level = "forbid", priority = 1, check-cfg = ["cfg(test)", 'cfg(target_os, values("solana"))'] }
 unfulfilled_lint_expectations = { level = "forbid", priority = 1 }
 unused = "deny"
 warnings = "deny"


### PR DESCRIPTION
## Summary

Mirror into all four workspace roots the one-line `check-cfg` addition ibc-solray's SYNC block gained in nolus-protocol/ibc-solray#562: `unexpected_cfgs` now also admits `cfg(target_os, values("solana"))`. ibc-solray needs the value because its entrypoint gates on that target cfg and armed the lint tables; this repo does not use the cfg at all, so the line is inert here — the point is keeping the `[SYNC WITH OTHER WORKSPACES]` block byte-identical across repos, so a future sync-by-copy in either direction cannot silently drop the value.

## Changes

- `protocol/Cargo.toml`, `platform/Cargo.toml`, `tools/Cargo.toml`, `tests/Cargo.toml`: the identical one-line `check-cfg` extension in each SYNC block. Nothing else.

## Verification

- Ran `cargo metadata` against all four workspace manifests; all parse clean.
- Ran `cargo check -p json-value` (the one crate that currently opts into the workspace lint table via `[lints] workspace = true`); clean — `check-cfg` is permissive metadata, so an unused allowance changes no lint outcome.

## Follow-ups

- The wider observation from the ibc-solray work stands separately: these tables bind to a crate only through a `[lints] workspace = true` opt-in, which `tools/json-value` alone carries today. Arming them repo-wide is its own pass and stays with @gmanev7 (per nolus-protocol/ibc-solray#557).