### PR TITLE
feat(remote_lease): make SwapParams an enum with One and Two variants

### DIFF
--- a/docs/remote-lease-wire-contract.md
+++ b/docs/remote-lease-wire-contract.md
@@ -17,10 +17,14 @@ The `remote_lease` crate defines the IBC packet types exchanged between the Nolu
 
 - `OpenLease { expected_instance_ordinal: u16, downpayment_currency, lpn_currency, asset_currency }` — the only enforced inequality is `lpn_currency != asset_currency`. `downpayment_currency == lpn_currency` and `downpayment_currency == asset_currency` are both permitted; the Solana side does not constrain those pairs. The wire-level invariant is intentionally permissive — any tighter constraint belongs in the Nolus-side caller, not the wire.
 - `CloseLease {}`
-- `Swap { coin_in, min_out }` — both amounts non-zero, currencies distinct.
+- `Swap` — externally-tagged enum, one variant per input arity:
+  - `One { coin_in, min_out }` — single input coin; wire shape `{"swap":{"one":{"coin_in":…,"min_out":…}}}`.
+  - `Two { coin_in_1, coin_in_2, min_out }` — two input coins; wire shape `{"swap":{"two":{"coin_in_1":…,"coin_in_2":…,"min_out":…}}}`.
+
+  All coins non-zero; each input currency distinct from `min_out`; for `Two`, the two inputs are also distinct from each other (else `DuplicateSwapInputCurrency`).
 - `TransferOut { amount }` — amount non-zero.
 
-Invariants are enforced both in constructors (`new`) and on the deserialiser path via `try_from` raw shadows.
+Invariants are enforced both in constructors (`new`, or `one` / `two` for `Swap`) and on the deserialiser path via `try_from` raw shadows.
 
 ## Callback
 

