### PR TITLE
refactor(dex): model SwapTask input coins as a One/Two enum

### DIFF
--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
@@ -1,18 +1,13 @@
-use std::iter;
-
 use currency::Group;
 use oracle::stub::SwapPath;
 use serde::{Deserialize, Serialize};
 
 use dex::{
     Account, AnomalyTreatment, ContractInSwap, Error as DexError, SlippageCalculator, Stage,
-    SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
+    SwapCoins, SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
 };
 use finance::instant::Instant;
-use finance::{
-    coin::{Coin, CoinDTO},
-    duration::Duration,
-};
+use finance::{coin::Coin, duration::Duration};
 use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
@@ -135,8 +130,8 @@ where
         .map_err(DexError::Unauthorized)
     }
 
-    fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>> {
-        iter::once(*self.repayable.amount(&self.lease))
+    fn coins(&self) -> SwapCoins<Self::InG> {
+        SwapCoins::One(*self.repayable.amount(&self.lease))
     }
 
     fn with_slippage_calc<WithCalc>(&self, with_calc: WithCalc) -> WithCalc::Output

--- a/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
@@ -1,18 +1,13 @@
-use std::iter;
-
 use currency::Group;
 use oracle::stub::SwapPath;
 use serde::{Deserialize, Serialize};
 
 use dex::{
     AcceptAnyNonZeroSwap, Account, AnomalyTreatment, ContractInSwap, Error as DexError, Stage,
-    StartLocalLocalState, SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
+    StartLocalLocalState, SwapCoins, SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
 };
 use finance::instant::Instant;
-use finance::{
-    coin::{Coin, CoinDTO},
-    duration::Duration,
-};
+use finance::{coin::Coin, duration::Duration};
 use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
@@ -115,8 +110,8 @@ impl SwapTask for BuyLpn {
         .map_err(DexError::Unauthorized)
     }
 
-    fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>> {
-        iter::once(self.payment)
+    fn coins(&self) -> SwapCoins<Self::InG> {
+        SwapCoins::One(self.payment)
     }
 
     fn with_slippage_calc<WithCalc>(&self, with_calc: WithCalc) -> WithCalc::Output

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -6,11 +6,11 @@ use remote_lease::response::RemoteLeaseId;
 use serde::{Deserialize, Serialize};
 
 use dex::{
-    Account, ContractInSwap, Error as DexError, Stage, StartLocalRemoteState, SwapOutputTask,
-    SwapTask, WithCalculator, WithOutputTask,
+    Account, ContractInSwap, Error as DexError, Stage, StartLocalRemoteState, SwapCoins,
+    SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
 };
+use finance::duration::Duration;
 use finance::instant::Instant;
-use finance::{coin::CoinDTO, duration::Duration};
 use sdk::cosmwasm_std::{MessageInfo, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
@@ -148,8 +148,8 @@ impl SwapTask for BuyAsset {
             .map_err(DexError::Unauthorized)
     }
 
-    fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>> {
-        [self.downpayment, self.loan.principal.into_super_group()].into_iter()
+    fn coins(&self) -> SwapCoins<Self::InG> {
+        SwapCoins::Two(self.downpayment, self.loan.principal.into_super_group())
     }
 
     fn with_slippage_calc<WithCalc>(&self, with_calc: WithCalc) -> WithCalc::Output

--- a/protocol/contracts/lease/src/contract/state/paid/transfer_in.rs
+++ b/protocol/contracts/lease/src/contract/state/paid/transfer_in.rs
@@ -1,4 +1,4 @@
-use std::{iter, marker::PhantomData};
+use std::marker::PhantomData;
 
 use oracle::stub::SwapPath;
 use serde::{Deserialize, Serialize};
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use currency::{CurrencyDef, Group, MemberOf};
 use dex::{
     Account, AnomalyTreatment, ContractInSwap, Error as DexError, Stage, StartTransferInState,
-    SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
+    SwapCoins, SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
 };
 use finance::instant::Instant;
 use finance::{
@@ -118,8 +118,8 @@ impl SwapTask for TransferIn {
         .map_err(DexError::Unauthorized)
     }
 
-    fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>> {
-        iter::once(*self.amount())
+    fn coins(&self) -> SwapCoins<Self::InG> {
+        SwapCoins::One(*self.amount())
     }
 
     fn with_slippage_calc<Cmd>(&self, _cmd: Cmd) -> Cmd::Output

--- a/protocol/packages/dex/src/coins_in.rs
+++ b/protocol/packages/dex/src/coins_in.rs
@@ -9,7 +9,11 @@ use crate::CoinsNb;
 ///
 /// The design limits a swap to a single input coin or a pair, so the bound is
 /// modelled as an enum — a compile-time invariant rather than a runtime length
-/// check. Mirrors the `One`/`Two` shape of the wire-level `SwapParams`.
+/// check. The variants share only the structural `One`/`Two` shape of the
+/// wire-level `SwapParams`, not its invariants: the swap engine sums inputs
+/// already in the output currency and swaps the rest, so repeated or
+/// output-matching input currencies are accepted — provided at least one
+/// input still needs swapping.
 pub enum SwapCoins<G>
 where
     G: Group,

--- a/protocol/packages/dex/src/coins_in.rs
+++ b/protocol/packages/dex/src/coins_in.rs
@@ -1,0 +1,81 @@
+use std::{iter, option};
+
+use currency::Group;
+use finance::coin::CoinDTO;
+
+use crate::CoinsNb;
+
+/// The one or two input coins a swap operates on.
+///
+/// The design limits a swap to a single input coin or a pair, so the bound is
+/// modelled as an enum — a compile-time invariant rather than a runtime length
+/// check. Mirrors the `One`/`Two` shape of the wire-level `SwapParams`.
+pub enum SwapCoins<G>
+where
+    G: Group,
+{
+    One(CoinDTO<G>),
+    Two(CoinDTO<G>, CoinDTO<G>),
+}
+
+impl<G> SwapCoins<G>
+where
+    G: Group,
+{
+    pub(crate) const fn len(&self) -> CoinsNb {
+        match self {
+            Self::One(_) => 1,
+            Self::Two(..) => 2,
+        }
+    }
+}
+
+impl<G> IntoIterator for SwapCoins<G>
+where
+    G: Group,
+{
+    type Item = CoinDTO<G>;
+    type IntoIter = iter::Chain<iter::Once<CoinDTO<G>>, option::IntoIter<CoinDTO<G>>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let (first, second) = match self {
+            Self::One(first) => (first, None),
+            Self::Two(first, second) => (first, Some(second)),
+        };
+        iter::once(first).chain(second)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use currency::test::{SuperGroup, SuperGroupTestC1, SuperGroupTestC2};
+    use finance::coin::{Amount, Coin, CoinDTO};
+
+    use super::SwapCoins;
+
+    #[test]
+    fn len() {
+        assert_eq!(1, SwapCoins::One(c1(5)).len());
+        assert_eq!(2, SwapCoins::Two(c1(5), c2(7)).len());
+    }
+
+    #[test]
+    fn into_iter_preserves_order() {
+        assert_eq!(
+            vec![c1(5)],
+            SwapCoins::One(c1(5)).into_iter().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            vec![c1(5), c2(7)],
+            SwapCoins::Two(c1(5), c2(7)).into_iter().collect::<Vec<_>>()
+        );
+    }
+
+    fn c1(amount: Amount) -> CoinDTO<SuperGroup> {
+        Coin::<SuperGroupTestC1>::new(amount).into()
+    }
+
+    fn c2(amount: Amount) -> CoinDTO<SuperGroup> {
+        Coin::<SuperGroupTestC2>::new(amount).into()
+    }
+}

--- a/protocol/packages/dex/src/coins_in.rs
+++ b/protocol/packages/dex/src/coins_in.rs
@@ -7,12 +7,10 @@ use crate::CoinsNb;
 
 /// The one or two input coins a swap operates on.
 ///
-/// The design limits a swap to a single input coin or a pair, so the bound is
-/// modelled as an enum — a compile-time invariant rather than a runtime length
-/// check. The variants mirror the `One`/`Two` shape of the wire-level
-/// `SwapParams` but enforce none of its further invariants: input currencies
-/// may repeat or already equal the output currency, provided at least one of
-/// them differs from it.
+/// Modelled as an enum so the one-or-two bound is a compile-time invariant
+/// rather than a runtime length check. It is a plain container: unlike the
+/// validated wire-level `SwapParams`, it constrains neither the input
+/// currencies nor their amounts.
 pub enum SwapCoins<G>
 where
     G: Group,

--- a/protocol/packages/dex/src/coins_in.rs
+++ b/protocol/packages/dex/src/coins_in.rs
@@ -9,11 +9,10 @@ use crate::CoinsNb;
 ///
 /// The design limits a swap to a single input coin or a pair, so the bound is
 /// modelled as an enum — a compile-time invariant rather than a runtime length
-/// check. The variants share only the structural `One`/`Two` shape of the
-/// wire-level `SwapParams`, not its invariants: the swap engine sums inputs
-/// already in the output currency and swaps the rest, so repeated or
-/// output-matching input currencies are accepted — provided at least one
-/// input still needs swapping.
+/// check. The variants mirror the `One`/`Two` shape of the wire-level
+/// `SwapParams` but enforce none of its further invariants: input currencies
+/// may repeat or already equal the output currency, provided at least one of
+/// them differs from it.
 pub enum SwapCoins<G>
 where
     G: Group,

--- a/protocol/packages/dex/src/impl_/transfer_out/mod.rs
+++ b/protocol/packages/dex/src/impl_/transfer_out/mod.rs
@@ -31,7 +31,7 @@ use cw_time::IntoInstant;
 
 /// Transfer out a list of coins to DEX
 ///
-/// Supports up to `CoinsNb::MAX` number of coins.
+/// Supports one or two coins.
 /// In does it in a single transaction with multiple messages expecting
 /// an acknowledgment per message.
 #[derive(Serialize, Deserialize)]
@@ -89,10 +89,7 @@ where
     }
 
     fn coins_len(spec: &SwapTask) -> CoinsNb {
-        let ret = spec.coins().into_iter().count();
-        assert!(ret > 0, "The swap task did not provide any coins!");
-        ret.try_into()
-            .expect("Functionality doesn't support this many coins!")
+        spec.coins().len()
     }
 
     fn generate_requests(&self, now: Instant) -> Batch {

--- a/protocol/packages/dex/src/lib.rs
+++ b/protocol/packages/dex/src/lib.rs
@@ -4,6 +4,7 @@ pub use self::error::Error;
 pub use self::{
     account::Account,
     anomaly::{Handler as AnomalyHandler, Treatment as AnomalyTreatment},
+    coins_in::SwapCoins,
     connect::{Connectable, ConnectionParams, Ics20Channel},
     enterable::Enterable,
     error::Result as DexResult,
@@ -27,6 +28,8 @@ pub use self::{
 mod account;
 #[cfg(feature = "impl")]
 mod anomaly;
+#[cfg(feature = "impl")]
+mod coins_in;
 #[cfg(feature = "impl")]
 mod connect;
 #[cfg(feature = "impl")]

--- a/protocol/packages/dex/src/swap_task.rs
+++ b/protocol/packages/dex/src/swap_task.rs
@@ -1,16 +1,18 @@
 use currency::{CurrencyDef, Group, MemberOf};
-use finance::coin::{Coin, CoinDTO};
+use finance::coin::Coin;
 use oracle::stub::SwapPath;
 use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
-use crate::{Account, AnomalyTreatment, error::Result as DexResult, slippage::WithCalculator};
+use crate::{
+    Account, AnomalyTreatment, SwapCoins, error::Result as DexResult, slippage::WithCalculator,
+};
 
 pub type CoinsNb = u8;
 
 /// Specification of a swap process
 ///
-/// Supports up to `CoinsNb::MAX` coins.
+/// A swap operates on one or two input coins; see [`SwapCoins`].
 pub trait SwapTask
 where
     Self: Sized,
@@ -39,13 +41,8 @@ where
         info: &MessageInfo,
     ) -> DexResult<()>;
 
-    /// Provide the coins, at least one, this swap is about.
-    /// The iteration is done always in the same order.
-    //
-    // TODO define the Item type as an associative : AsRef<CoinDTO<Self::InG>> to allow iterating over values and references.
-    // This would avoid clone-ing of values kept in the task. At the same time, we cannot iterate over '&' due to
-    // having temporary instances in some of the tasks.
-    fn coins(&self) -> impl IntoIterator<Item = CoinDTO<Self::InG>>;
+    /// The one or two input coins this swap is about, always in the same order.
+    fn coins(&self) -> SwapCoins<Self::InG>;
 
     fn with_slippage_calc<WithCalc>(&self, with_calc: WithCalc) -> WithCalc::Output
     where


### PR DESCRIPTION
## What

Replaces `SwapTask::coins()`'s open-ended `impl IntoIterator<Item = CoinDTO<Self::InG>>` return with a concrete enum that models the design's 1-or-2 input-coin limit at the type level:

```rust
pub enum SwapCoins<G: Group> {
    One(CoinDTO<G>),
    Two(CoinDTO<G>, CoinDTO<G>),
}
```

## Why

The number of input coins to a swap is now capped at two (one or two). With `impl IntoIterator` that bound was invisible and enforced only by runtime checks in `TransferOut::coins_len`:

```rust
let ret = spec.coins().into_iter().count();
assert!(ret > 0, "The swap task did not provide any coins!");
ret.try_into().expect("Functionality doesn't support this many coins!")
```

Modelling it as an enum makes the invariant compile-time:
- **zero coins are unrepresentable** — removes the `assert!(ret > 0)` panic;
- **the maximum is two** — removes the `try_into().expect(...)` overflow panic.

`coins_len` collapses to `spec.coins().len()`. The enum mirrors the `One`/`Two` shape of the wire-level `SwapParams` already in the codebase.

## Details

- New `dex::coins_in` module holds `SwapCoins`, its `pub(crate) const fn len() -> CoinsNb`, and an order-preserving `IntoIterator` (`once(first).chain(second)`) — so the three existing consumers (`transfer_out`, `swap_exact_in` encode/decode) compile unchanged.
- `len()` is `pub(crate)` (only `transfer_out` needs it); this also avoids `clippy::len_without_is_empty` without an always-false `is_empty`.
- Four implementors updated: `BuyAsset → Two(downpayment, principal)` (same order as before), `SellAsset`/`BuyLpn`/`TransferIn → One(..)`.
- Unit tests for `len` and iteration order added alongside the enum.

## Testing

Scoped gate (with `SOFTWARE_RELEASE_ID` / `PROTOCOL_*` set):
- `cargo build -p dex -p lease` ✓
- `cargo fmt --all -- --check` ✓
- `cargo clippy` ✓ — dex (`impl,migration,testing`) and lease (`internal.test.contract,dex-test_impl`), all-targets
- `cargo test` ✓ — 88 lease + 5 dex (incl. `coins_in::test::{len, into_iter_preserves_order}`)

No serde/wire-format/state-migration impact: `SwapCoins` derives nothing and is never persisted; `TransferOut::acks_left` stays `CoinsNb` (u8).
