### PR TITLE
refactor(remote_lease): parameterize msg types over currency groups

### DIFF
--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -88,18 +88,17 @@ impl OpenLease {
     }
 
     pub(super) fn enter(&self) -> ContractResult<Batch> {
-        type OpenLease =
-            OpenLeaseParams<LeaseAssetCurrencies, LpnCurrencies, LeasePaymentCurrencies>;
-        OpenLease::new(
+        type Params = OpenLeaseParams<LeaseAssetCurrencies, LpnCurrencies, LeasePaymentCurrencies>;
+        Params::new(
             self.new_lease.expected_instance_ordinal,
             self.downpayment.currency(),
-            self.loan.principal.currency().into_super_group(),
-            self.new_lease.form.currency.into_super_group(),
+            self.loan.principal.currency(),
+            self.new_lease.form.currency,
         )
         .map_err(ContractError::OpenLeaseParams)
         .and_then(|params| {
             Factory::new(&self.new_lease.remote_lease_controller)
-                .open(params, OpenLease::TIMEOUT)
+                .open(params, Params::TIMEOUT)
                 .map_err(ContractError::from)
         })
     }

--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -33,7 +33,7 @@ use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
     api::{
-        DownpaymentCoin,
+        DownpaymentCoin, LeaseAssetCurrencies, LeasePaymentCurrencies,
         open::NewLeaseContract,
         query::{StateResponse as QueryStateResponse, opening::OngoingTrx},
     },
@@ -44,7 +44,7 @@ use crate::{
         state::{Response, State, open_failed::OpenFailed},
     },
     error::{ContractError, ContractResult},
-    finance::{LpnCoin, LpnCurrency, LppRef, OracleRef, ReserveRef},
+    finance::{LpnCoin, LpnCurrencies, LpnCurrency, LppRef, OracleRef, ReserveRef},
 };
 
 const OPEN_FAILED_EVENT: &str = "ls-remote-lease-open-failed";