--- a/protocol/contracts/remote_lease/src/contract/tests/execute_outbound.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/execute_outbound.rs
@@ -170,7 +170,7 @@ fn open_lease_execute() -> ExecuteMsg {
 }
 
 fn sample_swap_params() -> SwapParams {
-    SwapParams::new(
+    SwapParams::one(
         Coin::<PaymentC1>::new(1_000).into(),
         Coin::<PaymentC2>::new(42).into(),
     )

--- a/protocol/packages/remote_lease/src/msg.rs
+++ b/protocol/packages/remote_lease/src/msg.rs
@@ -143,56 +143,113 @@ impl CloseLeaseParams {
     rename_all = "snake_case",
     try_from = "SwapParamsRaw"
 )]
-pub struct SwapParams {
-    coin_in: CoinDTO<PaymentGroup>,
-    min_out: CoinDTO<PaymentGroup>,
+pub enum SwapParams {
+    One {
+        coin_in: CoinDTO<PaymentGroup>,
+        min_out: CoinDTO<PaymentGroup>,
+    },
+    Two {
+        coin_in_1: CoinDTO<PaymentGroup>,
+        coin_in_2: CoinDTO<PaymentGroup>,
+        min_out: CoinDTO<PaymentGroup>,
+    },
 }
 
 impl SwapParams {
     pub const TIMEOUT: Duration = Duration::from_secs(300);
 
-    pub fn new(
+    pub fn one(
         coin_in: CoinDTO<PaymentGroup>,
         min_out: CoinDTO<PaymentGroup>,
     ) -> Result<Self, Error> {
         if coin_in.is_zero() || min_out.is_zero() {
             return Err(Error::ZeroSwapAmount);
         }
-        let params = Self { coin_in, min_out };
-        params
-            .invariant_held()
-            .then_some(params)
-            .ok_or(Error::SameSwapCurrency)
-            .inspect(|p| debug_assert!(p.invariant_held()))
+        if coin_in.currency() == min_out.currency() {
+            return Err(Error::SameSwapCurrency);
+        }
+        let params = Self::One { coin_in, min_out };
+        debug_assert!(params.invariant_held());
+        Ok(params)
     }
 
-    pub const fn coin_in(&self) -> &CoinDTO<PaymentGroup> {
-        &self.coin_in
+    pub fn two(
+        coin_in_1: CoinDTO<PaymentGroup>,
+        coin_in_2: CoinDTO<PaymentGroup>,
+        min_out: CoinDTO<PaymentGroup>,
+    ) -> Result<Self, Error> {
+        if coin_in_1.is_zero() || coin_in_2.is_zero() || min_out.is_zero() {
+            return Err(Error::ZeroSwapAmount);
+        }
+        if coin_in_1.currency() == min_out.currency() || coin_in_2.currency() == min_out.currency()
+        {
+            return Err(Error::SameSwapCurrency);
+        }
+        if coin_in_1.currency() == coin_in_2.currency() {
+            return Err(Error::DuplicateSwapInputCurrency);
+        }
+        let params = Self::Two {
+            coin_in_1,
+            coin_in_2,
+            min_out,
+        };
+        debug_assert!(params.invariant_held());
+        Ok(params)
     }
 
-    pub const fn min_out(&self) -> &CoinDTO<PaymentGroup> {
-        &self.min_out
+    pub fn min_out(&self) -> &CoinDTO<PaymentGroup> {
+        match self {
+            Self::One { min_out, .. } | Self::Two { min_out, .. } => min_out,
+        }
     }
 
     pub fn invariant_held(&self) -> bool {
-        !self.coin_in.is_zero()
-            && !self.min_out.is_zero()
-            && self.coin_in.currency() != self.min_out.currency()
+        match self {
+            Self::One { coin_in, min_out } => {
+                !coin_in.is_zero() && !min_out.is_zero() && coin_in.currency() != min_out.currency()
+            }
+            Self::Two {
+                coin_in_1,
+                coin_in_2,
+                min_out,
+            } => {
+                !coin_in_1.is_zero()
+                    && !coin_in_2.is_zero()
+                    && !min_out.is_zero()
+                    && coin_in_1.currency() != min_out.currency()
+                    && coin_in_2.currency() != min_out.currency()
+                    && coin_in_1.currency() != coin_in_2.currency()
+            }
+        }
     }
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-struct SwapParamsRaw {
-    coin_in: CoinDTO<PaymentGroup>,
-    min_out: CoinDTO<PaymentGroup>,
+enum SwapParamsRaw {
+    One {
+        coin_in: CoinDTO<PaymentGroup>,
+        min_out: CoinDTO<PaymentGroup>,
+    },
+    Two {
+        coin_in_1: CoinDTO<PaymentGroup>,
+        coin_in_2: CoinDTO<PaymentGroup>,
+        min_out: CoinDTO<PaymentGroup>,
+    },
 }
 
 impl TryFrom<SwapParamsRaw> for SwapParams {
     type Error = Error;
 
     fn try_from(raw: SwapParamsRaw) -> Result<Self, Self::Error> {
-        SwapParams::new(raw.coin_in, raw.min_out)
+        match raw {
+            SwapParamsRaw::One { coin_in, min_out } => SwapParams::one(coin_in, min_out),
+            SwapParamsRaw::Two {
+                coin_in_1,
+                coin_in_2,
+                min_out,
+            } => SwapParams::two(coin_in_1, coin_in_2, min_out),
+        }
     }
 }
 
@@ -273,8 +330,21 @@ impl From<&OpenLeaseParams> for remote_lease_wire::msg::OpenLeaseParams {
 
 impl From<&SwapParams> for remote_lease_wire::msg::SwapParams {
     fn from(typed: &SwapParams) -> Self {
-        Self::new(wire_coin(typed.coin_in()), wire_coin(typed.min_out()))
-            .expect("typed SwapParams already upholds the non-zero distinct-currency invariant")
+        match typed {
+            SwapParams::One { coin_in, min_out } => {
+                Self::one(wire_coin(coin_in), wire_coin(min_out))
+            }
+            SwapParams::Two {
+                coin_in_1,
+                coin_in_2,
+                min_out,
+            } => Self::two(
+                wire_coin(coin_in_1),
+                wire_coin(coin_in_2),
+                wire_coin(min_out),
+            ),
+        }
+        .expect("typed SwapParams already upholds the non-zero distinct-currency invariant")
     }
 }
 
@@ -360,7 +430,7 @@ mod tests {
     #[test]
     fn swap_wire_shape() {
         let msg = ExecuteMsg::Swap {
-            params: SwapParams::new(
+            params: SwapParams::one(
                 Coin::<PaymentC1>::new(1000).into(),
                 Coin::<PaymentC2>::new(42).into(),
             )

--- a/protocol/packages/remote_lease/src/msg.rs
+++ b/protocol/packages/remote_lease/src/msg.rs
@@ -143,6 +143,10 @@ impl CloseLeaseParams {
     rename_all = "snake_case",
     try_from = "SwapParamsRaw"
 )]
+/// Swap parameters for the remote lease protocol.
+///
+/// `One` carries a single input coin; `Two` carries two input coins.
+/// All coins must be non-zero and all currencies pairwise distinct.
 pub enum SwapParams {
     One {
         coin_in: CoinDTO<PaymentGroup>,
@@ -158,6 +162,8 @@ pub enum SwapParams {
 impl SwapParams {
     pub const TIMEOUT: Duration = Duration::from_secs(300);
 
+    /// Single-input swap. Returns `Err(ZeroSwapAmount)` if either coin is
+    /// zero, or `Err(SameSwapCurrency)` if the currencies match.
     pub fn one(
         coin_in: CoinDTO<PaymentGroup>,
         min_out: CoinDTO<PaymentGroup>,
@@ -173,6 +179,9 @@ impl SwapParams {
         Ok(params)
     }
 
+    /// Two-input swap. Returns `Err(ZeroSwapAmount)` if any coin is zero,
+    /// `Err(SameSwapCurrency)` if an input currency equals the output currency,
+    /// or `Err(DuplicateSwapInputCurrency)` if the two input currencies match.
     pub fn two(
         coin_in_1: CoinDTO<PaymentGroup>,
         coin_in_2: CoinDTO<PaymentGroup>,
@@ -197,7 +206,8 @@ impl SwapParams {
         Ok(params)
     }
 
-    pub fn min_out(&self) -> &CoinDTO<PaymentGroup> {
+    /// Returns the minimum output coin, common to both variants.
+    pub const fn min_out(&self) -> &CoinDTO<PaymentGroup> {
         match self {
             Self::One { min_out, .. } | Self::Two { min_out, .. } => min_out,
         }

--- a/protocol/packages/remote_lease/src/stub.rs
+++ b/protocol/packages/remote_lease/src/stub.rs
@@ -123,7 +123,7 @@ mod tests {
     }
 
     fn sample_swap_params() -> SwapParams {
-        SwapParams::new(
+        SwapParams::one(
             Coin::<PaymentC1>::new(1000).into(),
             Coin::<PaymentC2>::new(42).into(),
         )

--- a/protocol/packages/remote_lease/src/tests.rs
+++ b/protocol/packages/remote_lease/src/tests.rs
@@ -54,7 +54,23 @@ fn close_lease_msg_serde() {
 fn swap_msg_serde() {
     let value = Operation::Swap(sample_swap_params());
     assert_round_trip_eq(
-        r#"{"swap":{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}"#,
+        r#"{"swap":{"one":{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}}"#,
+        &value,
+    );
+}
+
+#[test]
+fn swap_msg_two_serde() {
+    let value = Operation::Swap(
+        SwapParams::two(
+            Coin::<PaymentC1>::new(1000).into(),
+            Coin::<PaymentC3>::new(500).into(),
+            Coin::<PaymentC2>::new(42).into(),
+        )
+        .expect("sample uses three distinct non-zero amounts"),
+    );
+    assert_round_trip_eq(
+        r#"{"swap":{"two":{"coin_in_1":{"amount":"1000","ticker":"NLS"},"coin_in_2":{"amount":"500","ticker":"LC1"},"min_out":{"amount":"42","ticker":"LPN"}}}}"#,
         &value,
     );
 }
@@ -274,8 +290,8 @@ fn open_lease_params_deserialize_above_u16_rejected() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn swap_params_distinct_currencies_ok() {
-    let params = SwapParams::new(
+fn swap_params_one_distinct_currencies_ok() {
+    let params = SwapParams::one(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC2>::new(42).into(),
     )
@@ -284,8 +300,8 @@ fn swap_params_distinct_currencies_ok() {
 }
 
 #[test]
-fn swap_params_same_currency_rejected() {
-    let res = SwapParams::new(
+fn swap_params_one_same_currency_rejected() {
+    let res = SwapParams::one(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC1>::new(42).into(),
     );
@@ -293,8 +309,8 @@ fn swap_params_same_currency_rejected() {
 }
 
 #[test]
-fn swap_params_zero_coin_in_rejected() {
-    let res = SwapParams::new(
+fn swap_params_one_zero_coin_in_rejected() {
+    let res = SwapParams::one(
         Coin::<PaymentC1>::new(0).into(),
         Coin::<PaymentC2>::new(42).into(),
     );
@@ -302,8 +318,8 @@ fn swap_params_zero_coin_in_rejected() {
 }
 
 #[test]
-fn swap_params_zero_min_out_rejected() {
-    let res = SwapParams::new(
+fn swap_params_one_zero_min_out_rejected() {
+    let res = SwapParams::one(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC2>::new(0).into(),
     );
@@ -311,19 +327,85 @@ fn swap_params_zero_min_out_rejected() {
 }
 
 #[test]
-fn swap_params_deserialize_invariant_violation_rejected() {
-    let bad_wire =
-        r#"{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"NLS"}}"#;
+fn swap_params_one_deserialize_invariant_violation_rejected() {
+    let bad_wire = r#"{"one":{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"NLS"}}}"#;
     serde_json::from_str::<SwapParams>(bad_wire)
         .expect_err("invariant violation must fail deserialization");
 }
 
 #[test]
-fn swap_params_deserialize_zero_amount_rejected() {
-    let bad_wire =
-        r#"{"coin_in":{"amount":"0","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}"#;
+fn swap_params_one_deserialize_zero_amount_rejected() {
+    let bad_wire = r#"{"one":{"coin_in":{"amount":"0","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}"#;
     serde_json::from_str::<SwapParams>(bad_wire)
         .expect_err("zero coin_in must fail deserialization");
+}
+
+#[test]
+fn swap_params_two_distinct_currencies_ok() {
+    let params = SwapParams::two(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC3>::new(500).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    )
+    .expect("three distinct non-zero amounts must be accepted");
+    assert!(params.invariant_held());
+}
+
+#[test]
+fn swap_params_two_zero_coin_in_1_rejected() {
+    let res = SwapParams::two(
+        Coin::<PaymentC1>::new(0).into(),
+        Coin::<PaymentC3>::new(500).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    );
+    assert!(matches!(res, Err(Error::ZeroSwapAmount)));
+}
+
+#[test]
+fn swap_params_two_zero_coin_in_2_rejected() {
+    let res = SwapParams::two(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC3>::new(0).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    );
+    assert!(matches!(res, Err(Error::ZeroSwapAmount)));
+}
+
+#[test]
+fn swap_params_two_coin_in_1_same_as_min_out_rejected() {
+    let res = SwapParams::two(
+        Coin::<PaymentC2>::new(1000).into(),
+        Coin::<PaymentC3>::new(500).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    );
+    assert!(matches!(res, Err(Error::SameSwapCurrency)));
+}
+
+#[test]
+fn swap_params_two_coin_in_2_same_as_min_out_rejected() {
+    let res = SwapParams::two(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC2>::new(500).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    );
+    assert!(matches!(res, Err(Error::SameSwapCurrency)));
+}
+
+#[test]
+fn swap_params_two_coin_in_1_same_as_coin_in_2_rejected() {
+    let res = SwapParams::two(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC1>::new(500).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    );
+    assert!(matches!(res, Err(Error::DuplicateSwapInputCurrency)));
+}
+
+#[test]
+fn swap_params_two_deserialize_invariant_violation_rejected() {
+    let bad_wire = r#"{"two":{"coin_in_1":{"amount":"1000","ticker":"NLS"},"coin_in_2":{"amount":"500","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}"#;
+    serde_json::from_str::<SwapParams>(bad_wire)
+        .expect_err("duplicate input currencies must fail deserialization");
 }
 
 // ---------------------------------------------------------------------------
@@ -401,7 +483,7 @@ fn sample_open_lease_params() -> OpenLeaseParams {
 }
 
 fn sample_swap_params() -> SwapParams {
-    SwapParams::new(
+    SwapParams::one(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC2>::new(42).into(),
     )

--- a/protocol/packages/remote_lease/src/tests.rs
+++ b/protocol/packages/remote_lease/src/tests.rs
@@ -372,6 +372,16 @@ fn swap_params_two_zero_coin_in_2_rejected() {
 }
 
 #[test]
+fn swap_params_two_zero_min_out_rejected() {
+    let res = SwapParams::two(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC3>::new(500).into(),
+        Coin::<PaymentC2>::new(0).into(),
+    );
+    assert!(matches!(res, Err(Error::ZeroSwapAmount)));
+}
+
+#[test]
 fn swap_params_two_coin_in_1_same_as_min_out_rejected() {
     let res = SwapParams::two(
         Coin::<PaymentC2>::new(1000).into(),

--- a/protocol/packages/remote_lease/tests/cross_surface.rs
+++ b/protocol/packages/remote_lease/tests/cross_surface.rs
@@ -52,6 +52,17 @@ fn operation_swap_byte_identical() {
 }
 
 #[test]
+fn operation_swap_two_byte_identical() {
+    let params = SwapParams::two(
+        Coin::<PaymentC1>::new(1000).into(),
+        Coin::<PaymentC3>::new(500).into(),
+        Coin::<PaymentC2>::new(42).into(),
+    )
+    .expect("three distinct non-zero amounts");
+    assert_cross_surface_eq::<Operation, WireOperation>(&Operation::Swap(params));
+}
+
+#[test]
 fn operation_transfer_out_byte_identical() {
     assert_cross_surface_eq::<Operation, WireOperation>(&Operation::TransferOut(transfer_out()));
 }
@@ -141,7 +152,7 @@ fn open_lease() -> OpenLeaseParams {
 }
 
 fn swap() -> SwapParams {
-    SwapParams::new(
+    SwapParams::one(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC2>::new(42).into(),
     )

--- a/protocol/packages/remote_lease_wire/src/error.rs
+++ b/protocol/packages/remote_lease_wire/src/error.rs
@@ -10,6 +10,9 @@ pub enum Error {
     #[error("swap input and output currencies must differ")]
     SameSwapCurrency,
 
+    #[error("the two swap input currencies must differ")]
+    DuplicateSwapInputCurrency,
+
     #[error("swap input amount and minimum output must be greater than zero")]
     ZeroSwapAmount,
 

--- a/protocol/packages/remote_lease_wire/src/msg.rs
+++ b/protocol/packages/remote_lease_wire/src/msg.rs
@@ -97,6 +97,10 @@ pub struct CloseLeaseParams {}
     rename_all = "snake_case",
     try_from = "SwapParamsRaw"
 )]
+/// Swap parameters for the remote lease protocol.
+///
+/// `One` carries a single input coin; `Two` carries two input coins.
+/// All coins must be non-zero and all tickers pairwise distinct.
 pub enum SwapParams {
     One {
         coin_in: WireCoin,
@@ -110,6 +114,8 @@ pub enum SwapParams {
 }
 
 impl SwapParams {
+    /// Single-input swap. Returns `Err(ZeroSwapAmount)` if either coin is
+    /// zero, or `Err(SameSwapCurrency)` if the tickers match.
     pub fn one(coin_in: WireCoin, min_out: WireCoin) -> Result<Self, Error> {
         if coin_in.is_zero() || min_out.is_zero() {
             return Err(Error::ZeroSwapAmount);
@@ -122,6 +128,9 @@ impl SwapParams {
         Ok(params)
     }
 
+    /// Two-input swap. Returns `Err(ZeroSwapAmount)` if any coin is zero,
+    /// `Err(SameSwapCurrency)` if an input ticker equals the output ticker,
+    /// or `Err(DuplicateSwapInputCurrency)` if the two input tickers match.
     pub fn two(coin_in_1: WireCoin, coin_in_2: WireCoin, min_out: WireCoin) -> Result<Self, Error> {
         if coin_in_1.is_zero() || coin_in_2.is_zero() || min_out.is_zero() {
             return Err(Error::ZeroSwapAmount);
@@ -141,7 +150,8 @@ impl SwapParams {
         Ok(params)
     }
 
-    pub fn min_out(&self) -> &WireCoin {
+    /// Returns the minimum output coin, common to both variants.
+    pub const fn min_out(&self) -> &WireCoin {
         match self {
             Self::One { min_out, .. } | Self::Two { min_out, .. } => min_out,
         }

--- a/protocol/packages/remote_lease_wire/src/msg.rs
+++ b/protocol/packages/remote_lease_wire/src/msg.rs
@@ -97,51 +97,103 @@ pub struct CloseLeaseParams {}
     rename_all = "snake_case",
     try_from = "SwapParamsRaw"
 )]
-pub struct SwapParams {
-    coin_in: WireCoin,
-    min_out: WireCoin,
+pub enum SwapParams {
+    One {
+        coin_in: WireCoin,
+        min_out: WireCoin,
+    },
+    Two {
+        coin_in_1: WireCoin,
+        coin_in_2: WireCoin,
+        min_out: WireCoin,
+    },
 }
 
 impl SwapParams {
-    pub fn new(coin_in: WireCoin, min_out: WireCoin) -> Result<Self, Error> {
+    pub fn one(coin_in: WireCoin, min_out: WireCoin) -> Result<Self, Error> {
         if coin_in.is_zero() || min_out.is_zero() {
             return Err(Error::ZeroSwapAmount);
         }
-        let params = Self { coin_in, min_out };
-        params
-            .invariant_held()
-            .then_some(params)
-            .ok_or(Error::SameSwapCurrency)
-            .inspect(|p| debug_assert!(p.invariant_held()))
+        if coin_in.ticker() == min_out.ticker() {
+            return Err(Error::SameSwapCurrency);
+        }
+        let params = Self::One { coin_in, min_out };
+        debug_assert!(params.invariant_held());
+        Ok(params)
     }
 
-    pub const fn coin_in(&self) -> &WireCoin {
-        &self.coin_in
+    pub fn two(coin_in_1: WireCoin, coin_in_2: WireCoin, min_out: WireCoin) -> Result<Self, Error> {
+        if coin_in_1.is_zero() || coin_in_2.is_zero() || min_out.is_zero() {
+            return Err(Error::ZeroSwapAmount);
+        }
+        if coin_in_1.ticker() == min_out.ticker() || coin_in_2.ticker() == min_out.ticker() {
+            return Err(Error::SameSwapCurrency);
+        }
+        if coin_in_1.ticker() == coin_in_2.ticker() {
+            return Err(Error::DuplicateSwapInputCurrency);
+        }
+        let params = Self::Two {
+            coin_in_1,
+            coin_in_2,
+            min_out,
+        };
+        debug_assert!(params.invariant_held());
+        Ok(params)
     }
 
-    pub const fn min_out(&self) -> &WireCoin {
-        &self.min_out
+    pub fn min_out(&self) -> &WireCoin {
+        match self {
+            Self::One { min_out, .. } | Self::Two { min_out, .. } => min_out,
+        }
     }
 
     pub fn invariant_held(&self) -> bool {
-        !self.coin_in.is_zero()
-            && !self.min_out.is_zero()
-            && self.coin_in.ticker() != self.min_out.ticker()
+        match self {
+            Self::One { coin_in, min_out } => {
+                !coin_in.is_zero() && !min_out.is_zero() && coin_in.ticker() != min_out.ticker()
+            }
+            Self::Two {
+                coin_in_1,
+                coin_in_2,
+                min_out,
+            } => {
+                !coin_in_1.is_zero()
+                    && !coin_in_2.is_zero()
+                    && !min_out.is_zero()
+                    && coin_in_1.ticker() != min_out.ticker()
+                    && coin_in_2.ticker() != min_out.ticker()
+                    && coin_in_1.ticker() != coin_in_2.ticker()
+            }
+        }
     }
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-struct SwapParamsRaw {
-    coin_in: WireCoin,
-    min_out: WireCoin,
+enum SwapParamsRaw {
+    One {
+        coin_in: WireCoin,
+        min_out: WireCoin,
+    },
+    Two {
+        coin_in_1: WireCoin,
+        coin_in_2: WireCoin,
+        min_out: WireCoin,
+    },
 }
 
 impl TryFrom<SwapParamsRaw> for SwapParams {
     type Error = Error;
 
     fn try_from(raw: SwapParamsRaw) -> Result<Self, Self::Error> {
-        SwapParams::new(raw.coin_in, raw.min_out)
+        match raw {
+            SwapParamsRaw::One { coin_in, min_out } => SwapParams::one(coin_in, min_out),
+            SwapParamsRaw::Two {
+                coin_in_1,
+                coin_in_2,
+                min_out,
+            } => SwapParams::two(coin_in_1, coin_in_2, min_out),
+        }
     }
 }
 

--- a/protocol/packages/remote_lease_wire/src/tests.rs
+++ b/protocol/packages/remote_lease_wire/src/tests.rs
@@ -51,7 +51,23 @@ fn close_lease_msg_serde() {
 fn swap_msg_serde() {
     let value = Operation::Swap(sample_swap_params());
     assert_round_trip_eq(
-        r#"{"swap":{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}"#,
+        r#"{"swap":{"one":{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}}"#,
+        &value,
+    );
+}
+
+#[test]
+fn swap_msg_two_serde() {
+    let value = Operation::Swap(
+        SwapParams::two(
+            WireCoin::new(1000, Ticker::new("NLS")),
+            WireCoin::new(500, Ticker::new("LC1")),
+            WireCoin::new(42, Ticker::new("LPN")),
+        )
+        .expect("sample uses three distinct non-zero amounts"),
+    );
+    assert_round_trip_eq(
+        r#"{"swap":{"two":{"coin_in_1":{"amount":"1000","ticker":"NLS"},"coin_in_2":{"amount":"500","ticker":"LC1"},"min_out":{"amount":"42","ticker":"LPN"}}}}"#,
         &value,
     );
 }
@@ -292,8 +308,8 @@ fn open_lease_params_deserialize_above_u16_rejected() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn swap_params_distinct_currencies_ok() {
-    let params = SwapParams::new(
+fn swap_params_one_distinct_currencies_ok() {
+    let params = SwapParams::one(
         WireCoin::new(1000, Ticker::new("NLS")),
         WireCoin::new(42, Ticker::new("LPN")),
     )
@@ -302,8 +318,8 @@ fn swap_params_distinct_currencies_ok() {
 }
 
 #[test]
-fn swap_params_same_currency_rejected() {
-    let res = SwapParams::new(
+fn swap_params_one_same_currency_rejected() {
+    let res = SwapParams::one(
         WireCoin::new(1000, Ticker::new("NLS")),
         WireCoin::new(42, Ticker::new("NLS")),
     );
@@ -311,8 +327,8 @@ fn swap_params_same_currency_rejected() {
 }
 
 #[test]
-fn swap_params_zero_coin_in_rejected() {
-    let res = SwapParams::new(
+fn swap_params_one_zero_coin_in_rejected() {
+    let res = SwapParams::one(
         WireCoin::new(0, Ticker::new("NLS")),
         WireCoin::new(42, Ticker::new("LPN")),
     );
@@ -320,8 +336,8 @@ fn swap_params_zero_coin_in_rejected() {
 }
 
 #[test]
-fn swap_params_zero_min_out_rejected() {
-    let res = SwapParams::new(
+fn swap_params_one_zero_min_out_rejected() {
+    let res = SwapParams::one(
         WireCoin::new(1000, Ticker::new("NLS")),
         WireCoin::new(0, Ticker::new("LPN")),
     );
@@ -329,19 +345,85 @@ fn swap_params_zero_min_out_rejected() {
 }
 
 #[test]
-fn swap_params_deserialize_invariant_violation_rejected() {
-    let bad_wire =
-        r#"{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"NLS"}}"#;
+fn swap_params_one_deserialize_invariant_violation_rejected() {
+    let bad_wire = r#"{"one":{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"NLS"}}}"#;
     serde_json::from_str::<SwapParams>(bad_wire)
         .expect_err("invariant violation must fail deserialization");
 }
 
 #[test]
-fn swap_params_deserialize_zero_amount_rejected() {
-    let bad_wire =
-        r#"{"coin_in":{"amount":"0","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}"#;
+fn swap_params_one_deserialize_zero_amount_rejected() {
+    let bad_wire = r#"{"one":{"coin_in":{"amount":"0","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}"#;
     serde_json::from_str::<SwapParams>(bad_wire)
         .expect_err("zero coin_in must fail deserialization");
+}
+
+#[test]
+fn swap_params_two_distinct_currencies_ok() {
+    let params = SwapParams::two(
+        WireCoin::new(1000, Ticker::new("NLS")),
+        WireCoin::new(500, Ticker::new("LC1")),
+        WireCoin::new(42, Ticker::new("LPN")),
+    )
+    .expect("three distinct non-zero amounts must be accepted");
+    assert!(params.invariant_held());
+}
+
+#[test]
+fn swap_params_two_zero_coin_in_1_rejected() {
+    let res = SwapParams::two(
+        WireCoin::new(0, Ticker::new("NLS")),
+        WireCoin::new(500, Ticker::new("LC1")),
+        WireCoin::new(42, Ticker::new("LPN")),
+    );
+    assert!(matches!(res, Err(Error::ZeroSwapAmount)));
+}
+
+#[test]
+fn swap_params_two_zero_coin_in_2_rejected() {
+    let res = SwapParams::two(
+        WireCoin::new(1000, Ticker::new("NLS")),
+        WireCoin::new(0, Ticker::new("LC1")),
+        WireCoin::new(42, Ticker::new("LPN")),
+    );
+    assert!(matches!(res, Err(Error::ZeroSwapAmount)));
+}
+
+#[test]
+fn swap_params_two_coin_in_1_same_as_min_out_rejected() {
+    let res = SwapParams::two(
+        WireCoin::new(1000, Ticker::new("LPN")),
+        WireCoin::new(500, Ticker::new("LC1")),
+        WireCoin::new(42, Ticker::new("LPN")),
+    );
+    assert!(matches!(res, Err(Error::SameSwapCurrency)));
+}
+
+#[test]
+fn swap_params_two_coin_in_2_same_as_min_out_rejected() {
+    let res = SwapParams::two(
+        WireCoin::new(1000, Ticker::new("NLS")),
+        WireCoin::new(500, Ticker::new("LPN")),
+        WireCoin::new(42, Ticker::new("LPN")),
+    );
+    assert!(matches!(res, Err(Error::SameSwapCurrency)));
+}
+
+#[test]
+fn swap_params_two_coin_in_1_same_as_coin_in_2_rejected() {
+    let res = SwapParams::two(
+        WireCoin::new(1000, Ticker::new("NLS")),
+        WireCoin::new(500, Ticker::new("NLS")),
+        WireCoin::new(42, Ticker::new("LPN")),
+    );
+    assert!(matches!(res, Err(Error::DuplicateSwapInputCurrency)));
+}
+
+#[test]
+fn swap_params_two_deserialize_invariant_violation_rejected() {
+    let bad_wire = r#"{"two":{"coin_in_1":{"amount":"1000","ticker":"NLS"},"coin_in_2":{"amount":"500","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}"#;
+    serde_json::from_str::<SwapParams>(bad_wire)
+        .expect_err("duplicate input currencies must fail deserialization");
 }
 
 // ---------------------------------------------------------------------------
@@ -539,7 +621,7 @@ fn sample_open_lease_params() -> OpenLeaseParams {
 }
 
 fn sample_swap_params() -> SwapParams {
-    SwapParams::new(
+    SwapParams::one(
         WireCoin::new(1000, Ticker::new("NLS")),
         WireCoin::new(42, Ticker::new("LPN")),
     )

--- a/protocol/packages/remote_lease_wire/src/tests.rs
+++ b/protocol/packages/remote_lease_wire/src/tests.rs
@@ -390,6 +390,16 @@ fn swap_params_two_zero_coin_in_2_rejected() {
 }
 
 #[test]
+fn swap_params_two_zero_min_out_rejected() {
+    let res = SwapParams::two(
+        WireCoin::new(1000, Ticker::new("NLS")),
+        WireCoin::new(500, Ticker::new("LC1")),
+        WireCoin::new(0, Ticker::new("LPN")),
+    );
+    assert!(matches!(res, Err(Error::ZeroSwapAmount)));
+}
+
+#[test]
 fn swap_params_two_coin_in_1_same_as_min_out_rejected() {
     let res = SwapParams::two(
         WireCoin::new(1000, Ticker::new("LPN")),


### PR DESCRIPTION
## Summary

- Convert `SwapParams` from a struct to an enum with `One` (single input coin) and `Two` (two input coins) variants, in both the wire (`remote_lease_wire`) and typed (`remote_lease`) crates
- Add `DuplicateSwapInputCurrency` error variant for when the two input currencies in the `Two` variant are identical
- Update all callers (`stub.rs`, `cross_surface.rs`, `execute_outbound.rs`) from `SwapParams::new()` to `SwapParams::one()`
- Add comprehensive tests for the `Two` variant: serde round-trip with pinned JSON, all invariant violations (zero amounts, same-as-output, duplicate inputs), deserialization rejection, and cross-surface byte equivalence

**Breaking wire change**: `Operation::Swap` JSON gains a variant tag layer — `{"swap":{"one":{"coin_in":...,"min_out":...}}}` instead of `{"swap":{"coin_in":...,"min_out":...}}`.

## Test plan

- [x] `cargo check` / `cargo clippy` / `cargo test` on `remote_lease_wire` — 62 tests pass
- [x] `cargo check` / `cargo clippy` / `cargo test` on `remote_lease` — 53 unit + 13 integration tests pass
- [x] `cargo test --all-features` on `remote_lease_controller` — 72 tests pass
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)