### PR TITLE
refactor(dex): rename swap trait to Transport and drop Nolus-side routing

### DIFF
--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -1740,7 +1740,6 @@ dependencies = [
  "currency",
  "dex",
  "finance",
- "oracle",
  "platform",
  "prost 0.13.5",
  "sdk",

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
@@ -1,5 +1,3 @@
-use currency::Group;
-use oracle::stub::SwapPath;
 use serde::{Deserialize, Serialize};
 
 use dex::{
@@ -108,10 +106,6 @@ where
 
     fn dex_account(&self) -> &Account {
         &self.lease.dex
-    }
-
-    fn oracle(&self) -> &impl SwapPath<<Self::InG as Group>::TopG> {
-        &self.lease.lease.oracle
     }
 
     fn time_alarm(&self) -> &TimeAlarmsRef {

--- a/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
@@ -1,5 +1,3 @@
-use currency::Group;
-use oracle::stub::SwapPath;
 use serde::{Deserialize, Serialize};
 
 use dex::{
@@ -92,10 +90,6 @@ impl SwapTask for BuyLpn {
 
     fn dex_account(&self) -> &Account {
         &self.lease.dex
-    }
-
-    fn oracle(&self) -> &impl SwapPath<<Self::InG as Group>::TopG> {
-        &self.lease.lease.oracle
     }
 
     fn time_alarm(&self) -> &TimeAlarmsRef {

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/mod.rs
@@ -1,7 +1,6 @@
 use calculator::Factory as CalculatorFactory;
 use currency::{CurrencyDef, Group, MemberOf};
 use finish::BuyAssetFinish;
-use oracle::stub::SwapPath;
 use platform::remote::Account as RemoteAccount;
 use serde::{Deserialize, Serialize};
 
@@ -125,10 +124,6 @@ impl SwapTask for BuyAsset {
 
     fn dex_account(&self) -> &Account {
         &self.dex_account
-    }
-
-    fn oracle(&self) -> &impl SwapPath<<Self::InG as Group>::TopG> {
-        &self.deps.1
     }
 
     fn time_alarm(&self) -> &TimeAlarmsRef {

--- a/protocol/contracts/lease/src/contract/state/paid/transfer_in.rs
+++ b/protocol/contracts/lease/src/contract/state/paid/transfer_in.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use oracle::stub::SwapPath;
 use serde::{Deserialize, Serialize};
 
 use currency::{CurrencyDef, Group, MemberOf};
@@ -96,10 +95,6 @@ impl SwapTask for TransferIn {
 
     fn dex_account(&self) -> &Account {
         &self.lease.dex
-    }
-
-    fn oracle(&self) -> &impl SwapPath<<Self::InG as Group>::TopG> {
-        &self.lease.lease.oracle
     }
 
     fn time_alarm(&self) -> &TimeAlarmsRef {

--- a/protocol/packages/dex/src/impl_/swap_exact_in/encode_req.rs
+++ b/protocol/packages/dex/src/impl_/swap_exact_in/encode_req.rs
@@ -42,11 +42,7 @@ where
     {
         let mut filtered = false;
 
-        let swap_trx = SwapTrx::<'_, '_, '_, <SwapTask::InG as Group>::TopG, _>::new(
-            self.spec.dex_account(),
-            self.spec.oracle(),
-            self.querier,
-        );
+        let swap_trx = SwapTrx::<'_>::new(self.spec.dex_account());
 
         let out_currency = CalculatorT::OutC::dto().into_super_group();
         super::try_filter_fold_coins(

--- a/protocol/packages/dex/src/impl_/trx.rs
+++ b/protocol/packages/dex/src/impl_/trx.rs
@@ -1,46 +1,27 @@
-use std::marker::PhantomData;
-
-use currency::{Group, MemberOf};
+use currency::Group;
 use cw_time::IntoTimestamp;
 use finance::{coin::CoinDTO, instant::Instant};
-use oracle::stub::SwapPath;
 use platform::{
     bank_ibc::remote::Sender as RemoteSender,
     batch::Batch as LocalBatch,
     remote::{self, Account as RemoteAccount},
     trx::Transaction,
 };
-use sdk::cosmwasm_std::QuerierWrapper;
 
 use crate::{Account, Connectable, IBC_TIMEOUT, error::Result, transport::Transport};
 
-pub(super) struct SwapTrx<'ica, 'swap_path, 'querier, SwapGroup, SwapPathImpl> {
+pub(super) struct SwapTrx<'ica> {
     conn: &'ica str,
     ica_account: &'ica RemoteAccount,
     trx: Transaction,
-    swap_path: &'swap_path SwapPathImpl,
-    querier: QuerierWrapper<'querier>,
-    _group: PhantomData<SwapGroup>,
 }
 
-impl<'ica, 'swap_path, 'querier, SwapGroup, SwapPathImpl>
-    SwapTrx<'ica, 'swap_path, 'querier, SwapGroup, SwapPathImpl>
-where
-    SwapGroup: Group,
-    SwapPathImpl: SwapPath<SwapGroup>,
-{
-    pub(super) fn new(
-        ica: &'ica Account,
-        swap_path: &'swap_path SwapPathImpl,
-        querier: QuerierWrapper<'querier>,
-    ) -> Self {
+impl<'ica> SwapTrx<'ica> {
+    pub(super) fn new(ica: &'ica Account) -> Self {
         Self {
             conn: &ica.dex().connection_id,
             ica_account: ica.remote(),
             trx: Transaction::default(),
-            swap_path,
-            querier,
-            _group: PhantomData::<SwapGroup>,
         }
     }
 
@@ -50,32 +31,22 @@ where
         min_amount_out: &CoinDTO<SwapGOut>,
     ) -> Result<()>
     where
-        SwapGIn: Group + MemberOf<SwapGroup>,
-        SwapGOut: Group + MemberOf<SwapGroup>,
+        SwapGIn: Group,
+        SwapGOut: Group,
         TransportImpl: Transport,
     {
-        self.swap_path
-            .swap_path(
-                amount_in.currency().into_super_group::<SwapGIn>(),
-                min_amount_out.currency(),
-                self.querier,
-            )
-            .map_err(Into::into)
-            .and_then(|ref swap_path| {
-                TransportImpl::build_request(
-                    &mut self.trx,
-                    self.ica_account.clone(),
-                    amount_in,
-                    min_amount_out,
-                    swap_path,
-                )
-                .map_err(Into::into)
-            })
+        TransportImpl::build_request(
+            &mut self.trx,
+            self.ica_account.clone(),
+            amount_in,
+            min_amount_out,
+        )
+        .map_err(Into::into)
     }
 }
 
-impl<SwapGroup, SwapPathImpl> From<SwapTrx<'_, '_, '_, SwapGroup, SwapPathImpl>> for LocalBatch {
-    fn from(value: SwapTrx<'_, '_, '_, SwapGroup, SwapPathImpl>) -> Self {
+impl From<SwapTrx<'_>> for LocalBatch {
+    fn from(value: SwapTrx<'_>) -> Self {
         remote::submit_transaction(value.conn, value.trx, "memo", IBC_TIMEOUT)
     }
 }

--- a/protocol/packages/dex/src/lib.rs
+++ b/protocol/packages/dex/src/lib.rs
@@ -10,7 +10,7 @@ pub use self::{
     slippage::{Calculator as SlippageCalculator, WithCalculator},
     swap_task::{CoinsNb, SwapOutputTask, SwapTask, WithOutputTask},
     time_alarm::TimeAlarm,
-    transport::{SwapError, SwapPathSlice, SwapResult, Transport},
+    transport::{SwapError, SwapResult, Transport},
 };
 
 #[cfg(feature = "impl")]

--- a/protocol/packages/dex/src/swap_task.rs
+++ b/protocol/packages/dex/src/swap_task.rs
@@ -1,6 +1,5 @@
 use currency::{CurrencyDef, Group, MemberOf};
 use finance::coin::Coin;
-use oracle::stub::SwapPath;
 use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
@@ -25,7 +24,6 @@ where
 
     fn label(&self) -> Self::Label;
     fn dex_account(&self) -> &Account;
-    fn oracle(&self) -> &impl SwapPath<<Self::InG as Group>::TopG>;
     fn time_alarm(&self) -> &TimeAlarmsRef;
 
     /// Authorise an inbound `RemoteLeaseCallback` against this task's

--- a/protocol/packages/dex/src/transport/mod.rs
+++ b/protocol/packages/dex/src/transport/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "impl")]
 use finance::duration::Duration;
 
-pub use self::remote_lease::{Error as SwapError, Result as SwapResult, SwapPathSlice, Transport};
+pub use self::remote_lease::{Error as SwapError, Result as SwapResult, Transport};
 #[cfg(feature = "impl")]
 pub use self::{
     remote_lease::Factory as RemoteLeaseTransportFactory,

--- a/protocol/packages/dex/src/transport/remote_lease.rs
+++ b/protocol/packages/dex/src/transport/remote_lease.rs
@@ -2,7 +2,6 @@ use thiserror::Error;
 
 use currency::Group;
 use finance::coin::{Amount, CoinDTO};
-use oracle::api::swap::SwapTarget;
 use platform::{remote::Account as RemoteAccount, trx::Transaction};
 use sdk::{api::ProtobufAny, cosmwasm_std::StdError};
 
@@ -28,29 +27,22 @@ pub trait Factory {
         Task: SwapTask;
 }
 
-pub type SwapPathSlice<'a, G> = &'a [SwapTarget<G>];
-
 /// A swap-exact-in against a specific DEX: the request messages it is made of
 /// and the amount read back from its responses.
 ///
 /// Implemented once per supported DEX.
 pub trait Transport {
-    /// `swap_path` should be a non-empty list
-    ///
     /// `GIn` - the group of the input token
     /// `GOut` - the group of the output token
-    /// `GSwap` - the group common for all tokens in the swap path
-    fn build_request<GIn, GOut, GSwap>(
+    fn build_request<GIn, GOut>(
         trx: &mut Transaction,
         sender: RemoteAccount,
         amount_in: &CoinDTO<GIn>,
         min_amount_out: &CoinDTO<GOut>,
-        swap_path: SwapPathSlice<'_, GSwap>,
     ) -> Result<()>
     where
         GIn: Group,
-        GOut: Group,
-        GSwap: Group;
+        GOut: Group;
 
     fn parse_response<I>(trx_resps: &mut I) -> Result<Amount>
     where

--- a/protocol/packages/swap/Cargo.toml
+++ b/protocol/packages/swap/Cargo.toml
@@ -39,7 +39,6 @@ testing = [
 
 [dependencies]
 dex = { workspace = true }
-oracle = { workspace = true, features = ["stub_swap"] }
 
 currency = { workspace = true }
 finance = { workspace = true }

--- a/protocol/packages/swap/src/astroport/mod.rs
+++ b/protocol/packages/swap/src/astroport/mod.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use currency::{self, DexSymbols, Group};
-use dex::{SwapError, SwapPathSlice, SwapResult, Transport};
+use dex::{SwapError, SwapResult, Transport};
 use finance::coin::{Amount, CoinDTO};
 use platform::{
     coin_legacy,
@@ -19,7 +19,7 @@ use sdk::{
 };
 
 use self::{
-    api::{AssetInfo, ExecuteMsg, SwapOperation, SwapResponseData},
+    api::{ExecuteMsg, SwapResponseData},
     router::Router,
 };
 
@@ -61,23 +61,20 @@ impl<R> Transport for GenericImpl<R>
 where
     R: Router,
 {
-    fn build_request<GIn, GOut, GSwap>(
+    fn build_request<GIn, GOut>(
         trx: &mut Transaction,
         sender: HostAccount,
         token_in: &CoinDTO<GIn>,
         min_amount_out: &CoinDTO<GOut>,
-        swap_path: SwapPathSlice<'_, GSwap>,
     ) -> SwapResult<()>
     where
         GIn: Group,
         GOut: Group,
-        GSwap: Group,
     {
-        debug_assert!(!swap_path.is_empty());
         let token_in = to_dex_proto_coin(token_in);
 
         cosmwasm_std::to_json_vec(&ExecuteMsg::ExecuteSwapOperations {
-            operations: to_operations::<GSwap>(&token_in.denom, swap_path),
+            operations: Default::default(),
             minimum_receive: Some(min_amount_out.amount().into()), // request a check on the received amount
             to: None,                                              // means the sender
             max_spread: Some(MAX_IMPACT), // checked on each individual swap operation, if None that would be equivalent to `astroport::pair::DEFAULT_SLIPPAGE`, i.e. 0.5%,
@@ -111,38 +108,6 @@ where
             })
             .map(|swap_resp| swap_resp.return_amount.into())
     }
-}
-
-fn to_operations<G>(token_in_denom: &str, swap_path: SwapPathSlice<'_, G>) -> Vec<SwapOperation>
-where
-    G: Group,
-{
-    struct OperationScan<'a> {
-        last_denom: &'a str,
-    }
-
-    let scanner = OperationScan {
-        last_denom: token_in_denom,
-    };
-
-    swap_path
-        .iter()
-        .map(|swap_target| swap_target.target.into_symbol::<DexSymbols<G>>())
-        .scan(scanner, |scanner, next_denom| {
-            Some({
-                let op = SwapOperation::AstroSwap {
-                    offer_asset_info: AssetInfo::NativeToken {
-                        denom: scanner.last_denom.into(),
-                    },
-                    ask_asset_info: AssetInfo::NativeToken {
-                        denom: next_denom.into(),
-                    },
-                };
-                scanner.last_denom = next_denom;
-                op
-            })
-        })
-        .collect()
 }
 
 fn to_dex_proto_coin<G>(token: &CoinDTO<G>) -> ProtoCoin

--- a/protocol/packages/swap/src/astroport/test.rs
+++ b/protocol/packages/swap/src/astroport/test.rs
@@ -1,14 +1,11 @@
 use currency::{
     CurrencyDef as _,
-    test::{SubGroupTestC6, SubGroupTestC10, SuperGroup, SuperGroupTestC1},
+    test::{SuperGroup, SuperGroupTestC1},
 };
 use finance::coin::Coin;
-use oracle::api::swap::SwapTarget;
 use sdk::cosmos_sdk_proto::cosmos::base::v1beta1::Coin as ProtoCoin;
 
 use crate::testing;
-
-use super::api::{AssetInfo, SwapOperation};
 
 #[test]
 fn to_dex_cwcoin() {
@@ -20,51 +17,6 @@ fn to_dex_cwcoin() {
             amount: coin_amount.to_string(),
         },
         super::to_dex_proto_coin::<SuperGroup>(&coin.into())
-    );
-}
-
-#[test]
-fn to_operations() {
-    type StartSwapCurrency = SubGroupTestC10;
-    let path = vec![
-        SwapTarget {
-            pool_id: 2,
-            target: currency::dto::<SuperGroupTestC1, _>(),
-        },
-        SwapTarget {
-            pool_id: 12,
-            target: currency::dto::<SubGroupTestC6, _>(),
-        },
-    ];
-    let expected = vec![
-        SwapOperation::AstroSwap {
-            offer_asset_info: AssetInfo::NativeToken {
-                denom: StartSwapCurrency::dex().into(),
-            },
-            ask_asset_info: AssetInfo::NativeToken {
-                denom: SuperGroupTestC1::dex().into(),
-            },
-        },
-        SwapOperation::AstroSwap {
-            offer_asset_info: AssetInfo::NativeToken {
-                denom: SuperGroupTestC1::dex().into(),
-            },
-            ask_asset_info: AssetInfo::NativeToken {
-                denom: SubGroupTestC6::dex().into(),
-            },
-        },
-    ];
-    assert_eq!(
-        super::to_operations::<SuperGroup>(StartSwapCurrency::dex(), &path[0..0]),
-        vec![]
-    );
-    assert_eq!(
-        expected[0..1].to_vec(),
-        super::to_operations::<SuperGroup>(StartSwapCurrency::dex(), &path[0..1])
-    );
-    assert_eq!(
-        expected,
-        super::to_operations::<SuperGroup>(StartSwapCurrency::dex(), &path)
     );
 }
 

--- a/protocol/packages/swap/src/astroport/testing.rs
+++ b/protocol/packages/swap/src/astroport/testing.rs
@@ -1,9 +1,8 @@
 use std::any;
 
-use currency::{CurrencyDTO, Group, MemberOf};
+use currency::Group;
 use dex::Transport;
 use finance::coin::{Amount, CoinDTO};
-use oracle::api::swap::SwapTarget;
 use sdk::{
     api::ProtobufAny,
     cosmos_sdk_proto::{
@@ -17,7 +16,7 @@ use crate::testing::{self, ExactAmountInSkel, SwapRequest};
 
 use super::{
     GenericImpl, RequestMsg, ResponseMsg,
-    api::{AssetInfo, ExecuteMsg, SwapOperation, SwapResponseData},
+    api::{ExecuteMsg, SwapResponseData},
     router::Router,
 };
 
@@ -26,10 +25,9 @@ where
     Self: Transport,
     R: Router,
 {
-    fn parse_request<GIn, GSwap>(request: ProtobufAny) -> SwapRequest<GIn, GSwap>
+    fn parse_request<GIn>(request: ProtobufAny) -> SwapRequest<GIn>
     where
-        GIn: Group + MemberOf<GSwap>,
-        GSwap: Group,
+        GIn: Group,
     {
         let RequestMsg {
             sender: _,
@@ -47,7 +45,7 @@ where
         let token_in = parse_one_token_from_vec::<GIn>(funds);
 
         let ExecuteMsg::ExecuteSwapOperations {
-            operations,
+            operations: _operations,
             minimum_receive: Some(min_token_out),
             to: None,
             max_spread: Some(super::MAX_IMPACT),
@@ -61,13 +59,9 @@ where
             testing::pattern_match_else(any::type_name::<RequestMsg>())
         };
 
-        let swap_path =
-            collect_swap_path::<GSwap>(operations, token_in.currency().into_super_group());
-
         SwapRequest {
             token_in,
             min_token_out: min_token_out.into(),
-            swap_path,
         }
     }
 
@@ -82,56 +76,6 @@ where
             (ResponseMsg { data: swap_resp }).encode_to_vec(),
         )
     }
-}
-
-fn collect_swap_path<GSwap>(
-    operations: Vec<SwapOperation>,
-    expected_first_currency: CurrencyDTO<GSwap>,
-) -> Vec<SwapTarget<GSwap>>
-where
-    GSwap: Group,
-{
-    operations
-        .into_iter()
-        .scan(
-            expected_first_currency,
-            |expected_offer_currency, operation| {
-                let SwapOperation::AstroSwap {
-                    offer_asset_info:
-                        AssetInfo::NativeToken {
-                            denom: offer_dex_denom,
-                        },
-                    ask_asset_info:
-                        AssetInfo::NativeToken {
-                            denom: ask_dex_denom,
-                        },
-                } = operation
-                else {
-                    unimplemented!(
-                        r#"Expected "AstroSwap" operation with both assets being native tokens!"#
-                    );
-                };
-
-                let offer_currency = testing::from_dex_symbol::<GSwap>(&offer_dex_denom)
-                    .expect("Offered asset doesn't belong to swapping currency group!");
-                let ask_currency = testing::from_dex_symbol::<GSwap>(&ask_dex_denom)
-                    .expect("Asked asset doesn't belong to swapping currency group!")
-                    .to_owned();
-
-                assert_eq!(
-                    offer_currency, *expected_offer_currency,
-                    "Expected operation's offered denom to be the same as the last asked denom!"
-                );
-
-                *expected_offer_currency = ask_currency;
-
-                Some(SwapTarget {
-                    pool_id: Default::default(),
-                    target: ask_currency,
-                })
-            },
-        )
-        .collect()
 }
 
 fn parse_request_from_any(request: ProtobufAny) -> RequestMsg {

--- a/protocol/packages/swap/src/osmosis/mod.rs
+++ b/protocol/packages/swap/src/osmosis/mod.rs
@@ -1,7 +1,6 @@
 use currency::{DexSymbols, Group};
-use dex::{SwapError, SwapPathSlice, SwapResult, Transport};
+use dex::{SwapError, SwapResult, Transport};
 use finance::coin::{Amount, CoinDTO};
-use oracle::api::swap::SwapTarget;
 use platform::{
     coin_legacy,
     remote::Account as HostAccount,
@@ -12,9 +11,7 @@ use sdk::{
     cosmwasm_std::Coin as CwCoin,
 };
 
-use self::api::{
-    MsgSwapExactAmountIn, MsgSwapExactAmountInResponse, SwapAmountInRoute, TypeUrl as _,
-};
+use self::api::{MsgSwapExactAmountIn, MsgSwapExactAmountInResponse, TypeUrl as _};
 
 mod api;
 #[cfg(test)]
@@ -31,24 +28,21 @@ where
     Self: Transport;
 
 impl Transport for Impl {
-    fn build_request<GIn, GOut, GSwap>(
+    fn build_request<GIn, GOut>(
         trx: &mut Transaction,
         sender: HostAccount,
         amount_in: &CoinDTO<GIn>,
         min_amount_out: &CoinDTO<GOut>,
-        swap_path: SwapPathSlice<'_, GSwap>,
     ) -> SwapResult<()>
     where
         GIn: Group,
         GOut: Group,
-        GSwap: Group,
     {
         // TODO bring the token balances, weights and swapFee-s from the DEX pools
         // into the oracle in order to calculate the tokenOut as per the formula at
         // https://docs.osmosis.zone/osmosis-core/modules/gamm/#swap.
         // Then apply the parameterized maximum slippage to get the minimum amount.
         // For the first version, we accept whatever price impact and slippage.
-        let routes = to_route::<GSwap>(swap_path);
         let token_in = to_dex_cwcoin(amount_in);
         let token_out_min_amount = min_amount_out.amount().to_string();
         to_osmosis_coin(token_in).map(|osmosis_coin| {
@@ -56,7 +50,7 @@ impl Transport for Impl {
                 RequestMsg::TYPE_URL,
                 RequestMsg {
                     sender: sender.into(),
-                    routes,
+                    routes: Default::default(),
                     token_in: Some(osmosis_coin),
                     token_out_min_amount,
                 },
@@ -78,19 +72,6 @@ impl Transport for Impl {
             .map(|response| response.token_out_amount)
             .and_then(|amount| amount.parse().map_err(|_| SwapError::InvalidAmount(amount)))
     }
-}
-
-fn to_route<GSwap>(swap_path: &[SwapTarget<GSwap>]) -> Vec<SwapAmountInRoute>
-where
-    GSwap: Group,
-{
-    swap_path
-        .iter()
-        .map(|swap_target| SwapAmountInRoute {
-            pool_id: swap_target.pool_id,
-            token_out_denom: swap_target.target.into_symbol::<DexSymbols<GSwap>>().into(),
-        })
-        .collect()
 }
 
 fn to_dex_cwcoin<G>(token: &CoinDTO<G>) -> CwCoin

--- a/protocol/packages/swap/src/osmosis/test.rs
+++ b/protocol/packages/swap/src/osmosis/test.rs
@@ -7,8 +7,6 @@ use sdk::cosmwasm_std::Coin as CwCoin;
 
 use crate::testing;
 
-use super::{SwapTarget, api::SwapAmountInRoute};
-
 #[test]
 fn to_dex_cwcoin() {
     let coin: Coin<SuperGroupTestC1> = Coin::new(3541415);
@@ -16,19 +14,6 @@ fn to_dex_cwcoin() {
         CwCoin::new(coin.to_primitive(), SuperGroupTestC1::dex()),
         super::to_dex_cwcoin::<SuperGroup>(&coin.into())
     );
-}
-
-#[test]
-fn into_route() {
-    let path = vec![SwapTarget {
-        pool_id: 2,
-        target: currency::dto::<SuperGroupTestC1, _>(),
-    }];
-    let expected = vec![SwapAmountInRoute {
-        pool_id: 2,
-        token_out_denom: SuperGroupTestC1::dex().into(),
-    }];
-    assert_eq!(expected, super::to_route::<SuperGroup>(&path));
 }
 
 #[test]

--- a/protocol/packages/swap/src/osmosis/testing.rs
+++ b/protocol/packages/swap/src/osmosis/testing.rs
@@ -2,25 +2,20 @@ use std::any::type_name;
 
 use currency::Group;
 use finance::coin::Amount;
-use oracle::api::swap::SwapTarget;
 use sdk::{api::ProtobufAny, cosmos_sdk_proto::prost::Message as _};
 
 use crate::testing::{self, ExactAmountInSkel, SwapRequest};
 
-use super::{
-    Impl, RequestMsg, ResponseMsg,
-    api::{SwapAmountInRoute, TypeUrl as _},
-};
+use super::{Impl, RequestMsg, ResponseMsg, api::TypeUrl as _};
 
 impl ExactAmountInSkel for Impl {
-    fn parse_request<GIn, GSwap>(request: ProtobufAny) -> SwapRequest<GIn, GSwap>
+    fn parse_request<GIn>(request: ProtobufAny) -> SwapRequest<GIn>
     where
         GIn: Group,
-        GSwap: Group,
     {
         let RequestMsg {
             sender: _,
-            routes,
+            routes: _,
             token_in: Some(token_in),
             token_out_min_amount,
         } = parse_request_from_any_and_type_url(request)
@@ -33,21 +28,6 @@ impl ExactAmountInSkel for Impl {
         SwapRequest {
             token_in,
             min_token_out: token_out_min_amount.parse().expect("valid amount integer"),
-            swap_path: routes
-                .into_iter()
-                .map(
-                    |SwapAmountInRoute {
-                         pool_id,
-                         token_out_denom: target,
-                     }| {
-                        SwapTarget {
-                            pool_id,
-                            target: testing::from_dex_symbol(&target)
-                                .expect("Asked asset doesn't belong to swapping currency group!"),
-                        }
-                    },
-                )
-                .collect(),
         }
     }
 

--- a/protocol/packages/swap/src/testing/mod.rs
+++ b/protocol/packages/swap/src/testing/mod.rs
@@ -2,29 +2,25 @@ use std::marker::PhantomData;
 
 use currency::{AnyVisitor, CurrencyDTO, CurrencyDef, DexSymbols, Group, GroupVisit, MemberOf};
 use finance::coin::{Amount, Coin, CoinDTO, NonZeroAmount};
-use oracle::api::swap::SwapTarget;
 use sdk::api::ProtobufAny;
 
 #[cfg(test)]
 mod tests;
 
 pub trait ExactAmountInSkel {
-    fn parse_request<GIn, GSwap>(request: ProtobufAny) -> SwapRequest<GIn, GSwap>
+    fn parse_request<GIn>(request: ProtobufAny) -> SwapRequest<GIn>
     where
-        GIn: Group + MemberOf<GSwap>,
-        GSwap: Group;
+        GIn: Group;
 
     fn build_response(amount_out: Amount) -> ProtobufAny;
 }
 
-pub struct SwapRequest<GIn, GSwap>
+pub struct SwapRequest<GIn>
 where
     GIn: Group,
-    GSwap: Group,
 {
     pub token_in: CoinDTO<GIn>,
     pub min_token_out: Amount,
-    pub swap_path: Vec<SwapTarget<GSwap>>,
 }
 
 pub(crate) fn parse_dex_token<G>(amount: &str, denom: &str) -> CoinDTO<G>

--- a/protocol/packages/swap/src/testing/tests/request.rs
+++ b/protocol/packages/swap/src/testing/tests/request.rs
@@ -1,7 +1,6 @@
-use currency::test::{SubGroup, SubGroupTestC10, SuperGroup, SuperGroupTestC2, SuperGroupTestC3};
-use dex::{SwapPathSlice, Transport};
+use currency::test::{SubGroup, SubGroupTestC10, SuperGroup, SuperGroupTestC2};
+use dex::Transport;
 use finance::coin::{Coin, CoinDTO};
-use oracle::api::swap::SwapTarget;
 use platform::trx::Transaction;
 use sdk::api::ProtobufAny;
 
@@ -15,35 +14,20 @@ fn build_and_parse() {
     let expected_token_in = Coin::<SubGroupTestC10>::new(20).into();
     let expected_token_out = Coin::<SuperGroupTestC2>::new(2).into();
 
-    let expected_swap_path = vec![
-        SwapTarget {
-            pool_id: 0,
-            target: currency::dto::<SuperGroupTestC2, _>(),
-        },
-        SwapTarget {
-            pool_id: 0,
-            target: currency::dto::<SuperGroupTestC3, _>(),
-        },
-    ];
-
-    let request: ProtobufAny =
-        build_request(&expected_token_in, &expected_token_out, &expected_swap_path);
+    let request: ProtobufAny = build_request(&expected_token_in, &expected_token_out);
 
     let SwapRequest {
         token_in,
         min_token_out: min_amount_out,
-        swap_path,
     } = <Impl as ExactAmountInSkel>::parse_request(request);
 
     assert_eq!(token_in, expected_token_in);
     assert_eq!(min_amount_out, expected_token_out.amount());
-    assert_eq!(swap_path, expected_swap_path);
 }
 
 fn build_request(
     expected_token_in: &CoinDTO<SubGroup>,
     expected_token_out: &CoinDTO<SuperGroup>,
-    expected_swap_path: SwapPathSlice<'_, SuperGroup>,
 ) -> ProtobufAny {
     let mut tx = Transaction::default();
 
@@ -52,7 +36,6 @@ fn build_request(
         String::from("host_account").try_into().unwrap(),
         expected_token_in,
         expected_token_out,
-        expected_swap_path,
     )
     .unwrap();
 

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -1755,7 +1755,6 @@ dependencies = [
  "currency",
  "dex",
  "finance",
- "oracle",
  "platform",
  "prost 0.13.5",
  "sdk",

--- a/tests/src/common/lease.rs
+++ b/tests/src/common/lease.rs
@@ -1,5 +1,5 @@
 use currencies::{LeaseGroup, Lpn, PaymentGroup};
-use currency::{Currency, CurrencyDTO, CurrencyDef};
+use currency::{Currency, CurrencyDTO, CurrencyDef, SymbolStatic};
 use dex::{ConnectionParams, Ics20Channel};
 use finance::{
     coin::Coin,
@@ -216,6 +216,7 @@ pub(crate) fn complete_initialization<DownpaymentC, Lpn>(
     lease_addr: Addr,
     downpayment: Coin<DownpaymentC>,
     exp_borrow: Coin<Lpn>,
+    out_denom: SymbolStatic,
 ) where
     DownpaymentC: CurrencyDef,
     Lpn: CurrencyDef,
@@ -231,7 +232,7 @@ pub(crate) fn complete_initialization<DownpaymentC, Lpn>(
         (downpayment, exp_borrow),
     );
 
-    let requests: Vec<SwapRequest<PaymentGroup, PaymentGroup>> = super::swap::expect_swap(
+    let requests: Vec<SwapRequest<PaymentGroup>> = super::swap::expect_swap(
         response,
         connection_id,
         TestCase::LEASE_ICA_ID,
@@ -247,6 +248,7 @@ pub(crate) fn complete_initialization<DownpaymentC, Lpn>(
         lease_addr.clone(),
         remote,
         requests.into_iter(),
+        out_denom,
         |price, _, _| price,
     )
     .ignore_response()

--- a/tests/src/common/swap.rs
+++ b/tests/src/common/swap.rs
@@ -48,11 +48,11 @@ pub(crate) fn expect_swap<InspectFn>(
     connection_id: &str,
     ica_id: &str,
     inspect_fn: InspectFn,
-) -> Vec<SwapRequest<PaymentGroup, PaymentGroup>>
+) -> Vec<SwapRequest<PaymentGroup>>
 where
     InspectFn: FnOnce(&AppResponse),
 {
-    let requests: Vec<SwapRequest<PaymentGroup, PaymentGroup>> = response
+    let requests: Vec<SwapRequest<PaymentGroup>> = response
         .expect_submit_tx(connection_id, ica_id)
         .into_iter()
         .map(|msg: ProtobufAny| <Impl as ExactAmountInSkel>::parse_request(msg))
@@ -68,37 +68,39 @@ pub(crate) fn do_swap<I, F>(
     initiator_contract_addr: Addr,
     ica_addr: Addr,
     requests: I,
+    out_denom: SymbolStatic,
     price_f: F,
 ) -> ResponseWithInterChainMsgs<'_, AppResponse>
 where
-    I: Iterator<Item = SwapRequest<PaymentGroup, PaymentGroup>>,
+    I: Iterator<Item = SwapRequest<PaymentGroup>>,
     F: for<'r, 't> FnMut(Amount, DexDenom<'r>, DexDenom<'t>) -> Amount,
 {
-    do_swap_with::<PaymentGroup, PaymentGroup, I, F>(
+    do_swap_with::<PaymentGroup, I, F>(
         app,
         initiator_contract_addr,
         ica_addr,
         requests,
+        out_denom,
         price_f,
     )
 }
 
-pub(crate) fn do_swap_with<GIn, GSwap, I, F>(
+pub(crate) fn do_swap_with<GIn, I, F>(
     app: &mut App,
     initiator_contract_addr: Addr,
     ica_addr: Addr,
     requests: I,
+    out_denom: SymbolStatic,
     mut price_f: F,
 ) -> ResponseWithInterChainMsgs<'_, AppResponse>
 where
     GIn: Group,
-    GSwap: Group,
-    I: Iterator<Item = SwapRequest<GIn, GSwap>>,
+    I: Iterator<Item = SwapRequest<GIn>>,
     F: for<'r, 't> FnMut(Amount, DexDenom<'r>, DexDenom<'t>) -> Amount,
 {
     let amounts: Vec<Amount> = requests
-        .map(|request: SwapRequest<GIn, GSwap>| {
-            do_swap_internal::<GIn, GSwap, _>(app, ica_addr.clone(), request, &mut price_f)
+        .map(|request: SwapRequest<GIn>| {
+            do_swap_internal::<GIn, _>(app, ica_addr.clone(), request, out_denom, &mut price_f)
         })
         .collect();
 
@@ -112,19 +114,17 @@ pub(crate) fn do_swap_with_error(
     send_error_response(app, requester_contract)
 }
 
-fn do_swap_internal<GIn, GSwap, F>(
+fn do_swap_internal<GIn, F>(
     app: &mut App,
     ica_addr: Addr,
-    request: SwapRequest<GIn, GSwap>,
+    request: SwapRequest<GIn>,
+    out_denom: SymbolStatic,
     price_f: &mut F,
 ) -> Amount
 where
     GIn: Group,
-    GSwap: Group,
     F: for<'r, 't> FnMut(Amount, DexDenom<'r>, DexDenom<'t>) -> Amount,
 {
-    assert!(!request.swap_path.is_empty());
-
     let dex_denom_in: SymbolStatic = request.token_in.currency().into_symbol::<DexSymbols<GIn>>();
     let amount_in = request.token_in.amount();
 
@@ -135,21 +135,12 @@ where
     )
     .unwrap();
 
-    let (amount_out, dex_denom_out) = request.swap_path.iter().fold(
-        (amount_in, dex_denom_in),
-        |(amount_in, dex_denom_in), swap_target| {
-            let dex_denom_out = swap_target.target.into_symbol::<DexSymbols<GSwap>>();
-
-            let amount_out = price_f(amount_in, DexDenom(dex_denom_in), DexDenom(dex_denom_out));
-
-            (amount_out, dex_denom_out)
-        },
-    );
+    let amount_out = price_f(amount_in, DexDenom(dex_denom_in), DexDenom(out_denom));
 
     app.send_tokens(
         testing::user(ADMIN),
         ica_addr,
-        &[CwCoin::new(amount_out, dex_denom_out)],
+        &[CwCoin::new(amount_out, out_denom)],
     )
     .unwrap();
 

--- a/tests/src/lease/close_policy/trigger.rs
+++ b/tests/src/lease/close_policy/trigger.rs
@@ -70,7 +70,7 @@ fn trigger_close(
         common::coin::<LpnCurrency>(quote),
     );
 
-    let requests: Vec<SwapRequest<PaymentGroup, PaymentGroup>> = swap::expect_swap(
+    let requests: Vec<SwapRequest<PaymentGroup>> = swap::expect_swap(
         response,
         TestCase::DEX_CONNECTION_ID,
         TestCase::LEASE_ICA_ID,

--- a/tests/src/lease/close_position.rs
+++ b/tests/src/lease/close_position.rs
@@ -284,7 +284,7 @@ fn do_close(
         &ExecuteMsg::ClosePosition(close_msg),
     );
 
-    let requests: Vec<SwapRequest<PaymentGroup, PaymentGroup>> = common::swap::expect_swap(
+    let requests: Vec<SwapRequest<PaymentGroup>> = common::swap::expect_swap(
         response_close,
         TestCase::DEX_CONNECTION_ID,
         TestCase::LEASE_ICA_ID,
@@ -296,6 +296,7 @@ fn do_close(
         lease_addr.clone(),
         lease_ica.clone(),
         requests.into_iter(),
+        LpnCurrency::dex(),
         |amount: Amount, _, _| {
             assert_eq!(amount, close_amount.to_primitive());
 

--- a/tests/src/lease/liquidation/price.rs
+++ b/tests/src/lease/liquidation/price.rs
@@ -95,7 +95,7 @@ fn full_liquidation() {
         common::coin(borrowed_amount),
     );
 
-    let requests: Vec<SwapRequest<PaymentGroup, PaymentGroup>> = common::swap::expect_swap(
+    let requests: Vec<SwapRequest<PaymentGroup>> = common::swap::expect_swap(
         response,
         TestCase::DEX_CONNECTION_ID,
         TestCase::LEASE_ICA_ID,
@@ -107,6 +107,7 @@ fn full_liquidation() {
         lease_addr.clone(),
         ica_addr.clone(),
         requests.into_iter(),
+        LpnCurrency::dex(),
         |amount, _, _| {
             assert_eq!(amount, lease_amount);
 

--- a/tests/src/lease/liquidation/time.rs
+++ b/tests/src/lease/liquidation/time.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use currencies::PaymentGroup;
+use currency::CurrencyDef as _;
 use finance::{coin::Amount, duration::Duration, price, zero::Zero};
 use lease::api::{ExecuteMsg, query::StateResponse};
 use platform::coin_legacy;
@@ -13,7 +14,7 @@ use crate::{
         leaser::Instantiator as LeaserInstantiator,
         test_case::{TestCase, response::ResponseWithInterChainMsgs},
     },
-    lease::{self as lease_test, LeaseCoin, PaymentCurrency},
+    lease::{self as lease_test, LeaseCoin, LpnCurrency, PaymentCurrency},
 };
 
 use super::super::LeaseTestCase;
@@ -57,7 +58,7 @@ fn liquidation_time_alarm(
         return;
     };
 
-    let requests: Vec<SwapRequest<PaymentGroup, PaymentGroup>> = crate::common::swap::expect_swap(
+    let requests: Vec<SwapRequest<PaymentGroup>> = crate::common::swap::expect_swap(
         response,
         TestCase::DEX_CONNECTION_ID,
         TestCase::LEASE_ICA_ID,
@@ -71,6 +72,7 @@ fn liquidation_time_alarm(
         lease_addr.clone(),
         ica_addr.clone(),
         requests.into_iter(),
+        LpnCurrency::dex(),
         |amount, _, _| amount,
     )
     .ignore_response();

--- a/tests/src/lease/mod.rs
+++ b/tests/src/lease/mod.rs
@@ -293,6 +293,7 @@ pub(super) fn complete_init_lease<
         lease.clone(),
         downpayment,
         exp_borrow,
+        LeaseCurrency::dex(),
     );
 }
 

--- a/tests/src/lease/remote_lease_callback.rs
+++ b/tests/src/lease/remote_lease_callback.rs
@@ -142,11 +142,7 @@ fn operation_ok_activates_safe_delivery() {
     );
 }
 
-fn drive_to_swap_pending() -> (
-    LeaseTestCase,
-    Addr,
-    Vec<SwapRequest<PaymentGroup, PaymentGroup>>,
-) {
+fn drive_to_swap_pending() -> (LeaseTestCase, Addr, Vec<SwapRequest<PaymentGroup>>) {
     let mut test_case = super::create_test_case::<LeaseCurrency>();
     let downpayment = LeaseCoin::new(10_000);
     let lease = super::try_init_lease(&mut test_case, downpayment, None);

--- a/tests/src/lease/repay.rs
+++ b/tests/src/lease/repay.rs
@@ -315,7 +315,7 @@ where
 
     let paid = price::total(payment, super::price_lpn_of()).unwrap();
 
-    let requests: Vec<SwapRequest<PaymentGroup, PaymentGroup>> = swap::expect_swap(
+    let requests: Vec<SwapRequest<PaymentGroup>> = swap::expect_swap(
         response,
         TestCase::DEX_CONNECTION_ID,
         TestCase::LEASE_ICA_ID,
@@ -337,6 +337,7 @@ where
         lease.clone(),
         lease_ica.clone(),
         requests.into_iter(),
+        LpnCurrency::dex(),
         |amount_in, in_denom, out_denom| {
             assert_eq!(amount_in, payment.to_primitive());
             assert_eq!(in_denom, PaymentCurrency::dex());

--- a/tests/src/lease/slippage.rs
+++ b/tests/src/lease/slippage.rs
@@ -110,7 +110,7 @@ fn full_liquidation_heal_sl_close() {
             testing::user(LEASE_ADMIN),
         );
 
-        let requests: Vec<SwapRequest<PaymentGroup, PaymentGroup>> = common::swap::expect_swap(
+        let requests: Vec<SwapRequest<PaymentGroup>> = common::swap::expect_swap(
             heal_response,
             TestCase::DEX_CONNECTION_ID,
             TestCase::LEASE_ICA_ID,
@@ -145,7 +145,7 @@ fn full_liquidation_heal_full_liquidation() {
             testing::user(LEASE_ADMIN),
         );
 
-        let requests: Vec<SwapRequest<PaymentGroup, PaymentGroup>> = common::swap::expect_swap(
+        let requests: Vec<SwapRequest<PaymentGroup>> = common::swap::expect_swap(
             heal_response,
             TestCase::DEX_CONNECTION_ID,
             TestCase::LEASE_ICA_ID,
@@ -171,7 +171,7 @@ fn trigger_full_liquidation(
     // the base is chosen to be close to the position amount to trigger a full liquidation
     let response =
         lease_mod::deliver_new_price(test_case, lease_amount + common::coin(10), borrowed_amount);
-    let requests: Vec<SwapRequest<PaymentGroup, PaymentGroup>> = common::swap::expect_swap(
+    let requests: Vec<SwapRequest<PaymentGroup>> = common::swap::expect_swap(
         response,
         TestCase::DEX_CONNECTION_ID,
         TestCase::LEASE_ICA_ID,
@@ -228,7 +228,7 @@ fn deliver_high_price(
 
 fn assert_min_out(
     test_case: &LeaseTestCase,
-    requests: &[SwapRequest<PaymentGroup, PaymentGroup>],
+    requests: &[SwapRequest<PaymentGroup>],
     lease_amount: LeaseCoin,
 ) {
     let price: Price<_, _> = oracle_mod::fetch_price::<LeaseCurrency, LeaseGroup, Lpn, Lpns>(
@@ -246,6 +246,6 @@ fn assert_min_out(
     );
 }
 
-fn assert_any_min_out(requests: &[SwapRequest<PaymentGroup, PaymentGroup>]) {
+fn assert_any_min_out(requests: &[SwapRequest<PaymentGroup>]) {
     assert_eq!(LeaseCoin::new(1), common::coin(requests[0].min_token_out));
 }

--- a/tests/src/leaser/open_lease.rs
+++ b/tests/src/leaser/open_lease.rs
@@ -322,6 +322,7 @@ where
         lease,
         downpayment,
         exp_borrow,
+        LeaseC::dex(),
     );
 }
 


### PR DESCRIPTION
Part of the #739 swap-over-remote-lease series (follows the merged transport-factory work in #743).

## What
- Renames the swap trait `ExactAmountIn` → `Transport` and its associated type to `TransportImpl`; documents the `Transport` and `Factory` traits.
- Removes swap-path/route resolution from `Transport`: `build_request` drops the `swap_path`/`SwapPathSlice`/`GSwap` parameter and the per-DEX route builders (osmosis `to_route`, astroport `to_operations`). `routes`/`operations` are now emitted empty.
- Removes the now-dead `SwapTask::oracle()` accessor, its four lease impls, and the `oracle::stub::SwapPath` usages; drops the swap crate's unused `oracle` dependency.
- Reduces the swap test harness to a single hop (explicit output denom instead of a path walk).

## Why
Nolus stops building DEX-specific swap instructions; the remote executor becomes responsible for routing. This is the mechanical trait-signature step — no behaviour change ships beyond the empty-route stub, which is inert until the remote-side routing lands.

## Deferred to the next step (#739 PR-4)
`oracle::stub::SwapPath` (trait + `OracleRef` impl) is now dead but retained: it is entangled with the oracle `stub_swap` feature, which still gates the live `QueryMsg::SwapPath` query, `SwapTarget`, and the cargo-each build matrix. Its removal, together with the remote `ExecuteMsg::Swap` dispatch and the integration-test re-authoring, belongs to the follow-up.

## Validation
`cargo build`, `cargo fmt --all -- --check`, `cargo lint`, and `cargo run-test` all pass across the protocol and tests workspaces (integration suite: 119 tests × 3 DEX feature combos, 0 failures).
