### PR TITLE
feat: store remote lease controller in Host

### DIFF
--- a/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/open_lease.rs
@@ -121,8 +121,12 @@ impl OpenLease {
         HostAccount::try_from(remote_lease.as_str().to_owned())
             .map_err(ContractError::PlatformError)
             .and_then(|remote_account| {
-                let dex_account =
-                    Account::new(env.contract.address, remote_account, self.new_lease.dex);
+                let dex_account = Account::new(
+                    env.contract.address,
+                    remote_account,
+                    self.new_lease.remote_lease_controller,
+                    self.new_lease.dex,
+                );
                 let next = super::buy_asset::start(
                     self.new_lease.form,
                     dex_account,

--- a/protocol/packages/dex/src/account.rs
+++ b/protocol/packages/dex/src/account.rs
@@ -13,6 +13,7 @@ pub struct Account {
     // converted from the Remote Lease Id, used as destination for outgoing transfers
     // cannot use Remote Account Id because `dex` is protocol-agnostic
     remote: HostAccount,
+    remote_controller: Addr,
     dex: ConnectionParams,
 }
 
@@ -25,8 +26,18 @@ impl Account {
         &self.remote
     }
 
-    pub fn new(owner: Addr, remote: HostAccount, dex: ConnectionParams) -> Self {
-        Self { owner, remote, dex }
+    pub fn new(
+        owner: Addr,
+        remote: HostAccount,
+        remote_controller: Addr,
+        dex: ConnectionParams,
+    ) -> Self {
+        Self {
+            owner,
+            remote,
+            remote_controller,
+            dex,
+        }
     }
 }
 


### PR DESCRIPTION
Host is kept with leases. The aim is to use the controller address when building swap and transfer in transactions.