### PR TITLE
refactor(dex): abstract transfer-out behind a transport factory

### DIFF
--- a/protocol/contracts/lease/src/contract/endpoins.rs
+++ b/protocol/contracts/lease/src/contract/endpoins.rs
@@ -63,7 +63,8 @@ pub fn migrate(
     _msg: ProtocolMigrationMessage<MigrateMsg>,
 ) -> ContractResult<CwResponse> {
     // v10 reshapes the persisted `LeaseDTO` to carry the Solana-side
-    // remote-lease PDA as a non-optional field, so a pre-v10 lease cannot
+    // remote-lease PDA as a non-optional field and adds `transport_out_fry`
+    // to `TransferOut`'s persisted layout, so a pre-v10 lease cannot
     // be deserialised under the new layout. A v9 lease has no meaningful
     // `remote_lease_id` to synthesise — its `dex_account` is an ICA host on
     // the DEX chain, not a Solana PDA — so a real v9→v10 migration would

--- a/protocol/contracts/lease/src/contract/mod.rs
+++ b/protocol/contracts/lease/src/contract/mod.rs
@@ -18,6 +18,7 @@ mod endpoins;
 mod finalize;
 pub mod msg;
 mod state;
+mod transport;
 
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
@@ -31,6 +31,7 @@ use crate::{
             opened::{self, payment::Repayable},
             resp_delivery::ForwardToDexEntry,
         },
+        transport::TransferOutFactory,
     },
     error::ContractResult,
     event::Type,
@@ -44,8 +45,12 @@ pub(in crate::contract::state) mod liquidation;
 mod task;
 
 type Task<RepayableT, CalculatorT> = SellAsset<RepayableT, CalculatorT>;
