### PR TITLE
feat(admin): add `Solana` network and `Metis` DEX variants.

### DIFF
--- a/platform/contracts/admin/src/contracts/protocol/mod.rs
+++ b/platform/contracts/admin/src/contracts/protocol/mod.rs
@@ -45,6 +45,7 @@ impl<T> FirstOrderType<higher_order_type::Protocol> for Protocol<T> {
 pub enum Network {
     Neutron,
     Osmosis,
+    Solana,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -55,6 +56,7 @@ pub enum Network {
 )]
 pub enum Dex {
     Astroport { router_address: String },
+    Metis,
     Osmosis,
 }
 
@@ -81,8 +83,31 @@ mod tests {
         );
 
         assert_eq!(
+            cosmwasm_std::from_json::<super::Dex>(r#""Metis""#).unwrap(),
+            super::Dex::Metis {}
+        );
+
+        assert_eq!(
             cosmwasm_std::from_json::<super::Dex>(r#""Osmosis""#).unwrap(),
             super::Dex::Osmosis {}
+        );
+    }
+
+    #[test]
+    fn test_network_serde() {
+        assert_eq!(
+            cosmwasm_std::from_json::<super::Network>(r#""Neutron""#).unwrap(),
+            super::Network::Neutron {}
+        );
+
+        assert_eq!(
+            cosmwasm_std::from_json::<super::Network>(r#""Osmosis""#).unwrap(),
+            super::Network::Osmosis {}
+        );
+
+        assert_eq!(
+            cosmwasm_std::from_json::<super::Network>(r#""Solana""#).unwrap(),
+            super::Network::Solana {}
         );
     }
 }


### PR DESCRIPTION
## What

Adds `Solana` to `Network` and a unit `Metis` variant to `Dex` in the admin contract's protocol registry (`platform/contracts/admin/src/contracts/protocol/mod.rs`), plus serde wire-form tests for the new variants (`"Solana"`, `"Metis"`).

## Why

`Protocol { network, dex, contracts }` requires both fields, so a Solana-based protocol (paired with the `remote_lease` controller) could not be registered. `Metis` carries no fields: no on-chain code consumes `Dex` payload data (even `Astroport::router_address` has no consumers), and swap routing for Solana protocols executes on the Solana side.

## Deploy order

`treasury` deserializes the full `Protocol<Addr>` when querying the admin registry; a treasury binary built before this change fails to decode a protocol stored with `"Solana"`/`"Metis"`. Rebuild/redeploy `treasury` with the updated `admin_contract` dependency before registering a Solana protocol on-chain.

## Verification

- `cargo check` / `cargo clippy -- -D warnings` on `admin_contract` under no-features, `contract`-only, and `--all-features` configurations
- Platform workspace: `cargo build --all-targets`, `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run` (306 passed)

No other change sites exist: nothing in the workspace dispatches on `Network`/`Dex` — the registry stores and echoes them verbatim, and `scripts/deploy-protocol.sh` passes both through unmodified.