@@ -88,7 +88,9 @@ impl OpenLease {
     }
 
     pub(super) fn enter(&self) -> ContractResult<Batch> {
-        OpenLeaseParams::new(
+        type OpenLease =
+            OpenLeaseParams<LeaseAssetCurrencies, LpnCurrencies, LeasePaymentCurrencies>;
+        OpenLease::new(
             self.new_lease.expected_instance_ordinal,
             self.downpayment.currency(),
             self.loan.principal.currency().into_super_group(),
@@ -97,7 +99,7 @@ impl OpenLease {
         .map_err(ContractError::OpenLeaseParams)
         .and_then(|params| {
             Factory::new(&self.new_lease.remote_lease_controller)
-                .open(params, OpenLeaseParams::TIMEOUT)
+                .open(params, OpenLease::TIMEOUT)
                 .map_err(ContractError::from)
         })
     }

--- a/protocol/contracts/remote_lease/Cargo.toml
+++ b/protocol/contracts/remote_lease/Cargo.toml
@@ -22,6 +22,7 @@ crate-type = ["cdylib", "rlib"]
 contract = [
     "dep:access-control",
     "dep:cosmwasm-std",
+    "dep:currencies",
     "cosmwasm-std/exports",
     "cosmwasm-std/stargate",
     "cosmwasm-std/cosmwasm_2_0",
@@ -34,6 +35,7 @@ testing = []
 
 [dependencies]
 access-control = { workspace = true, optional = true }
+currencies = { workspace = true, optional = true }
 cw-time = { workspace = true }
 finance = { workspace = true }
 platform = { workspace = true }

--- a/protocol/contracts/remote_lease/src/contract.rs
+++ b/protocol/contracts/remote_lease/src/contract.rs
@@ -2,6 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use access_control::SingleUserAccess;
 use cosmwasm_std::Storage;
+use currencies::{LeaseGroup, Lpns as LpnGroup, PaymentGroup};
 use cw_time::{IntoInstant as _, IntoTimestamp as _};
 use finance::{duration::Duration, instant::Instant};
 use platform::{
@@ -102,7 +103,7 @@ pub fn execute(
     deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
-    msg: ExecuteMsg,
+    msg: ExecuteMsg<LeaseGroup, LpnGroup, PaymentGroup>,
 ) -> Result<CwResponse> {
     let api = deps.api;
     match msg {
@@ -206,7 +207,7 @@ fn send_operation(
     deps: DepsMut<'_>,
     env: &Env,
     caller: Addr,
-    operation: Operation,
+    operation: Operation<LeaseGroup, LpnGroup, PaymentGroup>,
     timeout: Duration,
 ) -> Result<PlatformResponse> {
     let DepsMut {
@@ -241,7 +242,7 @@ fn build_packet(
     now: Instant,
     channel: &Channel,
     lease: Addr,
-    operation: Operation,
+    operation: Operation<LeaseGroup, LpnGroup, PaymentGroup>,
     timeout: Duration,
 ) -> Result<PlatformResponse> {
     let envelope = PacketEnvelope {

--- a/protocol/contracts/remote_lease/src/contract/tests/execute_outbound.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/execute_outbound.rs
@@ -1,4 +1,7 @@
-use currencies::testing::{PaymentC1, PaymentC2, PaymentC3};
+use currencies::{
+    LeaseGroup, Lpns as LpnGroup, PaymentGroup,
+    testing::{PaymentC1, PaymentC2, PaymentC3},
+};
 use finance::{coin::Coin, instant::Instant};
 use remote_lease::{
     envelope::{LeaseAddrOnWire, PacketEnvelope},
@@ -18,6 +21,12 @@ use super::{
     deps_with_lease, instantiate_default, sample_open_lease_params, sender, store_closing_channel,
     store_open_channel,
 };
+
+type ExecuteMsgT = ExecuteMsg<LeaseGroup, LpnGroup, PaymentGroup>;
+type OperationT = Operation<LeaseGroup, LpnGroup, PaymentGroup>;
+type PacketEnvelopeT = PacketEnvelope<LeaseGroup, LpnGroup, PaymentGroup>;
+type SwapParamsT = SwapParams<PaymentGroup, PaymentGroup>;
+type TransferOutParamsT = TransferOutParams<PaymentGroup>;
 
 #[test]
 fn open_lease_emits_send_packet() {
@@ -162,14 +171,14 @@ fn outbound_non_contract_caller_rejected() {
     assert!(matches!(err, Error::UnauthorisedCaller), "got {err:?}");
 }
 
-fn open_lease_execute() -> ExecuteMsg {
+fn open_lease_execute() -> ExecuteMsgT {
     ExecuteMsg::OpenLease {
         params: sample_open_lease_params(),
         timeout: PACKET_TIMEOUT,
     }
 }
 
-fn sample_swap_params() -> SwapParams {
+fn sample_swap_params() -> SwapParamsT {
     SwapParams::one(
         Coin::<PaymentC1>::new(1_000).into(),
         Coin::<PaymentC2>::new(42).into(),
@@ -177,12 +186,12 @@ fn sample_swap_params() -> SwapParams {
     .expect("sample uses two distinct non-zero amounts")
 }
 
-fn sample_transfer_out_params() -> TransferOutParams {
+fn sample_transfer_out_params() -> TransferOutParamsT {
     TransferOutParams::new(Coin::<PaymentC3>::new(1_000).into())
         .expect("sample uses a non-zero amount")
 }
 
-fn assert_send_packet(expected_operation: &Operation, messages: &[SubMsg]) {
+fn assert_send_packet(expected_operation: &OperationT, messages: &[SubMsg]) {
     assert_eq!(1, messages.len(), "expected exactly one outbound message");
     match &messages[0].msg {
         CosmosMsg::Ibc(IbcMsg::SendPacket {
@@ -192,7 +201,7 @@ fn assert_send_packet(expected_operation: &Operation, messages: &[SubMsg]) {
         }) => {
             assert_eq!(LOCAL_CHANNEL_ID, channel_id);
             assert_eq!(&expected_timeout(), timeout);
-            let envelope: PacketEnvelope = sdk::cosmwasm_std::from_json(data).unwrap();
+            let envelope: PacketEnvelopeT = sdk::cosmwasm_std::from_json(data).unwrap();
             assert_eq!(
                 LeaseAddrOnWire::new(sdk_testing::user(LEASE)),
                 envelope.lease,

--- a/protocol/contracts/remote_lease/src/contract/tests/mod.rs
+++ b/protocol/contracts/remote_lease/src/contract/tests/mod.rs
@@ -6,7 +6,7 @@ mod query;
 mod scenarios;
 
 use currencies::{
-    PaymentGroup,
+    LeaseGroup, Lpns as LpnGroup, PaymentGroup,
     testing::{PaymentC1, PaymentC2, PaymentC3},
 };
 use finance::duration::Duration;
@@ -27,6 +27,8 @@ use crate::{
     contract::{instantiate, query},
     state::Channel,
 };
+
+type OpenLeaseParamsT = OpenLeaseParams<LeaseGroup, LpnGroup, PaymentGroup>;
 
 const ADMIN: &str = "admin";
 const NON_ADMIN: &str = "intruder";
@@ -158,12 +160,12 @@ fn query_channel(deps: Deps<'_>) -> ChannelResponse {
     sdk::cosmwasm_std::from_json(raw).unwrap()
 }
 
-fn sample_open_lease_params() -> OpenLeaseParams {
+fn sample_open_lease_params() -> OpenLeaseParamsT {
     OpenLeaseParams::new(
         7,
         currency::dto::<PaymentC1, PaymentGroup>(),
-        currency::dto::<PaymentC2, PaymentGroup>(),
-        currency::dto::<PaymentC3, PaymentGroup>(),
+        currency::dto::<PaymentC2, LpnGroup>(),
+        currency::dto::<PaymentC3, LeaseGroup>(),
     )
     .expect("sample uses three distinct currencies")
 }

--- a/protocol/contracts/remote_lease/src/ibc.rs
+++ b/protocol/contracts/remote_lease/src/ibc.rs
@@ -1,3 +1,4 @@
+use currencies::{LeaseGroup, Lpns as LpnGroup, PaymentGroup};
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback},
     envelope::{NolusLeaseAddr, PacketEnvelope},
@@ -131,7 +132,7 @@ pub fn ibc_packet_ack(
     _env: Env,
     msg: IbcPacketAckMsg,
 ) -> Result<IbcBasicResponse> {
-    cosmwasm_std::from_json::<PacketEnvelope>(&msg.original_packet.data)
+    cosmwasm_std::from_json(&msg.original_packet.data)
         .map_err(Error::from)
         .and_then(|envelope| {
             cosmwasm_std::from_json::<StdAck>(&msg.acknowledgement.data)
@@ -147,7 +148,7 @@ pub fn ibc_packet_timeout(
     _env: Env,
     msg: IbcPacketTimeoutMsg,
 ) -> Result<IbcBasicResponse> {
-    cosmwasm_std::from_json::<PacketEnvelope>(&msg.packet.data)
+    cosmwasm_std::from_json(&msg.packet.data)
         .map_err(Error::from)
         .and_then(|envelope| {
             dispatch_lease_callback(deps.api, envelope, RemoteLeaseCallback::OperationTimeout)
@@ -174,7 +175,7 @@ fn ack_to_callback(ack: StdAck) -> Result<RemoteLeaseCallback> {
 // port uniqueness, not from a per-packet whitelist.
 fn dispatch_lease_callback(
     api: &dyn Api,
-    envelope: PacketEnvelope,
+    envelope: PacketEnvelope<LeaseGroup, LpnGroup, PaymentGroup>,
     callback: RemoteLeaseCallback,
 ) -> Result<IbcBasicResponse> {
     envelope

--- a/protocol/contracts/remote_lease/src/ibc/tests/packets.rs
+++ b/protocol/contracts/remote_lease/src/ibc/tests/packets.rs
@@ -1,3 +1,4 @@
+use currencies::{LeaseGroup, Lpns as LpnGroup, PaymentGroup};
 use remote_lease::{
     callback::{OPERATION_ERR_MAX_BYTES, RemoteErrorMessage, RemoteLeaseCallback},
     envelope::{LeaseAddrOnWire, PacketEnvelope},
@@ -24,6 +25,8 @@ use super::{
     COUNTERPARTY_CHANNEL_ID, COUNTERPARTY_PORT_ID, LOCAL_CHANNEL_ID, LOCAL_PORT_ID,
     deps_with_config,
 };
+
+type PacketEnvelopeT = PacketEnvelope<LeaseGroup, LpnGroup, PaymentGroup>;
 
 #[test]
 fn packet_receive_returns_error_ack() {
@@ -209,7 +212,7 @@ fn dispatched_callback_wire_shape_pinned() {
 #[test]
 fn packet_ack_malformed_lease_addr_in_envelope_errors() {
     let mut deps = deps_with_config();
-    let envelope = PacketEnvelope {
+    let envelope = PacketEnvelopeT {
         lease: LeaseAddrOnWire::new("NOT_BECH32!"),
         operation: Operation::CloseLease(CloseLeaseParams {}),
         version: ProtocolVersion,
@@ -231,7 +234,7 @@ fn packet_ack_malformed_lease_addr_in_envelope_errors() {
 #[test]
 fn packet_timeout_malformed_lease_addr_in_envelope_errors() {
     let mut deps = deps_with_config();
-    let envelope = PacketEnvelope {
+    let envelope = PacketEnvelopeT {
         lease: LeaseAddrOnWire::new("NOT_BECH32!"),
         operation: Operation::CloseLease(CloseLeaseParams {}),
         version: ProtocolVersion,
@@ -333,15 +336,15 @@ fn packet_ack_oversized_error_message_errors() {
     assert!(matches!(err, Error::RemoteCallback(_)), "got {err:?}");
 }
 
-fn envelope_with_close_lease(lease: &Addr) -> PacketEnvelope {
-    PacketEnvelope {
+fn envelope_with_close_lease(lease: &Addr) -> PacketEnvelopeT {
+    PacketEnvelopeT {
         lease: LeaseAddrOnWire::new(lease.as_str()),
         operation: Operation::CloseLease(CloseLeaseParams {}),
         version: ProtocolVersion,
     }
 }
 
-fn encode_envelope(envelope: &PacketEnvelope) -> Binary {
+fn encode_envelope(envelope: &PacketEnvelopeT) -> Binary {
     cosmwasm_std::to_json_binary(envelope).expect("envelope must serialise")
 }
 

--- a/protocol/packages/remote_lease/src/envelope.rs
+++ b/protocol/packages/remote_lease/src/envelope.rs
@@ -15,6 +15,9 @@ use crate::msg::Operation;
 /// receiver MUST convert it through [`NolusLeaseAddr::into_validated`] before
 /// using it for dispatch — the type prevents accidental use of the raw string
 /// as a `cosmwasm_std::Addr`.
+///
+/// `operation` is generic over the lease's asset (`LeaseG`), LPN (`LpnG`), and
+/// payment (`PaymentG`) currency groups; see [`Operation`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct PacketEnvelope<LeaseG, LpnG, PaymentG>

--- a/protocol/packages/remote_lease/src/envelope.rs
+++ b/protocol/packages/remote_lease/src/envelope.rs
@@ -1,3 +1,4 @@
+use currency::Group;
 use serde::{Deserialize, Serialize};
 
 pub use remote_lease_wire::envelope::LeaseAddrOnWire;
@@ -16,9 +17,14 @@ use crate::msg::Operation;
 /// as a `cosmwasm_std::Addr`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct PacketEnvelope {
+pub struct PacketEnvelope<LeaseG, LpnG, PaymentG>
+where
+    LeaseG: Group,
+    LpnG: Group,
+    PaymentG: Group,
+{
     pub lease: LeaseAddrOnWire,
-    pub operation: Operation,
+    pub operation: Operation<LeaseG, LpnG, PaymentG>,
     pub version: ProtocolVersion,
 }
 

--- a/protocol/packages/remote_lease/src/msg.rs
+++ b/protocol/packages/remote_lease/src/msg.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use currencies::PaymentGroup;
-use currency::CurrencyDTO;
+use currency::{CurrencyDTO, Group};
 use finance::{coin::CoinDTO, duration::Duration};
 use platform::contract::Code;
 
@@ -9,7 +8,12 @@ use crate::error::Error;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub enum ExecuteMsg {
+pub enum ExecuteMsg<LeaseG, LpnG, PaymentG>
+where
+    LeaseG: Group,
+    LpnG: Group,
+    PaymentG: Group,
+{
     /// Initiate the channel handshake. Allowed only when no channel is recorded.
     OpenChannel(),
     /// Begin closing the recorded channel. Allowed only when it is currently `Open`.
@@ -22,7 +26,7 @@ pub enum ExecuteMsg {
     /// `timeout` is the relative duration after which the ICS-04 packet expires;
     /// the controller anchors it to its own block time at send.
     OpenLease {
-        params: OpenLeaseParams,
+        params: OpenLeaseParams<LeaseG, LpnG, PaymentG>,
         timeout: Duration,
     },
     /// Outbound `CloseLease` packet. See [`ExecuteMsg::OpenLease`] for `timeout` semantics.
@@ -32,46 +36,62 @@ pub enum ExecuteMsg {
     },
     /// Outbound `Swap` packet. See [`ExecuteMsg::OpenLease`] for `timeout` semantics.
     Swap {
-        params: SwapParams,
+        params: SwapParams<PaymentG, PaymentG>,
         timeout: Duration,
     },
     /// Outbound `TransferOut` packet. See [`ExecuteMsg::OpenLease`] for `timeout` semantics.
     TransferOut {
-        params: TransferOutParams,
+        params: TransferOutParams<PaymentG>,
         timeout: Duration,
     },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub enum Operation {
-    OpenLease(OpenLeaseParams),
+pub enum Operation<LeaseG, LpnG, PaymentG>
+where
+    LeaseG: Group,
+    LpnG: Group,
+    PaymentG: Group,
+{
+    OpenLease(OpenLeaseParams<LeaseG, LpnG, PaymentG>),
     CloseLease(CloseLeaseParams),
-    Swap(SwapParams),
-    TransferOut(TransferOutParams),
+    Swap(SwapParams<PaymentG, PaymentG>),
+    TransferOut(TransferOutParams<PaymentG>),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(
+    bound(serialize = "LeaseG: Serialize, LpnG: Serialize, PaymentG: Serialize"),
     deny_unknown_fields,
     rename_all = "snake_case",
-    try_from = "OpenLeaseParamsRaw"
+    try_from = "OpenLeaseParamsRaw<LeaseG, LpnG, PaymentG>"
 )]
-pub struct OpenLeaseParams {
+pub struct OpenLeaseParams<LeaseG, LpnG, PaymentG>
+where
+    LeaseG: Group,
+    LpnG: Group,
+    PaymentG: Group,
+{
     expected_instance_ordinal: u16,
-    downpayment_currency: CurrencyDTO<PaymentGroup>,
-    lpn_currency: CurrencyDTO<PaymentGroup>,
-    asset_currency: CurrencyDTO<PaymentGroup>,
+    downpayment_currency: CurrencyDTO<PaymentG>,
+    lpn_currency: CurrencyDTO<LpnG>,
+    asset_currency: CurrencyDTO<LeaseG>,
 }
 
-impl OpenLeaseParams {
+impl<LeaseG, LpnG, PaymentG> OpenLeaseParams<LeaseG, LpnG, PaymentG>
+where
+    LeaseG: Group,
+    LpnG: Group,
+    PaymentG: Group,
+{
     pub const TIMEOUT: Duration = Duration::from_secs(60);
 
     pub fn new(
         expected_instance_ordinal: u16,
-        downpayment_currency: CurrencyDTO<PaymentGroup>,
-        lpn_currency: CurrencyDTO<PaymentGroup>,
-        asset_currency: CurrencyDTO<PaymentGroup>,
+        downpayment_currency: CurrencyDTO<PaymentG>,
+        lpn_currency: CurrencyDTO<LpnG>,
+        asset_currency: CurrencyDTO<LeaseG>,
     ) -> Result<Self, Error> {
         let params = Self {
             expected_instance_ordinal,
@@ -90,15 +110,15 @@ impl OpenLeaseParams {
         self.expected_instance_ordinal
     }
 
-    pub const fn downpayment_currency(&self) -> &CurrencyDTO<PaymentGroup> {
+    pub const fn downpayment_currency(&self) -> &CurrencyDTO<PaymentG> {
         &self.downpayment_currency
     }
 
-    pub const fn lpn_currency(&self) -> &CurrencyDTO<PaymentGroup> {
+    pub const fn lpn_currency(&self) -> &CurrencyDTO<LpnG> {
         &self.lpn_currency
     }
 
-    pub const fn asset_currency(&self) -> &CurrencyDTO<PaymentGroup> {
+    pub const fn asset_currency(&self) -> &CurrencyDTO<LeaseG> {
         &self.asset_currency
     }
 
@@ -109,17 +129,28 @@ impl OpenLeaseParams {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-struct OpenLeaseParamsRaw {
+struct OpenLeaseParamsRaw<LeaseG, LpnG, PaymentG>
+where
+    LeaseG: Group,
+    LpnG: Group,
+    PaymentG: Group,
+{
     expected_instance_ordinal: u16,
-    downpayment_currency: CurrencyDTO<PaymentGroup>,
-    lpn_currency: CurrencyDTO<PaymentGroup>,
-    asset_currency: CurrencyDTO<PaymentGroup>,
+    downpayment_currency: CurrencyDTO<PaymentG>,
+    lpn_currency: CurrencyDTO<LpnG>,
+    asset_currency: CurrencyDTO<LeaseG>,
 }
 
-impl TryFrom<OpenLeaseParamsRaw> for OpenLeaseParams {
+impl<LeaseG, LpnG, PaymentG> TryFrom<OpenLeaseParamsRaw<LeaseG, LpnG, PaymentG>>
+    for OpenLeaseParams<LeaseG, LpnG, PaymentG>
+where
+    LeaseG: Group,
+    LpnG: Group,
+    PaymentG: Group,
+{
     type Error = Error;
 
-    fn try_from(raw: OpenLeaseParamsRaw) -> Result<Self, Self::Error> {
+    fn try_from(raw: OpenLeaseParamsRaw<LeaseG, LpnG, PaymentG>) -> Result<Self, Self::Error> {
         OpenLeaseParams::new(
             raw.expected_instance_ordinal,
             raw.downpayment_currency,
@@ -141,33 +172,38 @@ impl CloseLeaseParams {
 #[serde(
     deny_unknown_fields,
     rename_all = "snake_case",
-    try_from = "SwapParamsRaw"
+    try_from = "SwapParamsRaw<GIn, GOut>"
 )]
 /// Swap parameters for the remote lease protocol.
 ///
 /// `One` carries a single input coin; `Two` carries two input coins.
 /// All coins must be non-zero and all currencies pairwise distinct.
-pub enum SwapParams {
+pub enum SwapParams<GIn, GOut>
+where
+    GIn: Group,
+    GOut: Group,
+{
     One {
-        coin_in: CoinDTO<PaymentGroup>,
-        min_out: CoinDTO<PaymentGroup>,
+        coin_in: CoinDTO<GIn>,
+        min_out: CoinDTO<GOut>,
     },
     Two {
-        coin_in_1: CoinDTO<PaymentGroup>,
-        coin_in_2: CoinDTO<PaymentGroup>,
-        min_out: CoinDTO<PaymentGroup>,
+        coin_in_1: CoinDTO<GIn>,
+        coin_in_2: CoinDTO<GIn>,
+        min_out: CoinDTO<GOut>,
     },
 }
 
-impl SwapParams {
+impl<GIn, GOut> SwapParams<GIn, GOut>
+where
+    GIn: Group,
+    GOut: Group,
+{
     pub const TIMEOUT: Duration = Duration::from_secs(300);
 
     /// Single-input swap. Returns `Err(ZeroSwapAmount)` if either coin is
     /// zero, or `Err(SameSwapCurrency)` if the currencies match.
-    pub fn one(
-        coin_in: CoinDTO<PaymentGroup>,
-        min_out: CoinDTO<PaymentGroup>,
-    ) -> Result<Self, Error> {
+    pub fn one(coin_in: CoinDTO<GIn>, min_out: CoinDTO<GOut>) -> Result<Self, Error> {
         if coin_in.is_zero() || min_out.is_zero() {
             return Err(Error::ZeroSwapAmount);
         }
@@ -183,9 +219,9 @@ impl SwapParams {
     /// `Err(SameSwapCurrency)` if an input currency equals the output currency,
     /// or `Err(DuplicateSwapInputCurrency)` if the two input currencies match.
     pub fn two(
-        coin_in_1: CoinDTO<PaymentGroup>,
-        coin_in_2: CoinDTO<PaymentGroup>,
-        min_out: CoinDTO<PaymentGroup>,
+        coin_in_1: CoinDTO<GIn>,
+        coin_in_2: CoinDTO<GIn>,
+        min_out: CoinDTO<GOut>,
     ) -> Result<Self, Error> {
         if coin_in_1.is_zero() || coin_in_2.is_zero() || min_out.is_zero() {
             return Err(Error::ZeroSwapAmount);
@@ -207,7 +243,7 @@ impl SwapParams {
     }
 
     /// Returns the minimum output coin, common to both variants.
-    pub const fn min_out(&self) -> &CoinDTO<PaymentGroup> {
+    pub const fn min_out(&self) -> &CoinDTO<GOut> {
         match self {
             Self::One { min_out, .. } | Self::Two { min_out, .. } => min_out,
         }
@@ -236,22 +272,30 @@ impl SwapParams {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-enum SwapParamsRaw {
+enum SwapParamsRaw<GIn, GOut>
+where
+    GIn: Group,
+    GOut: Group,
+{
     One {
-        coin_in: CoinDTO<PaymentGroup>,
-        min_out: CoinDTO<PaymentGroup>,
+        coin_in: CoinDTO<GIn>,
+        min_out: CoinDTO<GOut>,
     },
     Two {
-        coin_in_1: CoinDTO<PaymentGroup>,
-        coin_in_2: CoinDTO<PaymentGroup>,
-        min_out: CoinDTO<PaymentGroup>,
+        coin_in_1: CoinDTO<GIn>,
+        coin_in_2: CoinDTO<GIn>,
+        min_out: CoinDTO<GOut>,
     },
 }
 
-impl TryFrom<SwapParamsRaw> for SwapParams {
+impl<GIn, GOut> TryFrom<SwapParamsRaw<GIn, GOut>> for SwapParams<GIn, GOut>
+where
+    GIn: Group,
+    GOut: Group,
+{
     type Error = Error;
 
-    fn try_from(raw: SwapParamsRaw) -> Result<Self, Self::Error> {
+    fn try_from(raw: SwapParamsRaw<GIn, GOut>) -> Result<Self, Self::Error> {
         match raw {
             SwapParamsRaw::One { coin_in, min_out } => SwapParams::one(coin_in, min_out),
             SwapParamsRaw::Two {
@@ -267,16 +311,22 @@ impl TryFrom<SwapParamsRaw> for SwapParams {
 #[serde(
     deny_unknown_fields,
     rename_all = "snake_case",
-    try_from = "TransferOutParamsRaw"
+    try_from = "TransferOutParamsRaw<GOut>"
 )]
-pub struct TransferOutParams {
-    amount: CoinDTO<PaymentGroup>,
+pub struct TransferOutParams<GOut>
+where
+    GOut: Group,
+{
+    amount: CoinDTO<GOut>,
 }
 
-impl TransferOutParams {
+impl<GOut> TransferOutParams<GOut>
+where
+    GOut: Group,
+{
     pub const TIMEOUT: Duration = Duration::from_secs(120);
 
-    pub fn new(amount: CoinDTO<PaymentGroup>) -> Result<Self, Error> {
+    pub fn new(amount: CoinDTO<GOut>) -> Result<Self, Error> {
         let params = Self { amount };
         params
             .invariant_held()
@@ -285,7 +335,7 @@ impl TransferOutParams {
             .inspect(|p| debug_assert!(p.invariant_held()))
     }
 
-    pub const fn amount(&self) -> &CoinDTO<PaymentGroup> {
+    pub const fn amount(&self) -> &CoinDTO<GOut> {
         &self.amount
     }
 
@@ -296,14 +346,20 @@ impl TransferOutParams {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-struct TransferOutParamsRaw {
-    amount: CoinDTO<PaymentGroup>,
+struct TransferOutParamsRaw<GOut>
+where
+    GOut: Group,
+{
+    amount: CoinDTO<GOut>,
 }
 
-impl TryFrom<TransferOutParamsRaw> for TransferOutParams {
+impl<GOut> TryFrom<TransferOutParamsRaw<GOut>> for TransferOutParams<GOut>
+where
+    GOut: Group,
+{
     type Error = Error;
 
-    fn try_from(raw: TransferOutParamsRaw) -> Result<Self, Self::Error> {
+    fn try_from(raw: TransferOutParamsRaw<GOut>) -> Result<Self, Self::Error> {
         TransferOutParams::new(raw.amount)
     }
 }
@@ -318,16 +374,28 @@ impl TryFrom<TransferOutParamsRaw> for TransferOutParams {
 // variant.
 // ---------------------------------------------------------------------------
 
-fn wire_ticker(currency: &CurrencyDTO<PaymentGroup>) -> remote_lease_wire::ticker::Ticker {
+fn wire_ticker<G>(currency: &CurrencyDTO<G>) -> remote_lease_wire::ticker::Ticker
+where
+    G: Group,
+{
     remote_lease_wire::ticker::Ticker::new(currency.to_string())
 }
 
-fn wire_coin(coin: &CoinDTO<PaymentGroup>) -> remote_lease_wire::coin::WireCoin {
+fn wire_coin<G>(coin: &CoinDTO<G>) -> remote_lease_wire::coin::WireCoin
+where
+    G: Group,
+{
     remote_lease_wire::coin::WireCoin::new(coin.amount(), wire_ticker(&coin.currency()))
 }
 
-impl From<&OpenLeaseParams> for remote_lease_wire::msg::OpenLeaseParams {
-    fn from(typed: &OpenLeaseParams) -> Self {
+impl<LeaseG, LpnG, PaymentG> From<&OpenLeaseParams<LeaseG, LpnG, PaymentG>>
+    for remote_lease_wire::msg::OpenLeaseParams
+where
+    LeaseG: Group,
+    LpnG: Group,
+    PaymentG: Group,
+{
+    fn from(typed: &OpenLeaseParams<LeaseG, LpnG, PaymentG>) -> Self {
         Self::new(
             typed.expected_instance_ordinal(),
             wire_ticker(typed.downpayment_currency()),
@@ -338,8 +406,12 @@ impl From<&OpenLeaseParams> for remote_lease_wire::msg::OpenLeaseParams {
     }
 }
 
-impl From<&SwapParams> for remote_lease_wire::msg::SwapParams {
-    fn from(typed: &SwapParams) -> Self {
+impl<GIn, GOut> From<&SwapParams<GIn, GOut>> for remote_lease_wire::msg::SwapParams
+where
+    GIn: Group,
+    GOut: Group,
+{
+    fn from(typed: &SwapParams<GIn, GOut>) -> Self {
         match typed {
             SwapParams::One { coin_in, min_out } => {
                 Self::one(wire_coin(coin_in), wire_coin(min_out))
@@ -358,15 +430,24 @@ impl From<&SwapParams> for remote_lease_wire::msg::SwapParams {
     }
 }
 
-impl From<&TransferOutParams> for remote_lease_wire::msg::TransferOutParams {
-    fn from(typed: &TransferOutParams) -> Self {
+impl<GOut> From<&TransferOutParams<GOut>> for remote_lease_wire::msg::TransferOutParams
+where
+    GOut: Group,
+{
+    fn from(typed: &TransferOutParams<GOut>) -> Self {
         Self::new(wire_coin(typed.amount()))
             .expect("typed TransferOutParams already upholds the non-zero invariant")
     }
 }
 
-impl From<&Operation> for remote_lease_wire::msg::Operation {
-    fn from(typed: &Operation) -> Self {
+impl<LeaseG, Lpns, PaymentG> From<&Operation<LeaseG, Lpns, PaymentG>>
+    for remote_lease_wire::msg::Operation
+where
+    LeaseG: Group,
+    Lpns: Group,
+    PaymentG: Group,
+{
+    fn from(typed: &Operation<LeaseG, Lpns, PaymentG>) -> Self {
         match typed {
             Operation::OpenLease(p) => Self::OpenLease(p.into()),
             Operation::CloseLease(CloseLeaseParams {}) => {
@@ -384,10 +465,16 @@ mod tests {
         PaymentGroup,
         testing::{PaymentC1, PaymentC2, PaymentC3},
     };
+
     use finance::coin::Coin;
     use platform::contract::Code;
 
     use super::{CloseLeaseParams, ExecuteMsg, OpenLeaseParams, SwapParams, TransferOutParams};
+
+    type SwapP2P = SwapParams<PaymentGroup, PaymentGroup>;
+    type ExecuteP2P = ExecuteMsg<PaymentGroup, PaymentGroup, PaymentGroup>;
+    type OpenLeaseP2P = OpenLeaseParams<PaymentGroup, PaymentGroup, PaymentGroup>;
+    type TransferOutP2P = TransferOutParams<PaymentGroup>;
 
     // Each variant of `ExecuteMsg` carries its own serde encoding, so a
     // regression in one variant's attributes (`rename_all`, the tuple-vs-struct
@@ -399,7 +486,7 @@ mod tests {
     fn open_channel_wire_shape() {
         assert_eq!(
             serde_json::json!([]),
-            variant_body("open_channel", &ExecuteMsg::OpenChannel())
+            variant_body("open_channel", &ExecuteP2P::OpenChannel())
         );
     }
 
@@ -407,13 +494,13 @@ mod tests {
     fn close_channel_wire_shape() {
         assert_eq!(
             serde_json::json!([]),
-            variant_body("close_channel", &ExecuteMsg::CloseChannel())
+            variant_body("close_channel", &ExecuteP2P::CloseChannel())
         );
     }
 
     #[test]
     fn new_lease_code_wire_shape() {
-        let msg = ExecuteMsg::NewLeaseCode {
+        let msg = ExecuteP2P::NewLeaseCode {
             lease_code: Code::unchecked(20),
         };
         assert_struct_fields(&["lease_code"], &variant_body("new_lease_code", &msg));
@@ -421,16 +508,16 @@ mod tests {
 
     #[test]
     fn open_lease_wire_shape() {
-        let msg = ExecuteMsg::OpenLease {
+        let msg = ExecuteP2P::OpenLease {
             params: open_lease_params(),
-            timeout: OpenLeaseParams::TIMEOUT,
+            timeout: OpenLeaseP2P::TIMEOUT,
         };
         assert_struct_fields(&["params", "timeout"], &variant_body("open_lease", &msg));
     }
 
     #[test]
     fn close_lease_wire_shape() {
-        let msg = ExecuteMsg::CloseLease {
+        let msg = ExecuteP2P::CloseLease {
             params: CloseLeaseParams {},
             timeout: CloseLeaseParams::TIMEOUT,
         };
@@ -439,38 +526,38 @@ mod tests {
 
     #[test]
     fn swap_wire_shape() {
-        let msg = ExecuteMsg::Swap {
-            params: SwapParams::one(
+        let msg = ExecuteP2P::Swap {
+            params: SwapP2P::one(
                 Coin::<PaymentC1>::new(1000).into(),
                 Coin::<PaymentC2>::new(42).into(),
             )
             .expect("distinct non-zero amounts"),
-            timeout: SwapParams::TIMEOUT,
+            timeout: SwapP2P::TIMEOUT,
         };
         assert_struct_fields(&["params", "timeout"], &variant_body("swap", &msg));
     }
 
     #[test]
     fn transfer_out_wire_shape() {
-        let msg = ExecuteMsg::TransferOut {
+        let msg = ExecuteP2P::TransferOut {
             params: TransferOutParams::new(Coin::<PaymentC3>::new(1000).into())
                 .expect("non-zero amount"),
-            timeout: TransferOutParams::TIMEOUT,
+            timeout: TransferOutP2P::TIMEOUT,
         };
         assert_struct_fields(&["params", "timeout"], &variant_body("transfer_out", &msg));
     }
 
-    fn open_lease_params() -> OpenLeaseParams {
+    fn open_lease_params() -> OpenLeaseP2P {
         OpenLeaseParams::new(
             7,
-            currency::dto::<PaymentC1, PaymentGroup>(),
-            currency::dto::<PaymentC2, PaymentGroup>(),
-            currency::dto::<PaymentC3, PaymentGroup>(),
+            currency::dto::<PaymentC1, _>(),
+            currency::dto::<PaymentC2, _>(),
+            currency::dto::<PaymentC3, _>(),
         )
         .expect("three distinct currencies")
     }
 
-    fn variant_body(expected_tag: &str, msg: &ExecuteMsg) -> serde_json::Value {
+    fn variant_body(expected_tag: &str, msg: &ExecuteP2P) -> serde_json::Value {
         let json: serde_json::Value =
             serde_json::to_value(msg).expect("serialization must succeed");
         let mut object = json

--- a/protocol/packages/remote_lease/src/msg.rs
+++ b/protocol/packages/remote_lease/src/msg.rs
@@ -6,6 +6,12 @@ use platform::contract::Code;
 
 use crate::error::Error;
 
+/// The `remote_lease` controller's execute interface.
+///
+/// The currency-group parameters flow into the outbound-packet variants:
+/// `LeaseG` is the leased-asset group, `LpnG` the LPN group, `PaymentG` the
+/// payment/downpayment group (also the group `Swap` and `TransferOut` operate
+/// in). See [`OpenLeaseParams`] for the per-field mapping.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum ExecuteMsg<LeaseG, LpnG, PaymentG>
@@ -46,6 +52,10 @@ where
     },
 }
 
+/// A single cross-chain lease operation on the wire.
+///
+/// The group parameters carry the lease's asset (`LeaseG`), LPN (`LpnG`), and
+/// payment (`PaymentG`) currency groups — see [`OpenLeaseParams`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum Operation<LeaseG, LpnG, PaymentG>
@@ -60,9 +70,14 @@ where
     TransferOut(TransferOutParams<PaymentG>),
 }
 
+/// Parameters of an `OpenLease` operation.
+///
+/// The three currency groups fix which currency each field accepts: `PaymentG`
+/// for `downpayment_currency`, `LpnG` for `lpn_currency`, `LeaseG` for
+/// `asset_currency`. The only enforced inequality is
+/// `lpn_currency != asset_currency`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(
-    bound(serialize = "LeaseG: Serialize, LpnG: Serialize, PaymentG: Serialize"),
     deny_unknown_fields,
     rename_all = "snake_case",
     try_from = "OpenLeaseParamsRaw<LeaseG, LpnG, PaymentG>"
@@ -176,6 +191,7 @@ impl CloseLeaseParams {
 )]
 /// Swap parameters for the remote lease protocol.
 ///
+/// `GIn` is the input-coin group, `GOut` the output (`min_out`) group.
 /// `One` carries a single input coin; `Two` carries two input coins.
 /// All coins must be non-zero and all currencies pairwise distinct.
 pub enum SwapParams<GIn, GOut>
@@ -307,6 +323,8 @@ where
     }
 }
 
+/// Parameters of a `TransferOut` operation: the non-zero `amount` to send out,
+/// in the output group `GOut`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(
     deny_unknown_fields,
@@ -440,14 +458,14 @@ where
     }
 }
 
-impl<LeaseG, Lpns, PaymentG> From<&Operation<LeaseG, Lpns, PaymentG>>
+impl<LeaseG, LpnG, PaymentG> From<&Operation<LeaseG, LpnG, PaymentG>>
     for remote_lease_wire::msg::Operation
 where
     LeaseG: Group,
-    Lpns: Group,
+    LpnG: Group,
     PaymentG: Group,
 {
-    fn from(typed: &Operation<LeaseG, Lpns, PaymentG>) -> Self {
+    fn from(typed: &Operation<LeaseG, LpnG, PaymentG>) -> Self {
         match typed {
             Operation::OpenLease(p) => Self::OpenLease(p.into()),
             Operation::CloseLease(CloseLeaseParams {}) => {

--- a/protocol/packages/remote_lease/src/stub.rs
+++ b/protocol/packages/remote_lease/src/stub.rs
@@ -1,3 +1,6 @@
+use std::marker::PhantomData;
+
+use currency::Group;
 use serde::Serialize;
 
 use finance::duration::Duration;
@@ -6,45 +9,95 @@ use sdk::cosmwasm_std::Addr;
 
 use crate::msg::{CloseLeaseParams, ExecuteMsg, OpenLeaseParams, SwapParams, TransferOutParams};
 
-pub struct Factory<'controller> {
+pub struct Factory<'controller, LeaseG, LpnG, PaymentG>
+where
+    LeaseG: Group,
+    LpnG: Group,
+    PaymentG: Group,
+{
     controller: &'controller Addr,
+    _g_lease: PhantomData<LeaseG>,
+    _g_lpn: PhantomData<LpnG>,
+    _g_payment: PhantomData<PaymentG>,
 }
 
-impl<'controller> Factory<'controller> {
+impl<'controller, LeaseG, LpnG, PaymentG> Factory<'controller, LeaseG, LpnG, PaymentG>
+where
+    LeaseG: Group + Serialize,
+    LpnG: Group + Serialize,
+    PaymentG: Group + Serialize,
+{
     pub const fn new(controller: &'controller Addr) -> Self {
-        Self { controller }
+        Self {
+            controller,
+            _g_lease: PhantomData,
+            _g_lpn: PhantomData,
+            _g_payment: PhantomData,
+        }
     }
 
-    pub fn open(&self, params: OpenLeaseParams, timeout: Duration) -> PlatformResult<Batch> {
+    pub fn open(
+        &self,
+        params: OpenLeaseParams<LeaseG, LpnG, PaymentG>,
+        timeout: Duration,
+    ) -> PlatformResult<Batch> {
         schedule(self.controller, &ExecuteMsg::OpenLease { params, timeout })
     }
 
     pub fn close(&self, params: CloseLeaseParams, timeout: Duration) -> PlatformResult<Batch> {
-        schedule(self.controller, &ExecuteMsg::CloseLease { params, timeout })
+        schedule(
+            self.controller,
+            &ExecuteMsg::<LeaseG, LpnG, PaymentG>::CloseLease { params, timeout },
+        )
     }
 }
 
-pub struct Lease<'controller> {
+pub struct Lease<'controller, LeaseG, LpnG, PaymentG>
+where
+    LeaseG: Group,
+    LpnG: Group,
+    PaymentG: Group,
+{
     controller: &'controller Addr,
+    _g_lease: PhantomData<LeaseG>,
+    _g_lpn: PhantomData<LpnG>,
+    _g_payment: PhantomData<PaymentG>,
 }
 
-impl<'controller> Lease<'controller> {
+impl<'controller, LeaseG, LpnG, PaymentG> Lease<'controller, LeaseG, LpnG, PaymentG>
+where
+    LeaseG: Group + Serialize,
+    LpnG: Group + Serialize,
+    PaymentG: Group + Serialize,
+{
     pub const fn new(controller: &'controller Addr) -> Self {
-        Self { controller }
+        Self {
+            controller,
+            _g_lease: PhantomData,
+            _g_lpn: PhantomData,
+            _g_payment: PhantomData,
+        }
     }
 
-    pub fn swap(&self, params: SwapParams, timeout: Duration) -> PlatformResult<Batch> {
-        schedule(self.controller, &ExecuteMsg::Swap { params, timeout })
-    }
-
-    pub fn transfer_out(
+    pub fn swap(
         &self,
-        params: TransferOutParams,
+        params: SwapParams<PaymentG, PaymentG>,
         timeout: Duration,
     ) -> PlatformResult<Batch> {
         schedule(
             self.controller,
-            &ExecuteMsg::TransferOut { params, timeout },
+            &ExecuteMsg::<LeaseG, LpnG, PaymentG>::Swap { params, timeout },
+        )
+    }
+
+    pub fn transfer_out(
+        &self,
+        params: TransferOutParams<PaymentG>,
+        timeout: Duration,
+    ) -> PlatformResult<Batch> {
+        schedule(
+            self.controller,
+            &ExecuteMsg::<LeaseG, LpnG, PaymentG>::TransferOut { params, timeout },
         )
     }
 }
@@ -72,12 +125,17 @@ mod tests {
 
     use super::{Factory, Lease};
 
+    type FactoryP2P<'controller> = Factory<'controller, PaymentGroup, PaymentGroup, PaymentGroup>;
+    type LeaseP2P<'controller> = Lease<'controller, PaymentGroup, PaymentGroup, PaymentGroup>;
+    type TransferOutP2P = TransferOutParams<PaymentGroup>;
+    type OpenLeaseP2P = OpenLeaseParams<PaymentGroup, PaymentGroup, PaymentGroup>;
+
     #[test]
     fn factory_open_schedules_one_message() {
         let controller = Addr::unchecked("controller");
-        let factory = Factory::new(&controller);
+        let factory = FactoryP2P::new(&controller);
         let batch = factory
-            .open(sample_open_lease_params(), OpenLeaseParams::TIMEOUT)
+            .open(sample_open_lease_params(), OpenLeaseP2P::TIMEOUT)
             .expect("scheduling must succeed");
         assert_eq!(1, batch.len());
     }
@@ -85,7 +143,7 @@ mod tests {
     #[test]
     fn factory_close_schedules_one_message() {
         let controller = Addr::unchecked("controller");
-        let factory = Factory::new(&controller);
+        let factory = FactoryP2P::new(&controller);
         let batch = factory
             .close(CloseLeaseParams {}, CloseLeaseParams::TIMEOUT)
             .expect("scheduling must succeed");
@@ -95,9 +153,12 @@ mod tests {
     #[test]
     fn lease_swap_schedules_one_message() {
         let controller = Addr::unchecked("controller");
-        let lease = Lease::new(&controller);
+        let lease = LeaseP2P::new(&controller);
         let batch = lease
-            .swap(sample_swap_params(), SwapParams::TIMEOUT)
+            .swap(
+                sample_swap_params(),
+                SwapParams::<PaymentGroup, PaymentGroup>::TIMEOUT,
+            )
             .expect("scheduling must succeed");
         assert_eq!(1, batch.len());
     }
@@ -105,14 +166,14 @@ mod tests {
     #[test]
     fn lease_transfer_out_schedules_one_message() {
         let controller = Addr::unchecked("controller");
-        let lease = Lease::new(&controller);
+        let lease = LeaseP2P::new(&controller);
         let batch = lease
-            .transfer_out(sample_transfer_out_params(), TransferOutParams::TIMEOUT)
+            .transfer_out(sample_transfer_out_params(), TransferOutP2P::TIMEOUT)
             .expect("scheduling must succeed");
         assert_eq!(1, batch.len());
     }
 
-    fn sample_open_lease_params() -> OpenLeaseParams {
+    fn sample_open_lease_params() -> OpenLeaseP2P {
         OpenLeaseParams::new(
             7,
             currency::dto::<PaymentC1, PaymentGroup>(),
@@ -122,7 +183,7 @@ mod tests {
         .expect("sample uses three distinct currencies")
     }
 
-    fn sample_swap_params() -> SwapParams {
+    fn sample_swap_params() -> SwapParams<PaymentGroup, PaymentGroup> {
         SwapParams::one(
             Coin::<PaymentC1>::new(1000).into(),
             Coin::<PaymentC2>::new(42).into(),
@@ -130,7 +191,7 @@ mod tests {
         .expect("sample uses two distinct non-zero amounts")
     }
 
-    fn sample_transfer_out_params() -> TransferOutParams {
+    fn sample_transfer_out_params() -> TransferOutParams<PaymentGroup> {
         TransferOutParams::new(Coin::<PaymentC3>::new(1000).into())
             .expect("sample uses a non-zero amount")
     }

--- a/protocol/packages/remote_lease/src/stub.rs
+++ b/protocol/packages/remote_lease/src/stub.rs
@@ -9,6 +9,11 @@ use sdk::cosmwasm_std::Addr;
 
 use crate::msg::{CloseLeaseParams, ExecuteMsg, OpenLeaseParams, SwapParams, TransferOutParams};
 
+/// Builds outbound `OpenLease` / `CloseLease` batches addressed to the
+/// `remote_lease` controller.
+///
+/// Generic over the lease's asset (`LeaseG`), LPN (`LpnG`), and payment
+/// (`PaymentG`) currency groups; see [`OpenLeaseParams`].
 pub struct Factory<'controller, LeaseG, LpnG, PaymentG>
 where
     LeaseG: Group,
@@ -52,6 +57,12 @@ where
     }
 }
 
+/// Builds outbound `Swap` / `TransferOut` batches addressed to the
+/// `remote_lease` controller.
+///
+/// Generic over the lease's asset (`LeaseG`), LPN (`LpnG`), and payment
+/// (`PaymentG`) currency groups; `Swap` and `TransferOut` operate in
+/// `PaymentG`.
 pub struct Lease<'controller, LeaseG, LpnG, PaymentG>
 where
     LeaseG: Group,

--- a/protocol/packages/remote_lease/src/tests.rs
+++ b/protocol/packages/remote_lease/src/tests.rs
@@ -31,13 +31,19 @@ use crate::{
     version::ProtocolVersion,
 };
 
+type OperationP2P = Operation<PaymentGroup, PaymentGroup, PaymentGroup>;
+type PacketEnvelopeP2P = PacketEnvelope<PaymentGroup, PaymentGroup, PaymentGroup>;
+type SwapP2P = SwapParams<PaymentGroup, PaymentGroup>;
+type OpenLeaseP2P = OpenLeaseParams<PaymentGroup, PaymentGroup, PaymentGroup>;
+type TransferOutP2P = TransferOutParams<PaymentGroup>;
+
 // ---------------------------------------------------------------------------
 // 1. Operation variants — round-trip + literal JSON
 // ---------------------------------------------------------------------------
 
 #[test]
 fn open_lease_msg_serde() {
-    let value = Operation::OpenLease(sample_open_lease_params());
+    let value = OperationP2P::OpenLease(sample_open_lease_params());
     assert_round_trip_eq(
         r#"{"open_lease":{"expected_instance_ordinal":7,"downpayment_currency":"NLS","lpn_currency":"LPN","asset_currency":"LC1"}}"#,
         &value,
@@ -46,13 +52,13 @@ fn open_lease_msg_serde() {
 
 #[test]
 fn close_lease_msg_serde() {
-    let value = Operation::CloseLease(CloseLeaseParams {});
+    let value = OperationP2P::CloseLease(CloseLeaseParams {});
     assert_round_trip_eq(r#"{"close_lease":{}}"#, &value);
 }
 
 #[test]
 fn swap_msg_serde() {
-    let value = Operation::Swap(sample_swap_params());
+    let value = OperationP2P::Swap(sample_swap_params());
     assert_round_trip_eq(
         r#"{"swap":{"one":{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}}"#,
         &value,
@@ -61,7 +67,7 @@ fn swap_msg_serde() {
 
 #[test]
 fn swap_msg_two_serde() {
-    let value = Operation::Swap(
+    let value = OperationP2P::Swap(
         SwapParams::two(
             Coin::<PaymentC1>::new(1000).into(),
             Coin::<PaymentC3>::new(500).into(),
@@ -77,7 +83,7 @@ fn swap_msg_two_serde() {
 
 #[test]
 fn transfer_out_msg_serde() {
-    let value = Operation::TransferOut(sample_transfer_out_params());
+    let value = OperationP2P::TransferOut(sample_transfer_out_params());
     assert_round_trip_eq(
         r#"{"transfer_out":{"amount":{"amount":"1000","ticker":"LC1"}}}"#,
         &value,
@@ -179,9 +185,9 @@ fn callback_error_message_deserialize_over_cap_rejected() {
 
 #[test]
 fn packet_envelope_serde() {
-    let value = PacketEnvelope {
+    let value = PacketEnvelopeP2P {
         lease: LeaseAddrOnWire::new("nolus1leaseaddr"),
-        operation: Operation::CloseLease(CloseLeaseParams {}),
+        operation: OperationP2P::CloseLease(CloseLeaseParams {}),
         version: ProtocolVersion,
     };
     assert_round_trip_eq(
@@ -193,14 +199,14 @@ fn packet_envelope_serde() {
 #[test]
 fn packet_envelope_version_mismatch_rejected() {
     let bad_wire = r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}},"version":"nls-remote-lease.v2"}"#;
-    serde_json::from_str::<PacketEnvelope>(bad_wire)
+    serde_json::from_str::<PacketEnvelopeP2P>(bad_wire)
         .expect_err("mismatched protocol version must fail deserialization");
 }
 
 #[test]
 fn packet_envelope_missing_version_rejected() {
     let bad_wire = r#"{"lease":"nolus1leaseaddr","operation":{"close_lease":{}}}"#;
-    serde_json::from_str::<PacketEnvelope>(bad_wire)
+    serde_json::from_str::<PacketEnvelopeP2P>(bad_wire)
         .expect_err("missing version field must fail deserialization");
 }
 
@@ -262,7 +268,7 @@ fn open_lease_params_lpn_equals_asset_rejected() {
 #[test]
 fn open_lease_params_deserialize_invariant_violation_rejected() {
     let bad_wire = r#"{"expected_instance_ordinal":7,"downpayment_currency":"NLS","lpn_currency":"LPN","asset_currency":"LPN"}"#;
-    serde_json::from_str::<OpenLeaseParams>(bad_wire)
+    serde_json::from_str::<OpenLeaseP2P>(bad_wire)
         .expect_err("lpn==asset must fail deserialization");
 }
 
@@ -281,7 +287,7 @@ fn open_lease_params_max_ordinal_accepted() {
 #[test]
 fn open_lease_params_deserialize_above_u16_rejected() {
     let bad_wire = r#"{"expected_instance_ordinal":65536,"downpayment_currency":"NLS","lpn_currency":"LPN","asset_currency":"LC1"}"#;
-    serde_json::from_str::<OpenLeaseParams>(bad_wire)
+    serde_json::from_str::<OpenLeaseP2P>(bad_wire)
         .expect_err("ordinal above u16 range must fail deserialization");
 }
 
@@ -291,7 +297,7 @@ fn open_lease_params_deserialize_above_u16_rejected() {
 
 #[test]
 fn swap_params_one_distinct_currencies_ok() {
-    let params = SwapParams::one(
+    let params = SwapP2P::one(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC2>::new(42).into(),
     )
@@ -301,7 +307,7 @@ fn swap_params_one_distinct_currencies_ok() {
 
 #[test]
 fn swap_params_one_same_currency_rejected() {
-    let res = SwapParams::one(
+    let res = SwapP2P::one(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC1>::new(42).into(),
     );
@@ -310,7 +316,7 @@ fn swap_params_one_same_currency_rejected() {
 
 #[test]
 fn swap_params_one_zero_coin_in_rejected() {
-    let res = SwapParams::one(
+    let res = SwapP2P::one(
         Coin::<PaymentC1>::new(0).into(),
         Coin::<PaymentC2>::new(42).into(),
     );
@@ -319,7 +325,7 @@ fn swap_params_one_zero_coin_in_rejected() {
 
 #[test]
 fn swap_params_one_zero_min_out_rejected() {
-    let res = SwapParams::one(
+    let res = SwapP2P::one(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC2>::new(0).into(),
     );
@@ -329,20 +335,19 @@ fn swap_params_one_zero_min_out_rejected() {
 #[test]
 fn swap_params_one_deserialize_invariant_violation_rejected() {
     let bad_wire = r#"{"one":{"coin_in":{"amount":"1000","ticker":"NLS"},"min_out":{"amount":"42","ticker":"NLS"}}}"#;
-    serde_json::from_str::<SwapParams>(bad_wire)
+    serde_json::from_str::<SwapP2P>(bad_wire)
         .expect_err("invariant violation must fail deserialization");
 }
 
 #[test]
 fn swap_params_one_deserialize_zero_amount_rejected() {
     let bad_wire = r#"{"one":{"coin_in":{"amount":"0","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}"#;
-    serde_json::from_str::<SwapParams>(bad_wire)
-        .expect_err("zero coin_in must fail deserialization");
+    serde_json::from_str::<SwapP2P>(bad_wire).expect_err("zero coin_in must fail deserialization");
 }
 
 #[test]
 fn swap_params_two_distinct_currencies_ok() {
-    let params = SwapParams::two(
+    let params = SwapP2P::two(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC3>::new(500).into(),
         Coin::<PaymentC2>::new(42).into(),
@@ -353,7 +358,7 @@ fn swap_params_two_distinct_currencies_ok() {
 
 #[test]
 fn swap_params_two_zero_coin_in_1_rejected() {
-    let res = SwapParams::two(
+    let res = SwapP2P::two(
         Coin::<PaymentC1>::new(0).into(),
         Coin::<PaymentC3>::new(500).into(),
         Coin::<PaymentC2>::new(42).into(),
@@ -363,7 +368,7 @@ fn swap_params_two_zero_coin_in_1_rejected() {
 
 #[test]
 fn swap_params_two_zero_coin_in_2_rejected() {
-    let res = SwapParams::two(
+    let res = SwapP2P::two(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC3>::new(0).into(),
         Coin::<PaymentC2>::new(42).into(),
@@ -373,7 +378,7 @@ fn swap_params_two_zero_coin_in_2_rejected() {
 
 #[test]
 fn swap_params_two_zero_min_out_rejected() {
-    let res = SwapParams::two(
+    let res = SwapP2P::two(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC3>::new(500).into(),
         Coin::<PaymentC2>::new(0).into(),
@@ -383,7 +388,7 @@ fn swap_params_two_zero_min_out_rejected() {
 
 #[test]
 fn swap_params_two_coin_in_1_same_as_min_out_rejected() {
-    let res = SwapParams::two(
+    let res = SwapP2P::two(
         Coin::<PaymentC2>::new(1000).into(),
         Coin::<PaymentC3>::new(500).into(),
         Coin::<PaymentC2>::new(42).into(),
@@ -393,7 +398,7 @@ fn swap_params_two_coin_in_1_same_as_min_out_rejected() {
 
 #[test]
 fn swap_params_two_coin_in_2_same_as_min_out_rejected() {
-    let res = SwapParams::two(
+    let res = SwapP2P::two(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC2>::new(500).into(),
         Coin::<PaymentC2>::new(42).into(),
@@ -403,7 +408,7 @@ fn swap_params_two_coin_in_2_same_as_min_out_rejected() {
 
 #[test]
 fn swap_params_two_coin_in_1_same_as_coin_in_2_rejected() {
-    let res = SwapParams::two(
+    let res = SwapP2P::two(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC1>::new(500).into(),
         Coin::<PaymentC2>::new(42).into(),
@@ -414,7 +419,7 @@ fn swap_params_two_coin_in_1_same_as_coin_in_2_rejected() {
 #[test]
 fn swap_params_two_deserialize_invariant_violation_rejected() {
     let bad_wire = r#"{"two":{"coin_in_1":{"amount":"1000","ticker":"NLS"},"coin_in_2":{"amount":"500","ticker":"NLS"},"min_out":{"amount":"42","ticker":"LPN"}}}"#;
-    serde_json::from_str::<SwapParams>(bad_wire)
+    serde_json::from_str::<SwapP2P>(bad_wire)
         .expect_err("duplicate input currencies must fail deserialization");
 }
 
@@ -424,21 +429,21 @@ fn swap_params_two_deserialize_invariant_violation_rejected() {
 
 #[test]
 fn transfer_out_params_non_zero_ok() {
-    let params = TransferOutParams::new(Coin::<PaymentC3>::new(1000).into())
+    let params = TransferOutP2P::new(Coin::<PaymentC3>::new(1000).into())
         .expect("non-zero amount must be accepted");
     assert!(params.invariant_held());
 }
 
 #[test]
 fn transfer_out_params_zero_rejected() {
-    let res = TransferOutParams::new(Coin::<PaymentC3>::new(0).into());
+    let res = TransferOutP2P::new(Coin::<PaymentC3>::new(0).into());
     assert!(matches!(res, Err(Error::ZeroTransferAmount)));
 }
 
 #[test]
 fn transfer_out_params_deserialize_zero_rejected() {
     let bad_wire = r#"{"amount":{"amount":"0","ticker":"LC1"}}"#;
-    serde_json::from_str::<TransferOutParams>(bad_wire)
+    serde_json::from_str::<TransferOutP2P>(bad_wire)
         .expect_err("zero amount must fail deserialization");
 }
 
@@ -482,8 +487,8 @@ where
     assert_eq!(value, &decoded);
 }
 
-fn sample_open_lease_params() -> OpenLeaseParams {
-    OpenLeaseParams::new(
+fn sample_open_lease_params() -> OpenLeaseP2P {
+    OpenLeaseP2P::new(
         7,
         currency::dto::<PaymentC1, PaymentGroup>(),
         currency::dto::<PaymentC2, PaymentGroup>(),
@@ -492,15 +497,14 @@ fn sample_open_lease_params() -> OpenLeaseParams {
     .expect("sample uses three distinct currencies")
 }
 
-fn sample_swap_params() -> SwapParams {
-    SwapParams::one(
+fn sample_swap_params() -> SwapP2P {
+    SwapP2P::one(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC2>::new(42).into(),
     )
     .expect("sample uses two distinct non-zero amounts")
 }
 
-fn sample_transfer_out_params() -> TransferOutParams {
-    TransferOutParams::new(Coin::<PaymentC3>::new(1000).into())
-        .expect("sample uses a non-zero amount")
+fn sample_transfer_out_params() -> TransferOutP2P {
+    TransferOutP2P::new(Coin::<PaymentC3>::new(1000).into()).expect("sample uses a non-zero amount")
 }

--- a/protocol/packages/remote_lease/tests/cross_surface.rs
+++ b/protocol/packages/remote_lease/tests/cross_surface.rs
@@ -34,37 +34,43 @@ use remote_lease_wire::{
     msg::Operation as WireOperation, response::OperationResponse as WireResponse,
 };
 
+type OperationP = Operation<PaymentGroup, PaymentGroup, PaymentGroup>;
+type SwapParamsP = SwapParams<PaymentGroup, PaymentGroup>;
+type OpenLeaseParamsP = OpenLeaseParams<PaymentGroup, PaymentGroup, PaymentGroup>;
+type TransferOutParamsP = TransferOutParams<PaymentGroup>;
+type PacketEnvelopeP = PacketEnvelope<PaymentGroup, PaymentGroup, PaymentGroup>;
+
 #[test]
 fn operation_open_lease_byte_identical() {
-    assert_cross_surface_eq::<Operation, WireOperation>(&Operation::OpenLease(open_lease()));
+    assert_cross_surface_eq::<OperationP, WireOperation>(&OperationP::OpenLease(open_lease()));
 }
 
 #[test]
 fn operation_close_lease_byte_identical() {
-    assert_cross_surface_eq::<Operation, WireOperation>(&Operation::CloseLease(
+    assert_cross_surface_eq::<OperationP, WireOperation>(&OperationP::CloseLease(
         CloseLeaseParams {},
     ));
 }
 
 #[test]
 fn operation_swap_byte_identical() {
-    assert_cross_surface_eq::<Operation, WireOperation>(&Operation::Swap(swap()));
+    assert_cross_surface_eq::<OperationP, WireOperation>(&OperationP::Swap(swap()));
 }
 
 #[test]
 fn operation_swap_two_byte_identical() {
-    let params = SwapParams::two(
+    let params = SwapParamsP::two(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC3>::new(500).into(),
         Coin::<PaymentC2>::new(42).into(),
     )
     .expect("three distinct non-zero amounts");
-    assert_cross_surface_eq::<Operation, WireOperation>(&Operation::Swap(params));
+    assert_cross_surface_eq::<OperationP, WireOperation>(&OperationP::Swap(params));
 }
 
 #[test]
 fn operation_transfer_out_byte_identical() {
-    assert_cross_surface_eq::<Operation, WireOperation>(&Operation::TransferOut(transfer_out()));
+    assert_cross_surface_eq::<OperationP, WireOperation>(&OperationP::TransferOut(transfer_out()));
 }
 
 #[test]
@@ -118,12 +124,12 @@ fn callback_operation_timeout_byte_identical() {
 
 #[test]
 fn packet_envelope_byte_identical() {
-    let typed = PacketEnvelope {
+    let typed = PacketEnvelopeP {
         lease: LeaseAddrOnWire::new("nolus1leaseaddr"),
-        operation: Operation::Swap(swap()),
+        operation: OperationP::Swap(swap()),
         version: ProtocolVersion,
     };
-    assert_cross_surface_eq::<PacketEnvelope, WireEnvelope>(&typed);
+    assert_cross_surface_eq::<PacketEnvelopeP, WireEnvelope>(&typed);
 }
 
 fn assert_cross_surface_eq<T, W>(typed: &T)
@@ -141,7 +147,7 @@ where
     );
 }
 
-fn open_lease() -> OpenLeaseParams {
+fn open_lease() -> OpenLeaseParamsP {
     OpenLeaseParams::new(
         7,
         currency::dto::<PaymentC1, PaymentGroup>(),
@@ -151,7 +157,7 @@ fn open_lease() -> OpenLeaseParams {
     .expect("three distinct currencies")
 }
 
-fn swap() -> SwapParams {
+fn swap() -> SwapParamsP {
     SwapParams::one(
         Coin::<PaymentC1>::new(1000).into(),
         Coin::<PaymentC2>::new(42).into(),
@@ -159,6 +165,6 @@ fn swap() -> SwapParams {
     .expect("distinct non-zero amounts")
 }
 
-fn transfer_out() -> TransferOutParams {
+fn transfer_out() -> TransferOutParamsP {
     TransferOutParams::new(Coin::<PaymentC3>::new(1000).into()).expect("non-zero amount")
 }

--- a/tests/src/common/remote_lease_controller_stub.rs
+++ b/tests/src/common/remote_lease_controller_stub.rs
@@ -41,6 +41,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use currencies::{LeaseGroup, Lpns, PaymentGroup};
 use platform::contract::{Code, CodeId};
 use remote_lease::{
     callback::{RemoteErrorMessage, RemoteLeaseCallback},
@@ -108,7 +109,7 @@ pub enum StubExecuteMsg {
         lease_code: Code,
     },
     OpenLease {
-        params: OpenLeaseParams,
+        params: OpenLeaseParams<LeaseGroup, Lpns, PaymentGroup>,
         timeout: finance::duration::Duration,
     },
     CloseLease {
@@ -116,11 +117,11 @@ pub enum StubExecuteMsg {
         timeout: finance::duration::Duration,
     },
     Swap {
-        params: SwapParams,
+        params: SwapParams<PaymentGroup, PaymentGroup>,
         timeout: finance::duration::Duration,
     },
     TransferOut {
-        params: TransferOutParams,
+        params: TransferOutParams<PaymentGroup>,
         timeout: finance::duration::Duration,
     },
     /// Test-only: configure the stand-in's reply for a given op tag.
@@ -313,7 +314,7 @@ fn require_lease_code(
 
 fn synth_open_lease_response(
     storage: &mut dyn Storage,
-    _params: &OpenLeaseParams,
+    _params: &OpenLeaseParams<LeaseGroup, Lpns, PaymentGroup>,
 ) -> Result<OperationResponse, StubError> {
     let next = LEASE_PDA_COUNTER.may_load(storage)?.unwrap_or(0) + 1;
     LEASE_PDA_COUNTER.save(storage, &next)?;


### PR DESCRIPTION
ExecuteMsg, Operation, OpenLeaseParams, SwapParams, TransferOutParams and PacketEnvelope are now generic over the lease's currency groups (asset / LPN / payment) instead of being pinned to PaymentGroup. The controller and the lease-open caller instantiate them at the concrete LeaseGroup / LpnGroup / PaymentGroup. The WireCoin serialization is unchanged, so the on-wire schema is preserved; the genericity lets the swap-over-remote-lease flow carry typed input/output groups end to end.