-type DexState<Repayable, CalculatorT> =
-    dex::StateLocalOut<Task<Repayable, CalculatorT>, SwapClient, ForwardToDexEntry>;
+type DexState<Repayable, CalculatorT> = dex::StateLocalOut<
+    Task<Repayable, CalculatorT>,
+    TransferOutFactory,
+    SwapClient,
+    ForwardToDexEntry,
+>;
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct SellAsset<RepayableT, CalculatorT> {

--- a/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
@@ -16,6 +16,7 @@ use finance::{
 use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
+use crate::contract::transport::TransferOutFactory;
 use crate::{
     api::{
         LeasePaymentCurrencies, PaymentCoin,
@@ -37,11 +38,13 @@ use crate::{
     finance::{LpnCurrencies, LpnCurrency},
 };
 
-pub(super) type StartState = StartLocalLocalState<BuyLpn, SwapClient, ForwardToDexEntry>;
-pub(crate) type DexState = dex::StateLocalOut<BuyLpn, SwapClient, ForwardToDexEntry>;
+pub(super) type StartState =
+    StartLocalLocalState<BuyLpn, TransferOutFactory, SwapClient, ForwardToDexEntry>;
+pub(crate) type DexState =
+    dex::StateLocalOut<BuyLpn, TransferOutFactory, SwapClient, ForwardToDexEntry>;
 
 pub(in super::super) fn start(lease: Lease, payment: PaymentCoin) -> StartState {
-    dex::start_local_local(BuyLpn::new(lease, payment))
+    dex::start_local_local(BuyLpn::new(lease, payment), TransferOutFactory::default())
 }
 
 #[derive(Serialize, Deserialize)]

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -28,6 +28,7 @@ use crate::{
             out_task::{OutTaskFactory, WithOutCurrency},
             resp_delivery::ForwardToDexEntry,
         },
+        transport::TransferOutFactory,
     },
     error::ContractResult,
     event::Type,
@@ -39,8 +40,10 @@ mod finish;
 
 type AssetGroup = LeaseAssetCurrencies;
 #[allow(dead_code)]
-pub(super) type StartState = StartLocalRemoteState<BuyAsset, SwapClient, ForwardToDexEntry>;
-pub(in super::super) type DexState = dex::StateRemoteOut<BuyAsset, SwapClient, ForwardToDexEntry>;
+pub(super) type StartState =
+    StartLocalRemoteState<BuyAsset, TransferOutFactory, SwapClient, ForwardToDexEntry>;
+pub(in super::super) type DexState =
+    dex::StateRemoteOut<BuyAsset, TransferOutFactory, SwapClient, ForwardToDexEntry>;
 
 pub(super) fn start(
     new_lease: NewLeaseForm,
@@ -51,15 +54,18 @@ pub(super) fn start(
     deps: (LppRef, OracleRef, TimeAlarmsRef, LeasesRef),
     start_opening_at: Instant,
 ) -> StartState {
-    dex::start_local_remote(BuyAsset::new(
-        new_lease,
-        dex_account,
-        remote_lease,
-        downpayment,
-        loan,
-        deps,
-        start_opening_at,
-    ))
+    dex::start_local_remote(
+        BuyAsset::new(
+            new_lease,
+            dex_account,
+            remote_lease,
+            downpayment,
+            loan,
+            deps,
+            start_opening_at,
+        ),
+        TransferOutFactory::default(),
+    )
 }
 
 type BuyAssetStateResponse = <BuyAsset as SwapTask>::StateResponse;

--- a/protocol/contracts/lease/src/contract/state/paid/transfer_in.rs
+++ b/protocol/contracts/lease/src/contract/state/paid/transfer_in.rs
@@ -36,6 +36,7 @@ use crate::{
             out_task::{OutTaskFactory, WithOutCurrency},
             resp_delivery::ForwardToDexEntry,
         },
+        transport::TransferOutFactory,
     },
     error::ContractResult,
     event::Type,
@@ -43,8 +44,10 @@ use crate::{
 };
 
 type AssetGroup = LeaseAssetCurrencies;
-pub(super) type StartState = StartTransferInState<TransferIn, SwapClient, ForwardToDexEntry>;
-pub(in super::super) type DexState = dex::StateLocalOut<TransferIn, SwapClient, ForwardToDexEntry>;
+pub(super) type StartState =
+    StartTransferInState<TransferIn, TransferOutFactory, SwapClient, ForwardToDexEntry>;
+pub(in super::super) type DexState =
+    dex::StateLocalOut<TransferIn, TransferOutFactory, SwapClient, ForwardToDexEntry>;
 
 pub(in super::super) fn start(lease: Lease) -> StartState {
     let transfer = TransferIn::new(lease);

--- a/protocol/contracts/lease/src/contract/transport/mod.rs
+++ b/protocol/contracts/lease/src/contract/transport/mod.rs
@@ -1,0 +1,3 @@
+pub use transfer_out::TransferOutFactory;
+
+mod transfer_out;

--- a/protocol/contracts/lease/src/contract/transport/transfer_out.rs
+++ b/protocol/contracts/lease/src/contract/transport/transfer_out.rs
@@ -2,11 +2,9 @@ use serde::{Deserialize, Serialize};
 
 use currency::Group;
 use cw_time::IntoTimestamp;
-use dex::{Connectable, SwapTask, TransportOut, TransportOutFactory};
-use finance::{coin::CoinDTO, duration::Duration, instant::Instant};
+use dex::{Connectable, IBC_TIMEOUT, SwapTask, TransportOut, TransportOutFactory};
+use finance::{coin::CoinDTO, instant::Instant};
 use platform::{bank_ibc::local::Sender as LocalSender, batch::Batch};
-
-const IBC_TIMEOUT: Duration = Duration::from_days(1);
 
 #[derive(Default, Serialize, Deserialize)]
 pub struct TransferOutFactory {}

--- a/protocol/contracts/lease/src/contract/transport/transfer_out.rs
+++ b/protocol/contracts/lease/src/contract/transport/transfer_out.rs
@@ -1,0 +1,58 @@
+use serde::{Deserialize, Serialize};
+
+use currency::Group;
+use cw_time::IntoTimestamp;
+use dex::{Connectable, SwapTask, TransportOut, TransportOutFactory};
+use finance::{coin::CoinDTO, duration::Duration, instant::Instant};
+use platform::{bank_ibc::local::Sender as LocalSender, batch::Batch};
+
+const IBC_TIMEOUT: Duration = Duration::from_days(1);
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct TransferOutFactory {}
+
+impl TransportOutFactory for TransferOutFactory {
+    type Transport<'this> = TransferOutTrx<'this>;
+
+    fn transport<'task, Task>(&self, task: &'task Task, now: Instant) -> Self::Transport<'task>
+    where
+        Task: SwapTask,
+    {
+        Self::Transport::new(LocalSender::new(
+            &task.dex_account().dex().transfer_channel.local_endpoint,
+            task.dex_account().owner(),
+            task.dex_account().remote(),
+            (now + IBC_TIMEOUT).into_timestamp(),
+            format!(
+                "Transfer out: {sender} -> {receiver}",
+                sender = task.dex_account().owner(),
+                receiver = task.dex_account().remote()
+            ),
+        ))
+    }
+}
+
+pub struct TransferOutTrx<'account> {
+    sender: LocalSender<'account>,
+}
+
+impl<'account> TransferOutTrx<'account> {
+    fn new(sender: LocalSender<'account>) -> Self {
+        Self { sender }
+    }
+}
+
+impl<'account> TransportOut for TransferOutTrx<'account> {
+    fn send<G>(&mut self, amount: &CoinDTO<G>)
+    where
+        G: Group,
+    {
+        self.sender.send(amount)
+    }
+}
+
+impl<'account> From<TransferOutTrx<'account>> for Batch {
+    fn from(value: TransferOutTrx<'account>) -> Self {
+        value.sender.into()
+    }
+}

--- a/protocol/packages/dex/src/account.rs
+++ b/protocol/packages/dex/src/account.rs
@@ -21,7 +21,7 @@ impl Account {
         &self.owner
     }
 
-    pub(super) fn remote(&self) -> &HostAccount {
+    pub fn remote(&self) -> &HostAccount {
         &self.remote
     }
 

--- a/protocol/packages/dex/src/impl_/migration.rs
+++ b/protocol/packages/dex/src/impl_/migration.rs
@@ -1,4 +1,4 @@
-pub trait MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
+pub trait _MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
 where
     Self: Sized,
 {
@@ -9,7 +9,7 @@ where
         MigrateFn: FnOnce(SwapTask) -> SwapTaskNew;
 }
 
-pub trait InspectSpec<SwapTask, R> {
+pub trait _InspectSpec<SwapTask, R> {
     fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R
     where
         InspectFn: FnOnce(&SwapTask) -> R;

--- a/protocol/packages/dex/src/impl_/mod.rs
+++ b/protocol/packages/dex/src/impl_/mod.rs
@@ -30,8 +30,16 @@ mod transfer_in_init;
 mod transfer_out;
 mod trx;
 
-pub type TransferOutRespDelivery<SwapTask, SEnum, SwapClient, ForwardToInnerMsg> =
-    ResponseDelivery<TransferOut<SwapTask, SEnum, SwapClient>, ForwardToInnerMsg>;
+pub type TransferOutRespDelivery<
+    SwapTask,
+    SEnum,
+    TransportOutFactory,
+    SwapClient,
+    ForwardToInnerMsg,
+> = ResponseDelivery<
+    TransferOut<SwapTask, SEnum, TransportOutFactory, SwapClient>,
+    ForwardToInnerMsg,
+>;
 
 pub type SwapExactInRespDelivery<SwapTask, SEnum, SwapClient, ForwardToInnerMsg> =
     ResponseDelivery<SwapExactIn<SwapTask, SEnum, SwapClient>, ForwardToInnerMsg>;

--- a/protocol/packages/dex/src/impl_/mod.rs
+++ b/protocol/packages/dex/src/impl_/mod.rs
@@ -17,7 +17,7 @@ pub use self::{
 };
 
 #[cfg(feature = "migration")]
-pub mod migration;
+mod migration;
 mod out_local;
 mod out_remote;
 mod resp_delivery;

--- a/protocol/packages/dex/src/impl_/mod.rs
+++ b/protocol/packages/dex/src/impl_/mod.rs
@@ -17,7 +17,7 @@ pub use self::{
 };
 
 #[cfg(feature = "migration")]
-mod migration;
+pub mod migration;
 mod out_local;
 mod out_remote;
 mod resp_delivery;

--- a/protocol/packages/dex/src/impl_/out_local.rs
+++ b/protocol/packages/dex/src/impl_/out_local.rs
@@ -517,18 +517,20 @@ mod impl_migration {
         SwapTask as SwapTaskT,
         impl_::{ForwardToInner, migration::MigrateSpec},
         swap::ExactAmountIn,
+        transport::TransferOutFactory as TransportOutFactoryT,
     };
 
-    impl<SwapTask, SwapTaskNew, SEnumNew, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, SwapTaskNew, SEnumNew, TransportOutFactory, SwapClient, ForwardToInnerMsg>
         MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
+        TransportOutFactory: TransportOutFactoryT,
         SwapClient: ExactAmountIn,
         ForwardToInnerMsg: ForwardToInner,
         SwapTaskNew: SwapTaskT<OutG = SwapTask::OutG>,
     {
-        type Out = State<SwapTaskNew, SwapClient, ForwardToInnerMsg>;
+        type Out = State<SwapTaskNew, TransportOutFactory, SwapClient, ForwardToInnerMsg>;
 
         fn migrate_spec<MigrateFn>(self, migrate_fn: MigrateFn) -> Self::Out
         where
@@ -546,8 +548,8 @@ mod impl_migration {
         }
     }
 
-    impl<SwapTask, R, SwapClient, ForwardToInnerMsg> InspectSpec<SwapTask, R>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, R, TransportOutFactory, SwapClient, ForwardToInnerMsg> InspectSpec<SwapTask, R>
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
         ForwardToInnerMsg: ForwardToInner,

--- a/protocol/packages/dex/src/impl_/out_local.rs
+++ b/protocol/packages/dex/src/impl_/out_local.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{ForwardToInner, SwapTask as SwapTaskT};
+use crate::{ForwardToInner, SwapTask as SwapTaskT, TransportOutFactory as TransportOutFactoryT};
 
 use super::{
     SwapExactIn, SwapExactInRespDelivery, TransferInFinish, TransferInInit,
@@ -9,15 +9,19 @@ use super::{
 
 #[derive(Serialize, Deserialize)]
 #[serde(bound(
-    serialize = "SwapTask: Serialize",
-    deserialize = "SwapTask: Deserialize<'de>",
+    serialize = "SwapTask: Serialize,
+                    TransportOutFactory: Serialize",
+    deserialize = "SwapTask: Deserialize<'de>,
+                    TransportOutFactory: Deserialize<'de>",
 ))]
-pub enum State<SwapTask, SwapClient, ForwardToInnerMsg>
+pub enum State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
 where
     SwapTask: SwapTaskT,
 {
-    TransferOut(TransferOut<SwapTask, Self, SwapClient>),
-    TransferOutRespDelivery(TransferOutRespDelivery<SwapTask, Self, SwapClient, ForwardToInnerMsg>),
+    TransferOut(TransferOut<SwapTask, Self, TransportOutFactory, SwapClient>),
+    TransferOutRespDelivery(
+        TransferOutRespDelivery<SwapTask, Self, TransportOutFactory, SwapClient, ForwardToInnerMsg>,
+    ),
     SwapExactIn(SwapExactIn<SwapTask, Self, SwapClient>),
     SwapExactInRespDelivery(SwapExactInRespDelivery<SwapTask, Self, SwapClient, ForwardToInnerMsg>),
     TransferInInit(TransferInInit<SwapTask, Self>),
@@ -25,28 +29,40 @@ where
     TransferInFinish(TransferInFinish<SwapTask, Self>),
 }
 
-pub type StartLocalLocalState<SwapTask, SwapClient, ForwardToInnerMsg> =
-    TransferOut<SwapTask, State<SwapTask, SwapClient, ForwardToInnerMsg>, SwapClient>;
-pub type StartRemoteLocalState<SwapTask, SwapClient, ForwardToInnerMsg> =
-    SwapExactIn<SwapTask, State<SwapTask, SwapClient, ForwardToInnerMsg>, SwapClient>;
-pub type StartTransferInState<SwapTask, SwapClient, ForwardToInnerMsg> =
-    TransferInInit<SwapTask, State<SwapTask, SwapClient, ForwardToInnerMsg>>;
+pub type StartLocalLocalState<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg> =
+    TransferOut<
+        SwapTask,
+        State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>,
+        TransportOutFactory,
+        SwapClient,
+    >;
+pub type StartRemoteLocalState<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg> =
+    SwapExactIn<
+        SwapTask,
+        State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>,
+        SwapClient,
+    >;
+pub type StartTransferInState<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg> =
+    TransferInInit<SwapTask, State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>>;
 
-pub fn start_local_local<SwapTask, SwapClient, ForwardToInnerMsg>(
+pub fn start_local_local<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>(
     spec: SwapTask,
-) -> StartLocalLocalState<SwapTask, SwapClient, ForwardToInnerMsg>
+    transport: TransportOutFactory,
+) -> StartLocalLocalState<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
 where
     SwapTask: SwapTaskT,
+    TransportOutFactory: TransportOutFactoryT,
     ForwardToInnerMsg: ForwardToInner,
 {
-    StartLocalLocalState::new(spec)
+    StartLocalLocalState::new(spec, transport)
 }
 
-pub fn start_remote_local<SwapTask, SwapClient, ForwardToInnerMsg>(
+pub fn start_remote_local<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>(
     spec: SwapTask,
-) -> StartRemoteLocalState<SwapTask, SwapClient, ForwardToInnerMsg>
+) -> StartRemoteLocalState<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
 where
     SwapTask: SwapTaskT,
+    TransportOutFactory: TransportOutFactoryT,
     ForwardToInnerMsg: ForwardToInner,
 {
     StartRemoteLocalState::new(spec)
@@ -63,33 +79,48 @@ mod impl_into {
 
     use super::{State, SwapExactInRespDelivery};
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg> From<TransferOut<SwapTask, Self, SwapClient>>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
+        From<TransferOut<SwapTask, Self, TransportOutFactory, SwapClient>>
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
         ForwardToInnerMsg: ForwardToInner,
     {
-        fn from(value: TransferOut<SwapTask, Self, SwapClient>) -> Self {
+        fn from(value: TransferOut<SwapTask, Self, TransportOutFactory, SwapClient>) -> Self {
             Self::TransferOut(value)
         }
     }
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg>
-        From<TransferOutRespDelivery<SwapTask, Self, SwapClient, ForwardToInnerMsg>>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
+        From<
+            TransferOutRespDelivery<
+                SwapTask,
+                Self,
+                TransportOutFactory,
+                SwapClient,
+                ForwardToInnerMsg,
+            >,
+        > for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
         ForwardToInnerMsg: ForwardToInner,
     {
         fn from(
-            value: TransferOutRespDelivery<SwapTask, Self, SwapClient, ForwardToInnerMsg>,
+            value: TransferOutRespDelivery<
+                SwapTask,
+                Self,
+                TransportOutFactory,
+                SwapClient,
+                ForwardToInnerMsg,
+            >,
         ) -> Self {
             Self::TransferOutRespDelivery(value)
         }
     }
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg> From<SwapExactIn<SwapTask, Self, SwapClient>>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
+        From<SwapExactIn<SwapTask, Self, SwapClient>>
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
     {
@@ -98,9 +129,9 @@ mod impl_into {
         }
     }
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
         From<SwapExactInRespDelivery<SwapTask, Self, SwapClient, ForwardToInnerMsg>>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
     {
@@ -111,8 +142,9 @@ mod impl_into {
         }
     }
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg> From<TransferInInit<SwapTask, Self>>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
+        From<TransferInInit<SwapTask, Self>>
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
         ForwardToInnerMsg: ForwardToInner,
@@ -122,9 +154,9 @@ mod impl_into {
         }
     }
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
         From<TransferInInitRespDelivery<SwapTask, Self, ForwardToInnerMsg>>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
         ForwardToInnerMsg: ForwardToInner,
@@ -134,8 +166,9 @@ mod impl_into {
         }
     }
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg> From<TransferInFinish<SwapTask, Self>>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
+        From<TransferInFinish<SwapTask, Self>>
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
         ForwardToInnerMsg: ForwardToInner,
@@ -152,7 +185,7 @@ mod impl_handler {
     use platform::ica::ErrorResponse as ICAErrorResponse;
 
     use crate::{
-        SwapTask as SwapTaskT,
+        SwapTask as SwapTaskT, TransportOutFactory as TransportOutFactoryT,
         impl_::{
             self, Handler,
             response::{ContinueResult, Result},
@@ -162,10 +195,11 @@ mod impl_handler {
 
     use super::{ForwardToInner, State};
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg> Handler
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg> Handler
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
+        TransportOutFactory: TransportOutFactoryT,
         SwapClient: ExactAmountIn,
         ForwardToInnerMsg: ForwardToInner,
     {
@@ -404,15 +438,19 @@ mod impl_contract {
     use finance::instant::Instant;
     use sdk::cosmwasm_std::QuerierWrapper;
 
-    use crate::{Contract, ContractInSwap, ForwardToInner, SwapTask as SwapTaskT};
+    use crate::{
+        Contract, ContractInSwap, ForwardToInner, SwapTask as SwapTaskT,
+        TransportOutFactory as TransportOutFactoryT,
+    };
 
     use super::State;
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg> Contract
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg> Contract
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask:
             SwapTaskT + ContractInSwap<StateResponse = <SwapTask as SwapTaskT>::StateResponse>,
+        TransportOutFactory: TransportOutFactoryT,
         ForwardToInnerMsg: ForwardToInner,
     {
         type StateResponse = <SwapTask as SwapTaskT>::StateResponse;
@@ -452,8 +490,8 @@ mod impl_display {
     use super::State;
     use crate::SwapTask as SwapTaskT;
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg> Display
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg> Display
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
     {

--- a/protocol/packages/dex/src/impl_/out_local.rs
+++ b/protocol/packages/dex/src/impl_/out_local.rs
@@ -512,16 +512,16 @@ mod impl_display {
 #[cfg(feature = "migration")]
 mod impl_migration {
 
-    use super::{super::migration::InspectSpec, State};
+    use super::{super::migration::_InspectSpec, State};
     use crate::{
         SwapTask as SwapTaskT,
-        impl_::{ForwardToInner, migration::MigrateSpec},
+        impl_::{ForwardToInner, migration::_MigrateSpec},
         swap::ExactAmountIn,
         transport::TransferOutFactory as TransportOutFactoryT,
     };
 
     impl<SwapTask, SwapTaskNew, SEnumNew, TransportOutFactory, SwapClient, ForwardToInnerMsg>
-        MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
+        _MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
         for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
@@ -548,7 +548,7 @@ mod impl_migration {
         }
     }
 
-    impl<SwapTask, R, TransportOutFactory, SwapClient, ForwardToInnerMsg> InspectSpec<SwapTask, R>
+    impl<SwapTask, R, TransportOutFactory, SwapClient, ForwardToInnerMsg> _InspectSpec<SwapTask, R>
         for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,

--- a/protocol/packages/dex/src/impl_/out_remote.rs
+++ b/protocol/packages/dex/src/impl_/out_remote.rs
@@ -371,7 +371,7 @@ mod impl_display {
 mod impl_migration {
     use super::State;
     use crate::{
-        SwapTask as SwapTaskT,
+        SwapTask as SwapTaskT, TransportOutFactory as TransportOutFactoryT,
         impl_::{ForwardToInner, migration::MigrateSpec},
         swap::ExactAmountIn,
     };
@@ -381,6 +381,7 @@ mod impl_migration {
         for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
+        TransportOutFactory: TransportOutFactoryT,
         SwapClient: ExactAmountIn,
         ForwardToInnerMsg: ForwardToInner,
         SwapTaskNew: SwapTaskT<OutG = SwapTask::OutG>,

--- a/protocol/packages/dex/src/impl_/out_remote.rs
+++ b/protocol/packages/dex/src/impl_/out_remote.rs
@@ -1,36 +1,47 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ForwardToInner, SwapTask as SwapTaskT,
+    ForwardToInner, SwapTask as SwapTaskT, TransportOutFactory as TransportOutFactoryT,
     impl_::{SwapExactIn, SwapExactInRespDelivery, TransferOut, TransferOutRespDelivery},
 };
 
 #[derive(Serialize, Deserialize)]
 #[serde(bound(
-    serialize = "SwapTask: Serialize",
-    deserialize = "SwapTask: Deserialize<'de>",
+    serialize = "SwapTask: Serialize,
+                    TransportOutFactory: Serialize",
+    deserialize = "SwapTask: Deserialize<'de>,
+                    TransportOutFactory: Deserialize<'de>",
 ))]
-pub enum State<SwapTask, SwapClient, ForwardToInnerMsg>
+pub enum State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
 where
     SwapTask: SwapTaskT,
 {
-    TransferOut(TransferOut<SwapTask, Self, SwapClient>),
-    TransferOutRespDelivery(TransferOutRespDelivery<SwapTask, Self, SwapClient, ForwardToInnerMsg>),
+    TransferOut(TransferOut<SwapTask, Self, TransportOutFactory, SwapClient>),
+    TransferOutRespDelivery(
+        TransferOutRespDelivery<SwapTask, Self, TransportOutFactory, SwapClient, ForwardToInnerMsg>,
+    ),
     SwapExactIn(SwapExactIn<SwapTask, Self, SwapClient>),
     SwapExactInRespDelivery(SwapExactInRespDelivery<SwapTask, Self, SwapClient, ForwardToInnerMsg>),
 }
 
-pub type StartLocalRemoteState<SwapTask, SwapClient, ForwardToInnerMsg> =
-    TransferOut<SwapTask, State<SwapTask, SwapClient, ForwardToInnerMsg>, SwapClient>;
+pub type StartLocalRemoteState<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg> =
+    TransferOut<
+        SwapTask,
+        State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>,
+        TransportOutFactory,
+        SwapClient,
+    >;
 
-pub fn start<SwapTask, SwapClient, ForwardToInnerMsg>(
+pub fn start<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>(
     spec: SwapTask,
-) -> StartLocalRemoteState<SwapTask, SwapClient, ForwardToInnerMsg>
+    transport: TransportOutFactory,
+) -> StartLocalRemoteState<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
 where
     SwapTask: SwapTaskT,
+    TransportOutFactory: TransportOutFactoryT,
     ForwardToInnerMsg: ForwardToInner,
 {
-    StartLocalRemoteState::new(spec)
+    StartLocalRemoteState::new(spec, transport)
 }
 
 mod impl_into {
@@ -41,38 +52,52 @@ mod impl_into {
 
     use super::State;
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg>
-        From<TransferOut<SwapTask, State<SwapTask, SwapClient, ForwardToInnerMsg>, SwapClient>>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
+        From<
+            TransferOut<
+                SwapTask,
+                State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>,
+                TransportOutFactory,
+                SwapClient,
+            >,
+        > for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
     {
-        fn from(value: TransferOut<SwapTask, Self, SwapClient>) -> Self {
+        fn from(value: TransferOut<SwapTask, Self, TransportOutFactory, SwapClient>) -> Self {
             Self::TransferOut(value)
         }
     }
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
         From<
             TransferOutRespDelivery<
                 SwapTask,
-                State<SwapTask, SwapClient, ForwardToInnerMsg>,
+                State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>,
+                TransportOutFactory,
                 SwapClient,
                 ForwardToInnerMsg,
             >,
-        > for State<SwapTask, SwapClient, ForwardToInnerMsg>
+        > for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
     {
         fn from(
-            value: TransferOutRespDelivery<SwapTask, Self, SwapClient, ForwardToInnerMsg>,
+            value: TransferOutRespDelivery<
+                SwapTask,
+                Self,
+                TransportOutFactory,
+                SwapClient,
+                ForwardToInnerMsg,
+            >,
         ) -> Self {
             Self::TransferOutRespDelivery(value)
         }
     }
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg> From<SwapExactIn<SwapTask, Self, SwapClient>>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
+        From<SwapExactIn<SwapTask, Self, SwapClient>>
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
     {
@@ -81,9 +106,9 @@ mod impl_into {
         }
     }
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
         From<SwapExactInRespDelivery<SwapTask, Self, SwapClient, ForwardToInnerMsg>>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
     {
@@ -100,7 +125,7 @@ mod impl_handler {
     use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply};
 
     use crate::{
-        SwapTask as SwapTaskT,
+        SwapTask as SwapTaskT, TransportOutFactory as TransportOutFactoryT,
         impl_::{
             self, ForwardToInner, Handler,
             response::{ContinueResult, Result},
@@ -110,10 +135,11 @@ mod impl_handler {
 
     use super::State;
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg> Handler
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg> Handler
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
+        TransportOutFactory: TransportOutFactoryT,
         SwapClient: ExactAmountIn,
         ForwardToInnerMsg: ForwardToInner,
     {
@@ -290,8 +316,8 @@ mod impl_contract {
 
     use super::State;
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg> Contract
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg> Contract
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask:
             SwapTaskT + ContractInSwap<StateResponse = <SwapTask as SwapTaskT>::StateResponse>,
@@ -325,8 +351,8 @@ mod impl_display {
 
     use super::State;
 
-    impl<SwapTask, SwapClient, ForwardToInnerMsg> Display
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg> Display
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
     {
@@ -350,16 +376,16 @@ mod impl_migration {
         swap::ExactAmountIn,
     };
 
-    impl<SwapTask, SwapTaskNew, SEnumNew, SwapClient, ForwardToInnerMsg>
+    impl<SwapTask, SwapTaskNew, SEnumNew, TransportOutFactory, SwapClient, ForwardToInnerMsg>
         MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
-        for State<SwapTask, SwapClient, ForwardToInnerMsg>
+        for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,
         SwapClient: ExactAmountIn,
         ForwardToInnerMsg: ForwardToInner,
         SwapTaskNew: SwapTaskT<OutG = SwapTask::OutG>,
     {
-        type Out = State<SwapTaskNew, SwapClient, ForwardToInnerMsg>;
+        type Out = State<SwapTaskNew, TransportOutFactory, SwapClient, ForwardToInnerMsg>;
 
         fn migrate_spec<MigrateFn>(self, migrate_fn: MigrateFn) -> Self::Out
         where

--- a/protocol/packages/dex/src/impl_/out_remote.rs
+++ b/protocol/packages/dex/src/impl_/out_remote.rs
@@ -372,12 +372,12 @@ mod impl_migration {
     use super::State;
     use crate::{
         SwapTask as SwapTaskT, TransportOutFactory as TransportOutFactoryT,
-        impl_::{ForwardToInner, migration::MigrateSpec},
+        impl_::{ForwardToInner, migration::_MigrateSpec},
         swap::ExactAmountIn,
     };
 
     impl<SwapTask, SwapTaskNew, SEnumNew, TransportOutFactory, SwapClient, ForwardToInnerMsg>
-        MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
+        _MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
         for State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>
     where
         SwapTask: SwapTaskT,

--- a/protocol/packages/dex/src/impl_/resp_delivery/mod.rs
+++ b/protocol/packages/dex/src/impl_/resp_delivery/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 #[cfg(feature = "migration")]
-use super::migration::{InspectSpec, MigrateSpec};
+use super::migration::{_InspectSpec, _MigrateSpec};
 
 use self::adapter::{DeliveryAdapter, ResponseDeliveryAdapter};
 use cw_time::IntoInstant;
@@ -69,10 +69,10 @@ impl<H, ForwardToInnerMsg, R, Delivery> ResponseDeliveryImpl<H, ForwardToInnerMs
 
 #[cfg(feature = "migration")]
 impl<SwapTask, SwapTaskNew, SEnumNew, H, ForwardToInnerMsg, R, Delivery>
-    MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
+    _MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
     for ResponseDeliveryImpl<H, ForwardToInnerMsg, R, Delivery>
 where
-    H: MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>,
+    H: _MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>,
     H::Out: Into<SEnumNew>,
 {
     type Out = ResponseDeliveryImpl<H::Out, ForwardToInnerMsg, R, Delivery>;
@@ -86,10 +86,10 @@ where
 }
 
 #[cfg(feature = "migration")]
-impl<SwapTask, RInspect, H, ForwardToInnerMsg, R, Delivery> InspectSpec<SwapTask, RInspect>
+impl<SwapTask, RInspect, H, ForwardToInnerMsg, R, Delivery> _InspectSpec<SwapTask, RInspect>
     for ResponseDeliveryImpl<H, ForwardToInnerMsg, R, Delivery>
 where
-    H: InspectSpec<SwapTask, RInspect>,
+    H: _InspectSpec<SwapTask, RInspect>,
 {
     fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> RInspect
     where

--- a/protocol/packages/dex/src/impl_/swap_exact_in/mod.rs
+++ b/protocol/packages/dex/src/impl_/swap_exact_in/mod.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 
 #[cfg(feature = "migration")]
-use super::migration::{InspectSpec, MigrateSpec};
+use super::migration::{_InspectSpec, _MigrateSpec};
 use cw_time::IntoInstant;
 
 mod decode_resp;
@@ -260,7 +260,7 @@ where
 
 #[cfg(feature = "migration")]
 impl<SwapTask, SwapTaskNew, SEnum, SEnumNew, SwapClient>
-    MigrateSpec<SwapTask, SwapTaskNew, SEnumNew> for SwapExactIn<SwapTask, SEnum, SwapClient>
+    _MigrateSpec<SwapTask, SwapTaskNew, SEnumNew> for SwapExactIn<SwapTask, SEnum, SwapClient>
 where
     Self: Sized,
     SwapExactIn<SwapTaskNew, SEnumNew, SwapClient>: Into<SEnumNew>,
@@ -276,7 +276,7 @@ where
 }
 
 #[cfg(feature = "migration")]
-impl<SwapTask, R, SEnum, SwapClient> InspectSpec<SwapTask, R>
+impl<SwapTask, R, SEnum, SwapClient> _InspectSpec<SwapTask, R>
     for SwapExactIn<SwapTask, SEnum, SwapClient>
 {
     fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R

--- a/protocol/packages/dex/src/impl_/swap_exact_in/mod.rs
+++ b/protocol/packages/dex/src/impl_/swap_exact_in/mod.rs
@@ -19,16 +19,15 @@ use report_anomaly::ReportAnomalyCmd;
 use sdk::cosmwasm_std::{Binary, Env, QuerierWrapper};
 
 use crate::{
-    AnomalyTreatment, ConnectionParams, Contract, Stage, error::Result, swap::ExactAmountIn,
-};
-
-use crate::{
-    Connectable, ContractInSwap, Enterable, SwapTask as SwapTaskT, TimeAlarm,
+    AnomalyTreatment, Connectable, ConnectionParams, Contract, ContractInSwap, Enterable, Stage,
+    SwapTask as SwapTaskT, TimeAlarm, TransportOutFactory as TransportOutFactoryT,
+    error::Result,
     impl_::{
         ForwardToInner,
         response::{self, ContinueResult, Handler, Result as HandlerResult},
         timeout,
     },
+    swap::ExactAmountIn,
 };
 
 #[cfg(feature = "migration")]
@@ -117,18 +116,20 @@ where
     }
 }
 
-impl<SwapTask, SwapClient, ForwardToInnerMsg> Handler
+impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg> Handler
     for SwapExactIn<
         SwapTask,
-        super::out_local::State<SwapTask, SwapClient, ForwardToInnerMsg>,
+        super::out_local::State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>,
         SwapClient,
     >
 where
     SwapTask: SwapTaskT,
+    TransportOutFactory: TransportOutFactoryT,
     SwapClient: ExactAmountIn,
     ForwardToInnerMsg: ForwardToInner,
 {
-    type Response = super::out_local::State<SwapTask, SwapClient, ForwardToInnerMsg>;
+    type Response =
+        super::out_local::State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>;
     type SwapResult = SwapTask::Result;
 
     fn authz_remote_callback(
@@ -172,17 +173,18 @@ where
     }
 }
 
-impl<SwapTask, SwapClient, ForwardToInnerMsg> Handler
+impl<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg> Handler
     for SwapExactIn<
         SwapTask,
-        super::out_remote::State<SwapTask, SwapClient, ForwardToInnerMsg>,
+        super::out_remote::State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>,
         SwapClient,
     >
 where
     SwapTask: SwapTaskT,
     SwapClient: ExactAmountIn,
 {
-    type Response = super::out_remote::State<SwapTask, SwapClient, ForwardToInnerMsg>;
+    type Response =
+        super::out_remote::State<SwapTask, TransportOutFactory, SwapClient, ForwardToInnerMsg>;
     type SwapResult = SwapTask::Result;
 
     fn authz_remote_callback(

--- a/protocol/packages/dex/src/impl_/transfer_in_finish.rs
+++ b/protocol/packages/dex/src/impl_/transfer_in_finish.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 #[cfg(feature = "migration")]
-use super::migration::{InspectSpec, MigrateSpec};
+use super::migration::{_InspectSpec, _MigrateSpec};
 use super::{
     response::{self, Handler as HandlerT, Result as HandlerResult},
     transfer_in,
@@ -70,7 +70,7 @@ where
 }
 
 #[cfg(feature = "migration")]
-impl<SwapTask, SwapTaskNew, SEnum, SEnumNew> MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
+impl<SwapTask, SwapTaskNew, SEnum, SEnumNew> _MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
     for TransferInFinish<SwapTask, SEnum>
 where
     SwapTask: SwapTaskT,
@@ -87,7 +87,7 @@ where
 }
 
 #[cfg(feature = "migration")]
-impl<SwapTask, R, SEnum> InspectSpec<SwapTask, R> for TransferInFinish<SwapTask, SEnum>
+impl<SwapTask, R, SEnum> _InspectSpec<SwapTask, R> for TransferInFinish<SwapTask, SEnum>
 where
     SwapTask: SwapTaskT,
 {

--- a/protocol/packages/dex/src/impl_/transfer_in_init.rs
+++ b/protocol/packages/dex/src/impl_/transfer_in_init.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 #[cfg(feature = "migration")]
-use super::migration::{InspectSpec, MigrateSpec};
+use super::migration::{_InspectSpec, _MigrateSpec};
 use super::{
     SwapTask as SwapTaskT,
     response::{ContinueResult, Handler, Result as HandlerResult},
@@ -50,7 +50,7 @@ where
 }
 
 #[cfg(feature = "migration")]
-impl<SwapTask, SwapTaskNew, SEnum, SEnumNew> MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
+impl<SwapTask, SwapTaskNew, SEnum, SEnumNew> _MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
     for TransferInInit<SwapTask, SEnum>
 where
     SwapTask: SwapTaskT,
@@ -67,7 +67,7 @@ where
 }
 
 #[cfg(feature = "migration")]
-impl<SwapTask, R, SEnum> InspectSpec<SwapTask, R> for TransferInInit<SwapTask, SEnum>
+impl<SwapTask, R, SEnum> _InspectSpec<SwapTask, R> for TransferInInit<SwapTask, SEnum>
 where
     SwapTask: SwapTaskT,
 {

--- a/protocol/packages/dex/src/impl_/transfer_in_init.rs
+++ b/protocol/packages/dex/src/impl_/transfer_in_init.rs
@@ -1,17 +1,15 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::marker::PhantomData;
 
-use finance::duration::Duration;
 use serde::{Deserialize, Serialize};
 
-use finance::coin::CoinDTO;
-use finance::instant::Instant;
+use finance::{coin::CoinDTO, duration::Duration, instant::Instant};
 use platform::batch::Batch;
 use sdk::cosmwasm_std::{Binary, Env, QuerierWrapper};
 
 use crate::{
-    Connectable, ConnectionParams, Contract, ContractInSwap, Enterable, Stage, TimeAlarm,
-    error::Result,
+    Connectable, ConnectionParams, Contract, ContractInSwap, Enterable, IBC_TIMEOUT, Stage,
+    TimeAlarm, error::Result,
 };
 
 #[cfg(feature = "migration")]
@@ -21,7 +19,7 @@ use super::{
     response::{ContinueResult, Handler, Result as HandlerResult},
     timeout,
     transfer_in_finish::TransferInFinish,
-    trx::{IBC_TIMEOUT, TransferInTrx},
+    trx::TransferInTrx,
 };
 use cw_time::IntoInstant;
 

--- a/protocol/packages/dex/src/impl_/transfer_out/mod.rs
+++ b/protocol/packages/dex/src/impl_/transfer_out/mod.rs
@@ -269,6 +269,7 @@ impl<SwapTask, SwapTaskNew, SEnum, SEnumNew, TransportOutFactory, SwapClient>
 where
     Self: Sized,
     SwapTaskNew: SwapTaskT,
+    TransportOutFactory: TransportOutFactoryT,
     TransferOut<SwapTaskNew, SEnumNew, TransportOutFactory, SwapClient>: Into<SEnumNew>,
 {
     type Out = TransferOut<SwapTaskNew, SEnumNew, TransportOutFactory, SwapClient>;
@@ -277,7 +278,7 @@ where
     where
         MigrateFn: FnOnce(SwapTask) -> SwapTaskNew,
     {
-        Self::Out::new(migrate_fn(self.spec))
+        Self::Out::new(migrate_fn(self.spec), self.transport_out_fry)
     }
 }
 

--- a/protocol/packages/dex/src/impl_/transfer_out/mod.rs
+++ b/protocol/packages/dex/src/impl_/transfer_out/mod.rs
@@ -16,7 +16,8 @@ use sdk::cosmwasm_std::{Binary, Env, QuerierWrapper};
 
 use crate::{
     CoinsNb, Contract, ContractInSwap, Enterable, Stage, SwapTask as SwapTaskT, TimeAlarm,
-    error::Result, swap::ExactAmountIn,
+    TransportOut as TransportOutT, TransportOutFactory as TransportOutFactoryT, error::Result,
+    swap::ExactAmountIn,
 };
 
 #[cfg(feature = "migration")]
@@ -25,7 +26,6 @@ use super::{
     response::{self, ContinueResult, Handler, Result as HandlerResult},
     swap_exact_in::SwapExactIn,
     timeout,
-    trx::TransferOutTrx,
 };
 use cw_time::IntoInstant;
 
@@ -38,14 +38,17 @@ use cw_time::IntoInstant;
 #[cfg_attr(test, derive(Clone, Debug, PartialEq, Eq))]
 #[serde(
     bound(
-        serialize = "SwapTask: Serialize",
-        deserialize = "SwapTask: Deserialize<'de> + SwapTaskT"
+        serialize = "SwapTask: Serialize,
+                        TransportOutFactory: Serialize",
+        deserialize = "SwapTask: Deserialize<'de> + SwapTaskT,
+                        TransportOutFactory: Deserialize<'de>"
     ),
     deny_unknown_fields,
     rename_all = "snake_case"
 )]
-pub struct TransferOut<SwapTask, SEnum, SwapClient> {
+pub struct TransferOut<SwapTask, SEnum, TransportOutFactory, SwapClient> {
     spec: SwapTask,
+    transport_out_fry: TransportOutFactory,
     acks_left: CoinsNb,
     #[serde(skip)]
     _state_enum: PhantomData<SEnum>,
@@ -53,18 +56,25 @@ pub struct TransferOut<SwapTask, SEnum, SwapClient> {
     _swap_client: PhantomData<SwapClient>,
 }
 
-impl<SwapTask, SEnum, SwapClient> TransferOut<SwapTask, SEnum, SwapClient>
+impl<SwapTask, SEnum, TransportOutFactory, SwapClient>
+    TransferOut<SwapTask, SEnum, TransportOutFactory, SwapClient>
 where
     SwapTask: SwapTaskT,
+    TransportOutFactory: TransportOutFactoryT,
 {
-    pub fn new(spec: SwapTask) -> Self {
+    pub fn new(spec: SwapTask, transport: TransportOutFactory) -> Self {
         let acks_left = Self::coins_len(&spec);
-        Self::internal_new(spec, acks_left)
+        Self::internal_new(spec, transport, acks_left)
     }
 
-    fn internal_new(spec: SwapTask, acks_left: CoinsNb) -> Self {
+    fn internal_new(
+        spec: SwapTask,
+        transport_out_fry: TransportOutFactory,
+        acks_left: CoinsNb,
+    ) -> Self {
         let ret = Self {
             spec,
+            transport_out_fry,
             acks_left,
             _state_enum: PhantomData,
             _swap_client: PhantomData,
@@ -91,13 +101,14 @@ where
             self.acks_left,
             "calling 'enter_state' past initialization"
         );
-        let mut trx = TransferOutTrx::new(self.spec.dex_account(), now);
+
+        let mut transport = self.transport_out_fry.transport(&self.spec, now);
 
         self.spec
             .coins()
             .into_iter()
-            .for_each(|coin| trx.send(&coin));
-        trx.into()
+            .for_each(|coin| transport.send(&coin));
+        transport.into()
     }
 
     fn next(self) -> Self {
@@ -107,7 +118,7 @@ where
             "the method contract precondition `!self.last_ack()` should have been respected",
         );
 
-        Self::internal_new(self.spec, acks_left)
+        Self::internal_new(self.spec, self.transport_out_fry, acks_left)
     }
 
     fn last_ack(&self) -> bool {
@@ -116,9 +127,11 @@ where
     }
 }
 
-impl<SwapTask, SEnum, SwapClient> TransferOut<SwapTask, SEnum, SwapClient>
+impl<SwapTask, SEnum, TransportOutFactory, SwapClient>
+    TransferOut<SwapTask, SEnum, TransportOutFactory, SwapClient>
 where
     SwapTask: SwapTaskT,
+    TransportOutFactory: TransportOutFactoryT,
     SwapClient: ExactAmountIn,
     Self: Into<SEnum>,
     SwapExactIn<SwapTask, SEnum, SwapClient>: Into<SEnum>,
@@ -140,9 +153,11 @@ where
     }
 }
 
-impl<SwapTask, SEnum, SwapClient> Enterable for TransferOut<SwapTask, SEnum, SwapClient>
+impl<SwapTask, SEnum, TransportOutFactory, SwapClient> Enterable
+    for TransferOut<SwapTask, SEnum, TransportOutFactory, SwapClient>
 where
     SwapTask: SwapTaskT,
+    TransportOutFactory: TransportOutFactoryT,
     SwapClient: ExactAmountIn,
     Self: Into<SEnum>,
     SwapExactIn<SwapTask, SEnum, SwapClient>: Into<SEnum>,
@@ -152,9 +167,11 @@ where
     }
 }
 
-impl<SwapTask, SEnum, SwapClient> Handler for TransferOut<SwapTask, SEnum, SwapClient>
+impl<SwapTask, SEnum, TransportOutFactory, SwapClient> Handler
+    for TransferOut<SwapTask, SEnum, TransportOutFactory, SwapClient>
 where
     SwapTask: SwapTaskT,
+    TransportOutFactory: TransportOutFactoryT,
     SwapClient: ExactAmountIn,
     Self: Into<SEnum>,
     SwapExactIn<SwapTask, SEnum, SwapClient>: Into<SEnum>,
@@ -204,7 +221,8 @@ where
     }
 }
 
-impl<SwapTask, SEnum, SwapClient> Contract for TransferOut<SwapTask, SEnum, SwapClient>
+impl<SwapTask, SEnum, TransportOutFactory, SwapClient> Contract
+    for TransferOut<SwapTask, SEnum, TransportOutFactory, SwapClient>
 where
     SwapTask: SwapTaskT + ContractInSwap<StateResponse = <SwapTask as SwapTaskT>::StateResponse>,
 {
@@ -221,7 +239,8 @@ where
     }
 }
 
-impl<SwapTask, SEnum, SwapClient> Display for TransferOut<SwapTask, SEnum, SwapClient>
+impl<SwapTask, SEnum, TransportOutFactory, SwapClient> Display
+    for TransferOut<SwapTask, SEnum, TransportOutFactory, SwapClient>
 where
     SwapTask: SwapTaskT,
 {
@@ -230,7 +249,8 @@ where
     }
 }
 
-impl<SwapTask, SEnum, SwapClient> TimeAlarm for TransferOut<SwapTask, SEnum, SwapClient>
+impl<SwapTask, SEnum, TransportOutFactory, SwapClient> TimeAlarm
+    for TransferOut<SwapTask, SEnum, TransportOutFactory, SwapClient>
 where
     SwapTask: SwapTaskT,
 {
@@ -243,14 +263,15 @@ where
 }
 
 #[cfg(feature = "migration")]
-impl<SwapTask, SwapTaskNew, SEnum, SEnumNew, SwapClient>
-    MigrateSpec<SwapTask, SwapTaskNew, SEnumNew> for TransferOut<SwapTask, SEnum, SwapClient>
+impl<SwapTask, SwapTaskNew, SEnum, SEnumNew, TransportOutFactory, SwapClient>
+    MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
+    for TransferOut<SwapTask, SEnum, TransportOutFactory, SwapClient>
 where
     Self: Sized,
     SwapTaskNew: SwapTaskT,
-    TransferOut<SwapTaskNew, SEnumNew, SwapClient>: Into<SEnumNew>,
+    TransferOut<SwapTaskNew, SEnumNew, TransportOutFactory, SwapClient>: Into<SEnumNew>,
 {
-    type Out = TransferOut<SwapTaskNew, SEnumNew, SwapClient>;
+    type Out = TransferOut<SwapTaskNew, SEnumNew, TransportOutFactory, SwapClient>;
 
     fn migrate_spec<MigrateFn>(self, migrate_fn: MigrateFn) -> Self::Out
     where
@@ -261,8 +282,8 @@ where
 }
 
 #[cfg(feature = "migration")]
-impl<SwapTask, R, SEnum, SwapClient> InspectSpec<SwapTask, R>
-    for TransferOut<SwapTask, SEnum, SwapClient>
+impl<SwapTask, R, SEnum, TransportOutFactory, SwapClient> InspectSpec<SwapTask, R>
+    for TransferOut<SwapTask, SEnum, TransportOutFactory, SwapClient>
 {
     fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R
     where

--- a/protocol/packages/dex/src/impl_/transfer_out/mod.rs
+++ b/protocol/packages/dex/src/impl_/transfer_out/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 #[cfg(feature = "migration")]
-use super::migration::{InspectSpec, MigrateSpec};
+use super::migration::{_InspectSpec, _MigrateSpec};
 use super::{
     response::{self, ContinueResult, Handler, Result as HandlerResult},
     swap_exact_in::SwapExactIn,
@@ -264,7 +264,7 @@ where
 
 #[cfg(feature = "migration")]
 impl<SwapTask, SwapTaskNew, SEnum, SEnumNew, TransportOutFactory, SwapClient>
-    MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
+    _MigrateSpec<SwapTask, SwapTaskNew, SEnumNew>
     for TransferOut<SwapTask, SEnum, TransportOutFactory, SwapClient>
 where
     Self: Sized,
@@ -283,7 +283,7 @@ where
 }
 
 #[cfg(feature = "migration")]
-impl<SwapTask, R, SEnum, TransportOutFactory, SwapClient> InspectSpec<SwapTask, R>
+impl<SwapTask, R, SEnum, TransportOutFactory, SwapClient> _InspectSpec<SwapTask, R>
     for TransferOut<SwapTask, SEnum, TransportOutFactory, SwapClient>
 {
     fn inspect_spec<InspectFn>(&self, inspect_fn: InspectFn) -> R

--- a/protocol/packages/dex/src/impl_/trx.rs
+++ b/protocol/packages/dex/src/impl_/trx.rs
@@ -2,8 +2,7 @@ use std::marker::PhantomData;
 
 use currency::{Group, MemberOf};
 use cw_time::IntoTimestamp;
-use finance::instant::Instant;
-use finance::{coin::CoinDTO, duration::Duration};
+use finance::{coin::CoinDTO, instant::Instant};
 use oracle::stub::SwapPath;
 use platform::{
     bank_ibc::remote::Sender as RemoteSender,
@@ -13,9 +12,7 @@ use platform::{
 };
 use sdk::cosmwasm_std::QuerierWrapper;
 
-use crate::{Account, Connectable, error::Result, swap::ExactAmountIn};
-
-pub(super) const IBC_TIMEOUT: Duration = Duration::from_days(1); //enough for the relayers to process
+use crate::{Account, Connectable, IBC_TIMEOUT, error::Result, swap::ExactAmountIn};
 
 pub(super) struct SwapTrx<'ica, 'swap_path, 'querier, SwapGroup, SwapPathImpl> {
     conn: &'ica str,

--- a/protocol/packages/dex/src/impl_/trx.rs
+++ b/protocol/packages/dex/src/impl_/trx.rs
@@ -6,7 +6,7 @@ use finance::instant::Instant;
 use finance::{coin::CoinDTO, duration::Duration};
 use oracle::stub::SwapPath;
 use platform::{
-    bank_ibc::{local::Sender as LocalSender, remote::Sender as RemoteSender},
+    bank_ibc::remote::Sender as RemoteSender,
     batch::Batch as LocalBatch,
     ica::{self, HostAccount},
     trx::Transaction,
@@ -16,41 +16,6 @@ use sdk::cosmwasm_std::QuerierWrapper;
 use crate::{Account, Connectable, error::Result, swap::ExactAmountIn};
 
 pub(super) const IBC_TIMEOUT: Duration = Duration::from_days(1); //enough for the relayers to process
-
-pub(super) struct TransferOutTrx<'ica> {
-    sender: LocalSender<'ica>,
-}
-
-impl<'ica> TransferOutTrx<'ica> {
-    pub(super) fn new(ica: &'ica Account, now: Instant) -> Self {
-        Self {
-            sender: LocalSender::new(
-                &ica.dex().transfer_channel.local_endpoint,
-                ica.owner(),
-                ica.remote(),
-                (now + IBC_TIMEOUT).into_timestamp(),
-                format!(
-                    "Transfer out: {sender} -> {receiver}",
-                    sender = ica.owner(),
-                    receiver = ica.remote()
-                ),
-            ),
-        }
-    }
-
-    pub fn send<G>(&mut self, amount: &CoinDTO<G>)
-    where
-        G: Group,
-    {
-        self.sender.send(amount)
-    }
-}
-
-impl<'ica> From<TransferOutTrx<'ica>> for LocalBatch {
-    fn from(value: TransferOutTrx<'ica>) -> Self {
-        value.sender.into()
-    }
-}
 
 pub(super) struct SwapTrx<'ica, 'swap_path, 'querier, SwapGroup, SwapPathImpl> {
     conn: &'ica str,

--- a/protocol/packages/dex/src/lib.rs
+++ b/protocol/packages/dex/src/lib.rs
@@ -18,6 +18,7 @@ pub use self::{
     state::{Contract, ContractInSwap, Stage},
     swap_task::{CoinsNb, SwapOutputTask, SwapTask, WithOutputTask},
     time_alarm::TimeAlarm,
+    transport::{TransferOut as TransportOut, TransferOutFactory as TransportOutFactory},
 };
 
 #[cfg(feature = "impl")]
@@ -45,3 +46,5 @@ pub mod swap;
 mod swap_task;
 #[cfg(feature = "impl")]
 mod time_alarm;
+#[cfg(feature = "impl")]
+mod transport;

--- a/protocol/packages/dex/src/lib.rs
+++ b/protocol/packages/dex/src/lib.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "impl")]
 pub use self::error::Error;
-#[cfg(all(feature = "impl", feature = "migration"))]
-pub use self::impl_::migration::{InspectSpec, MigrateSpec};
 #[cfg(feature = "impl")]
 pub use self::{
     account::Account,

--- a/protocol/packages/dex/src/lib.rs
+++ b/protocol/packages/dex/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "impl")]
 pub use self::error::Error;
+#[cfg(all(feature = "impl", feature = "migration"))]
+pub use self::impl_::migration::{InspectSpec, MigrateSpec};
 #[cfg(feature = "impl")]
 pub use self::{
     account::Account,

--- a/protocol/packages/dex/src/lib.rs
+++ b/protocol/packages/dex/src/lib.rs
@@ -18,7 +18,9 @@ pub use self::{
     state::{Contract, ContractInSwap, Stage},
     swap_task::{CoinsNb, SwapOutputTask, SwapTask, WithOutputTask},
     time_alarm::TimeAlarm,
-    transport::{TransferOut as TransportOut, TransferOutFactory as TransportOutFactory},
+    transport::{
+        IBC_TIMEOUT, TransferOut as TransportOut, TransferOutFactory as TransportOutFactory,
+    },
 };
 
 #[cfg(feature = "impl")]

--- a/protocol/packages/dex/src/transport.rs
+++ b/protocol/packages/dex/src/transport.rs
@@ -4,7 +4,8 @@ use platform::batch::Batch;
 
 use crate::SwapTask;
 
-pub const IBC_TIMEOUT: Duration = Duration::from_days(1); //enough for the relayers to process
+/// IBC transfer timeout — long enough for relayers to process.
+pub const IBC_TIMEOUT: Duration = Duration::from_days(1);
 
 pub trait TransferOut
 where

--- a/protocol/packages/dex/src/transport.rs
+++ b/protocol/packages/dex/src/transport.rs
@@ -1,8 +1,10 @@
 use currency::Group;
-use finance::{coin::CoinDTO, instant::Instant};
+use finance::{coin::CoinDTO, duration::Duration, instant::Instant};
 use platform::batch::Batch;
 
 use crate::SwapTask;
+
+pub const IBC_TIMEOUT: Duration = Duration::from_days(1); //enough for the relayers to process
 
 pub trait TransferOut
 where

--- a/protocol/packages/dex/src/transport.rs
+++ b/protocol/packages/dex/src/transport.rs
@@ -1,0 +1,24 @@
+use currency::Group;
+use finance::{coin::CoinDTO, instant::Instant};
+use platform::batch::Batch;
+
+use crate::SwapTask;
+
+pub trait TransferOut
+where
+    Self: Into<Batch>,
+{
+    fn send<G>(&mut self, amount: &CoinDTO<G>)
+    where
+        G: Group;
+}
+
+pub trait TransferOutFactory {
+    type Transport<'this>: TransferOut
+    where
+        Self: 'this;
+
+    fn transport<'task, Task>(&self, task: &'task Task, now: Instant) -> Self::Transport<'task>
+    where
+        Task: SwapTask;
+}


### PR DESCRIPTION
dex held the remote counterparty as a concrete HostAccount destination on Account and owned the TransferOut trx builder, coupling the protocol-agnostic crate to the lease's transport concern.

Introduce TransportOut/TransportOutFactory so the caller supplies the transfer-out transport per operation. dex threads the factory through the out-local and out-remote state machines (and their migration paths) without naming a protocol-specific type; the lease provides the concrete factory over its dex::Account.

Refs #733.