### PR TITLE
docs: track CLAUDE.md in the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,6 @@
 # Cargo+Git helper file (https://github.com/rust-lang/cargo/blob/0.44.1/src/cargo/sources/git/utils.rs#L320-L327)
 .cargo-ok
 
-# Quality code criteria
-CLAUDE.md
-
 # Text file backups
 **/*.rs.bk
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# CLAUDE.md
+
+Guidance for Claude Code (claude.ai/code) in this repository.
+
+## Project Overview
+
+Nolus Money Market: a DeFi lending protocol implemented as CosmWasm smart contracts in Rust. Collateralized loans (leases), liquidity pools, oracle price feeds, multi-DEX swap support across Cosmos-ecosystem chains.
+
+## Build Commands
+
+Requires the `SOFTWARE_RELEASE_ID` env var (arbitrary string identifying the release).
+
+```bash
+# Build (from any workspace directory; platform/ needs only SOFTWARE_RELEASE_ID —
+# protocol/ and tests/ additionally require PROTOCOL_NETWORK, PROTOCOL_NAME, PROTOCOL_RELEASE_ID)
+SOFTWARE_RELEASE_ID='dev-release' cargo build
+
+# Lint across all workspaces (uses cargo-each tool)
+cargo lint
+
+# Run all tests across all workspaces
+cargo run-test
+
+# Run a single test (within a workspace)
+cargo test --all-features test_name
+
+# Build optimized WASM (from the protocol workspace; full pipeline incl. RUSTFLAGS in ci/build.sh)
+RUSTC_BOOTSTRAP=1 SOFTWARE_RELEASE_ID='dev-release' cargo each --tag build --tag @agnostic run --exact -- build -Zbuild-std="panic_abort,std" --profile "production_nets_release" --lib --locked --target wasm32-unknown-unknown
+
+# CI-equivalent lint of one workspace (two args: workspace + lint subcommand; PROFILE required)
+PROFILE=ci_dev ci/lint.sh protocol lint
+```
+
+IDE setup: set `SOFTWARE_RELEASE_ID=dev-release` in your editor's environment.
+
+## Workspace Structure
+
+Monorepo with three interconnected Cargo workspaces:
+
+### `platform/` - Network-agnostic foundation
+
+**Packages:**
+- **`finance`** - Core financial types: coins, prices, fractions, percentages, ratios, interest calculations, liability modeling. Uses `bnum` for arbitrary-precision arithmetic. No cosmwasm-std dependency — wall-clock time is its own `Instant` type (serde binary-compatible with cosmwasm `Timestamp`).
+- **`cw-time`** - Bridge crate converting between `finance::Instant` and cosmwasm `Timestamp` (`IntoInstant` / `IntoTimestamp` extension traits).
+- **`currency`** - Type-safe currency system with compile-time mismatch prevention. Core traits: `Currency` (type marker), `CurrencyDef` (group associations). Visitor pattern for runtime currency dispatch.
+- **`sdk`** - CosmWasm SDK wrapper with feature-gated re-exports (`contract`, `storage`, `testing`, `cosmos_ibc`, `cosmos_proto`). Abstracts external dependencies.
+- **`platform`** - Contract orchestration: state machine, banking operations, response/reply handling, protobuf transactions (`trx`), Interchain-Account registration and transaction submission (`ica`).
+- **`versioning`** - Contract migration and version management. Supports semver with separate storage versioning.
+- **`access-control`** - Permission management.
+- **`lpp`** - Liquidity Provider Pool abstractions.
+- **`oracle`** - Oracle protocol interfaces.
+- **`time-oracle`** - Time-based alarm system.
+- **`tree`** - Tree data structure utilities.
+
+**Contracts:** `admin` (protocol management), `timealarms`, `treasury`
+
+### `protocol/` - Network and DEX-specific implementations
+
+**Packages:** `currencies` (protocol-specific definitions), `dex` (DEX abstraction layer), `marketprice`, `swap` (per-DEX request builders: `astroport`, `osmosis`), `remote_lease` (typed cross-chain lease operations: stub client, callback classification, envelope/response types), `remote_lease_wire` (standalone wire-types crate shared with the Solana-side Remote Lease App per ADR 0001/0002 — no internal deps, MSRV 1.89 enforced in CI, hardened deserialization)
+
+**Contracts:** `lease` (loan positions), `leaser` (lease origination), `lpp` (lending pool), `oracle` (price feeds), `profit` (distribution), `remote_lease` (IBC controller paired with the Solana Remote Lease App per ADR 0001/0002), `reserve`, `void`
+
+### `tests/` - Integration tests
+
+Cross-workspace integration tests. The suite builds per DEX: `tests/Cargo.toml` declares a `{ tags = ["ci", "$dex"], include-rest = false }` combination with `$dex` generics over `dex-astroport_test`, `dex-astroport_main`, and `dex-osmosis`.
+
+### `tools/` - Build tooling
+
+- **`cargo-each`** - Custom cargo subcommand for running operations across workspace members with tag-based filtering. Powers `cargo lint` and `cargo run-test`.
+- **`topology`** - Network topology validation.
+- **`json-value`** - JSON manipulation utilities.
+
+## Key Architectural Patterns
+
+1. **Feature-gated compilation**: The `contract` feature enables actual contract implementations. Without it, only API types compile (useful for clients). Test utilities are gated behind `testing`.
+
+2. **Type-safe currency system**: Currencies are compile-time types, not runtime strings. The `Currency` trait + `CurrencyDef` with group associations prevent financial operation mismatches at compile time.
+
+3. **DEX and remote-swap abstraction**: The `dex` package drives asynchronous swaps over IBC Interchain Accounts (`dex::Account`, `ica_connectee`); the per-DEX request builders live in the `swap` package (`astroport`, `osmosis`). The `remote_lease` contract is the IBC controller paired with the Solana-side Remote Lease App (ADR 0001/0002); its typed operations and wire types live in the `remote_lease` and `remote_lease_wire` packages.
+
+4. **`cargo-each` tag system**: Workspace members declare tags in `[package.metadata.cargo-each]` in their Cargo.toml. CI uses these tags to select which packages to build/test for each configuration. New workspace members must declare appropriate tags.
+
+5. **Synchronized workspace lints**: The `[workspace.lints]` section is synchronized across all three workspace Cargo.toml files (marked with `### [SYNC WITH OTHER WORKSPACES]` comments).
+
+6. **IBC-enabled contracts** (`remote_lease`): turning a contract into an IBC counterparty requires three coordinated changes:
+   - Enable `cosmwasm-std/stargate`, `cosmwasm-std/cosmwasm_2_0`, and `sdk/cosmos_ibc` inside the contract's `contract` feature (the first emits `CosmosMsg::Ibc`, the second is required for `CosmosMsg::Any` in cosmwasm-std 3.x).
+   - Gate the six IBC entry points (`ibc_channel_open`, `ibc_channel_connect`, `ibc_channel_close`, `ibc_packet_receive`, `ibc_packet_ack`, `ibc_packet_timeout`) under `#[cfg(feature = "contract")]` in a dedicated `ibc.rs` module — keep them out of the API-only build.
+   - Update `ci/Containerfile`'s `cosmwasm_capabilities` allowlist if the contract enables a `cosmwasm_X_Y` feature not yet listed. The optimizer's `cosmwasm-check` runs against this allowlist independently of the chain runtime, so omissions surface as a CI-step failure on what looks like valid wasm.
+
+## Linting Rules
+
+All clippy lints denied. Key rules:
+- `unwrap_used` and `unwrap_in_result` denied - use proper error handling
+- `allow-unwrap-in-tests = true` (in `clippy.toml`)
+- Future-incompatible and deprecated features forbidden
+- All warnings are errors
+
+## Code Style & Test Conventions
+
+Imports below reference a private toolkit and won't resolve for external contributors; ignore them when building the repo.
+
+@~/.claude/kit/snippets/rust-style.md
+@~/.claude/kit/snippets/tests-style.md
+
+### Project-specific overrides & exceptions
+
+- **`expect()` posture**: clippy here denies `unwrap_used` / `unwrap_in_result` but not `expect_used`. `expect()` outside tests is still forbidden — reviewer-verified, not lint-enforced.
+- **`const fn` / `Addr`**: `Addr` is not `Copy` (it wraps `String`), so methods returning `Addr` by value cannot be `const fn`.
+- **Carve-out — `dex` composite state-machine vocabulary (issue #657)**, exception to *Avoid parasite words in names*: The `dex` crate's composite-workflow layer uses a deliberate, uniform vocabulary that is domain terminology here, not parasite words. Do not flag these names: the per-composite `pub enum State` and its disambiguating `State as StateXxx` re-exports (`out_local`→`StateLocalOut`, `out_remote`→`StateRemoteOut`), the `StartXxxState` start-state aliases (`StartLocalLocalState`, `StartLocalRemoteState`, `StartTransferInState`), and the lease-side `DexState` aliases that name those workflows. These are the established state-machine vocabulary of `protocol/packages/dex/src/impl_/` and its consumers; renaming one composite in isolation only fragments the convention. The fully-qualified `Handler::method(inner, …)` call style is likewise uniform across these composites and intentional — treat it as the established convention here, not a *Method syntax over fully-qualified trait calls* violation. New, unrelated abstractions remain subject to the rule.
+- **Prefix unused-yet items with `_`; never `#[allow(dead_code)]`**: When adding an item that has no caller yet (because the calling code lands in a follow-up PR), prefix the item's name with `_` rather than attaching `#[allow(dead_code)]`. Example: `fn _build_lease_id(ordinal: u64) -> LeaseId { … }`. The leading underscore is local, mechanical, and disappears the moment a real caller arrives. `#[allow]` is invisible to grep, survives forever, and tends to be forgotten when the caller eventually lands.
+- **Doc-comments on private items only when the *why* is non-obvious**: Public API items (`pub` / `pub(crate)` re-exports) use doc-comments to document their contract. Private items (private fns, private structs, inherent impls of private types) default to no doc-comment. A private item gets a doc-comment only when the comment encodes a non-obvious *why* — a hidden invariant, a workaround for a specific CosmWasm / IBC / DEX behaviour, a non-trivial choice between two reasonable implementations. The function's own name and signature carry the *what*. The word "helper" is banned **in identifiers and doc-comments** — it carries no information the function's own name and signature do not already convey. (Prose use of "helper" as a descriptive noun is fine.)
+
+### Review checklist additions
+
+- No `expect()` outside tests (see the `expect()` posture override above)
+- Feature-flag correctness: items used only under `contract` or `testing` are properly gated
+- New workspace members declare appropriate `[package.metadata.cargo-each]` tags
+- `[workspace.lints]` blocks remain in sync across `platform/`, `protocol/`, `tests/`
+- IBC-enabled contracts: every `cosmwasm_X_Y` / `stargate` / `neutron` feature enabled in the contract's Cargo.toml must appear in `ci/Containerfile`'s `cosmwasm_capabilities` allowlist
+- IBC error-path strings sourced from a counterparty (handshake versions, packet `ack` payloads, etc.) must not be echoed back unbounded — bound the length or hash before storing/emitting
+
+### Security review mapping
+
+- CosmWasm contract code (anything under `contracts/` in any workspace) → `building-secure-contracts` (Cosmos scanner)
+- Oracle / price-feed comparison, fraction / ratio math on untrusted input → `constant-time-analysis`
+- Code handling private keys, mnemonics, or any sensitive material → `zeroize-audit`
+- New/updated workspace dependencies → `supply-chain-risk-auditor`
+
+### Quality gate for delegated work
+
+Any agent performing a coding task must pass `cargo build`, `cargo fmt --all -- --check`, `cargo lint`, and `cargo run-test` (per-workspace — never from the repo root) before reporting the task complete.
+
+## Build Profiles
+
+- `ci_dev` - CI builds: no debug info, abort on panic
+- `ci_dev_no_debug_assertions` - CI without debug assertions
+- `test_nets_release` - Test network release (with debug assertions)
+- `production_nets_release` - Production release (optimized for size, LTO, stripped)
+
+## Environment Variables
+
+- `SOFTWARE_RELEASE_ID` (required) - Release identifier string
+- `PROTOCOL_NETWORK`, `PROTOCOL_NAME`, `PROTOCOL_RELEASE_ID` - Compile-time `env!` requirements of the protocol release in `versioning` (arbitrary strings; CI uses `ci-network` / `ci-protocol` / `ci-protocol-release`). Export them alongside `SOFTWARE_RELEASE_ID` before any protocol/tests workspace gate (`cargo lint`, `cargo lint-all`, `cargo run-test`); a missing one is a compile error.
+- `NET` - Target network (e.g., `dev`, `main`)
+- `PROTOCOL` - Protocol identifier (e.g., `osmosis-osmosis-usdc_axelar`, `neutron-astroport-usdc_noble`)

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -6,9 +6,9 @@ Discovery-tax patterns. Grouped by domain. Append on first re-encounter.
 
 ### `cargo build` fails in a fresh worktree: missing `build-configuration/protocol.json`
 
-**Symptom:** A fresh `git worktree add` checkout fails at build time because the build script reads `build-configuration/protocol.json` and the file is absent.
+**Symptom:** Fresh `git worktree add` checkout fails at build time: build script reads `build-configuration/protocol.json`, file absent.
 
-**Cause:** `build-configuration/protocol.json` is git-ignored and is populated locally per checkout. New worktrees inherit the workspace but not that file.
+**Cause:** `build-configuration/protocol.json` is git-ignored, populated locally per checkout. New worktrees inherit the workspace but not that file.
 
 **Fix:** Copy it from a working checkout:
 
@@ -40,15 +40,9 @@ Tried first (rejected at review): editing the tracked `/.cargo/config.toml`.
 
 ### Local clippy diverges from CI clippy
 
-**Symptom:** `cargo lint` / `cargo lint-all` fails locally on lints CI does not
-run (e.g. `unnecessary_sort_by` in the untouched oracle contract), or passes
-locally while CI fails — the verdicts differ on identical code.
+**Symptom:** `cargo lint` / `cargo lint-all` fails locally on lints CI does not run (e.g. `unnecessary_sort_by` in the untouched oracle contract), or passes locally while CI fails — verdicts differ on identical code.
 
-**Cause:** There is no `rust-toolchain.toml`; CI pins its toolchain via the
-`rust_image_digest` build argument in `ci/Containerfile` (currently 1.96.1),
-while the local default toolchain follows `rustup`. Clippy adds and tightens
-lints between releases, so a local toolchain that differs from the CI pin
-produces different verdicts.
+**Cause:** No `rust-toolchain.toml`; CI pins its toolchain via the `rust_image_digest` build argument in `ci/Containerfile` (currently 1.96.1), while the local default toolchain follows `rustup`. Clippy adds/tightens lints between releases, so a toolchain mismatch produces different verdicts.
 
 **Fix:** Run the gate on the CI-pinned toolchain:
 
@@ -59,38 +53,22 @@ cargo +1.96.1 lint-all
 cargo +1.96.1 run-test
 ```
 
-A local-only finding from a newer clippy is not a gate failure — fix it only
-if it survives on 1.96.1. Bump the pinned version here in lockstep with
-`ci/Containerfile`.
+A local-only finding from a newer clippy is not a gate failure — fix it only if it survives on 1.96.1. Bump the pinned version here in lockstep with `ci/Containerfile`.
 
-Tried first (did not work): treating local-only findings as CI blockers
-and patching untouched code to silence them.
+Tried first (did not work): treating local-only findings as CI blockers and patching untouched code to silence them.
 
 ### `cargo lint` / `cargo run-test` from the repo root silently match 0 packages
 
-**Symptom:** Running `cargo lint` or `cargo run-test` from the checkout **root** exits
-`0` with no output — it reads like a clean pass. It isn't: nothing was linted or tested.
+**Symptom:** Running `cargo lint` or `cargo run-test` from the checkout **root** exits `0` with no output — reads like a clean pass. It isn't: nothing was linted or tested.
 
-**Cause:** These are `cargo each` aliases that select packages by cargo-each **tag**, and
-the tags live in the per-workspace members. The repo root has **no `Cargo.toml`** (the
-workspaces are `protocol/`, `tests/`, `platform/`, plus tooling in `tools/`), so the tag
-match resolves to the empty set and `each` exits `0`. Worse, a stray `Cargo.toml`
-**above** the checkout hijacks cargo's upward manifest walk and runs against the wrong
-tree entirely.
+**Cause:** These are `cargo each` aliases that select packages by cargo-each **tag**, and the tags live in the per-workspace members. The repo root has **no `Cargo.toml`** (workspaces are `protocol/`, `tests/`, `platform/`, plus tooling in `tools/`), so the tag match resolves to the empty set and `each` exits `0`. Worse, a stray `Cargo.toml` **above** the checkout hijacks cargo's upward manifest walk and runs against the wrong tree entirely.
 
-**Fix:** Always run the gates **inside** a workspace dir — `protocol/`, `tests/`,
-`platform/`, or `tools/` — never from the repo root. Real CI iterates the workspaces via
-`ci/for-each-workspace.sh`; mirror that. Two corollaries:
+**Fix:** Always run the gates **inside** a workspace dir — `protocol/`, `tests/`, `platform/`, or `tools/` — never from the repo root. Real CI iterates the workspaces via `ci/for-each-workspace.sh`; mirror that. Two corollaries:
 
-- `cargo lint` runs **without** `--all-targets`, so it does not compile `#[cfg(test)]`
-  modules. When the change adds test code, lint it explicitly:
-  `cargo clippy -p <crate> --features <...> --all-targets` (or `cargo lint-all` — see the
-  Cargo section's "Pre-push lint" entry).
-- **Exit `0` with zero output is not a PASS.** A real test run prints per-suite counts;
-  require that evidence before calling it green.
+- `cargo lint` runs **without** `--all-targets`, so it does not compile `#[cfg(test)]` modules. When the change adds test code, lint it explicitly: `cargo clippy -p <crate> --features <...> --all-targets` (or `cargo lint-all` — see the Cargo section's "Pre-push lint" entry).
+- **Exit `0` with zero output is not a PASS.** A real test run prints per-suite counts; require that evidence before calling it green.
 
-Tried first (did not work): `cargo lint` / `cargo run-test` from the repo root and
-reading the `0` exit as success.
+Tried first (did not work): `cargo lint` / `cargo run-test` from the repo root, reading the `0` exit as success.
 
 ## CosmWasm
 
@@ -117,9 +95,9 @@ Tried first (did not work): enabling only `cosmwasm-std/stargate`; adding only `
 
 ### A workspace dep's feature does not propagate from a consumer's same-named feature
 
-**Symptom:** Contract crate `A` declares `feature = "stub"` and depends on workspace crate `B` which also has `feature = "stub"` (typically gating test or mock helpers). `cargo build --features stub` on `A` compiles, but the stub-gated items in `B` are unreachable — the items behind `#[cfg(feature = "stub")]` in `B` never compile in. Or: tests in `A` that rely on `B`'s stub helpers fail to find symbols.
+**Symptom:** Contract crate `A` declares `feature = "stub"` and depends on workspace crate `B` which also has `feature = "stub"` (typically gating test or mock helpers). `cargo build --features stub` on `A` compiles, but the stub-gated items in `B` are unreachable — items behind `#[cfg(feature = "stub")]` in `B` never compile in. Or: tests in `A` relying on `B`'s stub helpers fail to find symbols.
 
-**Cause:** Cargo features do not propagate by name. Declaring `[features] stub = []` in `A` does not turn on `stub` in `A`'s deps. The propagation must be spelled explicitly: `stub = ["B/stub"]`.
+**Cause:** Cargo features do not propagate by name. Declaring `[features] stub = []` in `A` does not turn on `stub` in `A`'s deps. Propagation must be spelled explicitly: `stub = ["B/stub"]`.
 
 **Fix:** In `A`'s Cargo.toml:
 
@@ -128,7 +106,7 @@ Tried first (did not work): enabling only `cosmwasm-std/stargate`; adding only `
 stub = ["B/stub"]
 ```
 
-If `A` also has a higher-level feature (e.g. `contract = [..., "stub"]`) that already lists `stub`, the propagation rides along automatically once the line above is in place — no extra work.
+If `A` also has a higher-level feature (e.g. `contract = [..., "stub"]`) that already lists `stub`, propagation rides along automatically once the line above is in place — no extra work.
 
 **Reviewer check:** any new `stub` (or test-helper / mock) feature on a contract crate that depends on a workspace crate exposing the same-named feature must propagate explicitly. Greppable: `git grep -n '^stub = \[\]$' protocol/contracts` should be empty.
 
@@ -138,16 +116,16 @@ Tried first (did not work): `stub = []` on the contract crate, expecting Cargo t
 
 **Symptom:** `cargo lint` passes locally, CI's "Lint codebase with tests" job fails with errors in `#[cfg(test)]` code — e.g. an unresolved test-only path like `versioning::ReleaseId::new_test` under a feature combination that does not activate `versioning/testing`.
 
-**Cause:** The repo has two distinct CI lint jobs, mirroring two distinct aliases in `/.cargo/config.toml`:
+**Cause:** Two distinct CI lint jobs, mirroring two distinct aliases in `/.cargo/config.toml`:
 
-- `lint = "each --tag ci run --print-command -- clippy --locked"` — runs every cargo-each feature combination **without** `--all-targets`. Test binaries are not compiled. `cfg(test) = false`. Any compile error gated `#[cfg(test)]` is invisible.
-- `lint-all = "each --tag ci run --print-command -- clippy --all-targets --locked"` — same matrix, **with** `--all-targets`. Test binaries compile under every combination. `cfg(test) = true`. This catches errors in `mod tests {}` blocks that only surface under feature combinations the test was not authored against.
+- `lint = "each --tag ci run --print-command -- clippy --locked"` — runs every cargo-each feature combination **without** `--all-targets`. Test binaries not compiled. `cfg(test) = false`. Any compile error gated `#[cfg(test)]` is invisible.
+- `lint-all = "each --tag ci run --print-command -- clippy --all-targets --locked"` — same matrix, **with** `--all-targets`. Test binaries compile under every combination. `cfg(test) = true`. Catches errors in `mod tests {}` blocks that only surface under feature combinations the test was not authored against.
 
 CI runs both. Running only `cargo lint` locally and assuming "lint passes ⇒ ready to push" misses every cross-combination test-compile bug.
 
-A second trap: `cargo test --features contract,testing` and `cargo clippy --features contract,testing --all-targets` both exercise test code, but only in the union combo. Test code that references symbols gated on `versioning/testing` (or any other dev-only feature) will compile under `contract,testing` but fail under `contract` alone — which CI's lint-with-tests matrix exercises.
+A second trap: `cargo test --features contract,testing` and `cargo clippy --features contract,testing --all-targets` both exercise test code, but only in the union combo. Test code referencing symbols gated on `versioning/testing` (or any other dev-only feature) will compile under `contract,testing` but fail under `contract` alone — which CI's lint-with-tests matrix exercises.
 
-**Fix / pre-push checklist:** before `git push` on any branch that touches `#[cfg(test)]` or `[dev-dependencies]`, run **both**:
+**Fix / pre-push checklist:** before `git push` on any branch touching `#[cfg(test)]` or `[dev-dependencies]`, run **both**:
 
 ```
 cargo lint           # all combos, library only
@@ -157,4 +135,4 @@ cargo run-test       # tests across every CI feature combo
 
 If `cargo lint-all` errors only under specific combinations, fix the root cause by activating the needed dev-only feature via `[dev-dependencies]` (Cargo unifies dev-dep features with regular-dep features whenever test/all-targets builds run) rather than wiring the test-only feature into the crate's own `[features]` table — the latter only helps when the consumer explicitly passes that feature flag, and CI's matrix doesn't.
 
-Tried first (did not catch the bug): `cargo lint` + `cargo clippy --features contract,testing --all-targets` + `cargo test --features contract,testing`. None of these compile test code under the `--features contract` (alone) combination that CI exercises.
+Tried first (did not catch the bug): `cargo lint` + `cargo clippy --features contract,testing --all-targets` + `cargo test --features contract,testing`. None compile test code under the `--features contract` (alone) combination that CI exercises.


### PR DESCRIPTION
## What

- Track `CLAUDE.md` in the repository (and drop its `.gitignore` entry). Contributor guidance previously lived only in local working copies; tracking it on `main` gives tooling and contributors one shared entry point. Code-style conventions are imported from a private toolkit rather than restated here.
- The content is verified against the current `main`: descriptions of designs that are no longer in the tree were removed, and the workspace/package/test descriptions were aligned with the code as it stands.

## Notes

- Single doc-only commit, rebased onto the current `main`; no code changes.
- `RUNBOOK.md` is already tracked on `main` and unchanged, so no runbook changes are needed here.