### PR TITLE
feat(dex,lease): route remote swap errors by cause, not by leg

### DIFF
--- a/platform/Cargo.lock
+++ b/platform/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "admin_contract"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "access-control",
  "cosmwasm-std",
@@ -966,7 +966,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "lpp-platform"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "currency",
  "finance",
@@ -1063,7 +1063,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "platform"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64",
  "currency",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "timealarms"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "access-control",
  "cosmwasm-std",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "treasury"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "access-control",
  "admin_contract",

--- a/platform/contracts/admin/Cargo.toml
+++ b/platform/contracts/admin/Cargo.toml
@@ -2,7 +2,7 @@ lints = { workspace = true }
 
 [package]
 name = "admin_contract"
-version = "0.6.3"
+version = "0.6.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/platform/contracts/timealarms/Cargo.toml
+++ b/platform/contracts/timealarms/Cargo.toml
@@ -2,7 +2,7 @@ lints = { workspace = true }
 
 [package]
 name = "timealarms"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/platform/contracts/treasury/Cargo.toml
+++ b/platform/contracts/treasury/Cargo.toml
@@ -2,7 +2,7 @@ lints = { workspace = true }
 
 [package]
 name = "treasury"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/platform/packages/lpp/Cargo.toml
+++ b/platform/packages/lpp/Cargo.toml
@@ -2,7 +2,7 @@ lints = { workspace = true }
 
 [package]
 name = "lpp-platform"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/platform/packages/platform/Cargo.toml
+++ b/platform/packages/platform/Cargo.toml
@@ -2,7 +2,7 @@ lints = { workspace = true }
 
 [package]
 name = "platform"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/platform/packages/platform/src/remote.rs
+++ b/platform/packages/platform/src/remote.rs
@@ -12,10 +12,12 @@ use crate::{error::Error, result::Result};
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct Account(String);
 
-/// Error response to a remote account request
+/// Why a remote-chain operation failed, as the remote side described it
 ///
 /// Contains an unstructured text, that is helpful for manual troubleshooting.
-pub struct ErrorResponse {
+/// Deliberately says nothing about which transport carried the failure — an
+/// interchain account and the remote-lease controller both report through it.
+pub struct ErrorDetails {
     details: String,
 }
 
@@ -49,13 +51,13 @@ impl Display for Account {
     }
 }
 
-impl Display for ErrorResponse {
+impl Display for ErrorDetails {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_fmt(format_args!("ICA error with details '{}'", self.details))
+        f.write_fmt(format_args!("remote error with details '{}'", self.details))
     }
 }
 
-impl From<String> for ErrorResponse {
+impl From<String> for ErrorDetails {
     fn from(details: String) -> Self {
         Self { details }
     }

--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "admin_contract"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "access-control",
  "currency",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "dex"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "access-control",
  "currency",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "lease"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "access-control",
  "cosmwasm-std",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "leaser"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "access-control",
  "admin_contract",
@@ -1053,7 +1053,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "lpp"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "access-control",
  "cosmwasm-std",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "lpp-platform"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "currency",
  "finance",
@@ -1202,7 +1202,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "platform"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "currency",
  "cw-time",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "remote_lease"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "currencies",
  "currency",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "remote_lease_controller"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "access-control",
  "cosmwasm-std",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "reserve"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "access-control",
  "cosmwasm-std",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "timealarms"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "access-control",
  "cw-time",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "void"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cosmwasm-std",
  "platform",

--- a/protocol/contracts/lease/Cargo.toml
+++ b/protocol/contracts/lease/Cargo.toml
@@ -2,7 +2,7 @@ lints = { workspace = true }
 
 [package]
 name = "lease"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/protocol/contracts/lease/src/contract/api.rs
+++ b/protocol/contracts/lease/src/contract/api.rs
@@ -1,9 +1,9 @@
 use enum_dispatch::enum_dispatch;
 
 use crate::api::LeasePaymentCurrencies;
+use dex::ErrorAck;
 use finance::duration::Duration;
 use finance::instant::Instant;
-use platform::remote::ErrorResponse as ICAErrorResponse;
 use remote_lease::callback::RemoteLeaseCallback;
 use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply};
 
@@ -33,11 +33,11 @@ where
 
     fn on_dex_error(
         self,
-        resp: ICAErrorResponse,
+        error: ErrorAck,
         _querier: QuerierWrapper<'_>,
         _env: Env,
     ) -> ContractResult<Response> {
-        err(format!("dex error({resp})",))
+        err(format!("dex error({error})",))
     }
 
     fn on_dex_timeout(self, _querier: QuerierWrapper<'_>, _env: Env) -> ContractResult<Response> {

--- a/protocol/contracts/lease/src/contract/endpoins.rs
+++ b/protocol/contracts/lease/src/contract/endpoins.rs
@@ -1,5 +1,6 @@
 use access_control::permissions::DexResponseSafeDeliveryPermission;
 use cw_time::IntoInstant;
+use dex::{AnomalyCause, ErrorAck};
 use finance::duration::Duration;
 use platform::{
     contract::{self, Validator},
@@ -183,9 +184,11 @@ fn process_sudo(
             request: _,
             details,
         } => {
-            let resp = details.into();
-            api.debug(&format!("SudoMsg::Error({resp})"));
-            state.on_dex_error(resp, querier, env)
+            // Not a swap ack: the ICA path carries no classified cause, and the
+            // only leg reachable through it re-emits regardless of one.
+            let error = ErrorAck::new(AnomalyCause::Other, details.into());
+            api.debug(&format!("SudoMsg::Error({error})"));
+            state.on_dex_error(error, querier, env)
         }
         SudoMsg::Timeout { request: _ } => state.on_dex_timeout(querier, env),
         SudoMsg::OpenAck { .. } => Err(ContractError::unsupported_operation("sudo open ack")),

--- a/protocol/contracts/lease/src/contract/state/dex.rs
+++ b/protocol/contracts/lease/src/contract/state/dex.rs
@@ -4,7 +4,7 @@ use crate::api::LeasePaymentCurrencies;
 use dex::{AnomalyCause, Contract as DexContract, ErrorAck, Handler as DexHandler};
 use finance::duration::Duration;
 use finance::instant::Instant;
-use platform::{remote::ErrorResponse as ICAErrorResponse, state_machine};
+use platform::{remote::ErrorDetails as RemoteErrorDetails, state_machine};
 use remote_lease::callback::{RemoteErrorKind, RemoteLeaseCallback};
 use sdk::cosmwasm_std::{self, Binary, Env, MessageInfo, QuerierWrapper, Reply};
 
@@ -79,7 +79,7 @@ where
                 RemoteLeaseCallback::OperationErr(error) => self.on_dex_error(
                     ErrorAck::new(
                         classify(error.kind()),
-                        ICAErrorResponse::from(error.message().as_str().to_owned()),
+                        RemoteErrorDetails::from(error.message().as_str().to_owned()),
                     ),
                     querier,
                     env,

--- a/protocol/contracts/lease/src/contract/state/dex.rs
+++ b/protocol/contracts/lease/src/contract/state/dex.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
 
 use crate::api::LeasePaymentCurrencies;
-use dex::{Contract as DexContract, Handler as DexHandler};
+use dex::{AnomalyCause, Contract as DexContract, ErrorAck, Handler as DexHandler};
 use finance::duration::Duration;
 use finance::instant::Instant;
 use platform::{remote::ErrorResponse as ICAErrorResponse, state_machine};
-use remote_lease::callback::RemoteLeaseCallback;
+use remote_lease::callback::{RemoteErrorKind, RemoteLeaseCallback};
 use sdk::cosmwasm_std::{self, Binary, Env, MessageInfo, QuerierWrapper, Reply};
 
 use crate::{
@@ -46,11 +46,11 @@ where
 
     fn on_dex_error(
         self,
-        details: ICAErrorResponse,
+        error: ErrorAck,
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> ContractResult<Response> {
-        self.handler.on_error(details, querier, env).into()
+        self.handler.on_error(error, querier, env).into()
     }
 
     fn on_dex_timeout(self, querier: QuerierWrapper<'_>, env: Env) -> ContractResult<Response> {
@@ -77,7 +77,10 @@ where
                         .and_then(|data| self.on_dex_response(data, querier, env))
                 }
                 RemoteLeaseCallback::OperationErr(error) => self.on_dex_error(
-                    ICAErrorResponse::from(error.message().as_str().to_owned()),
+                    ErrorAck::new(
+                        classify(error.kind()),
+                        ICAErrorResponse::from(error.message().as_str().to_owned()),
+                    ),
                     querier,
                     env,
                 ),
@@ -130,5 +133,15 @@ where
         _info: MessageInfo,
     ) -> ContractResult<Response> {
         super::ignore_msg(self)
+    }
+}
+
+// Project the counterparty's cause onto the coarser vocabulary the swap
+// workflow branches on. Exhaustive by construction — no wildcard arm — so a new
+// kind on the wire becomes a compile error here rather than a silent `Other`.
+const fn classify(kind: RemoteErrorKind) -> AnomalyCause {
+    match kind {
+        RemoteErrorKind::MinOutUnmet => AnomalyCause::MinOutputNotFulfilled,
+        RemoteErrorKind::Permanent | RemoteErrorKind::Transient => AnomalyCause::Other,
     }
 }

--- a/protocol/contracts/lease/src/contract/state/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/mod.rs
@@ -5,10 +5,9 @@ use serde::{Deserialize, Serialize};
 use enum_dispatch::enum_dispatch;
 
 use crate::api::LeasePaymentCurrencies;
+use ::dex::ErrorAck;
 use finance::duration::Duration;
-use platform::{
-    batch::Batch, message::Response as MessageResponse, remote::ErrorResponse as ICAErrorResponse,
-};
+use platform::{batch::Batch, message::Response as MessageResponse};
 use remote_lease::callback::RemoteLeaseCallback;
 use sdk::{
     cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply, Storage},

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/mod.rs
@@ -73,8 +73,6 @@ impl<RepayableImpl> AnomalyHandler<SellAsset<RepayableImpl, Calculator>>
 where
     RepayableImpl: Closable + Repayable,
 {
-    // Retries on every cause, including a below-floor one: this leg's
-    // calculator accepts any non-zero swap, so it has no floor to be below.
     fn on_anomaly(
         self,
         _cause: AnomalyCause,

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/customer_close/mod.rs
@@ -1,4 +1,4 @@
-use dex::{AcceptAnyNonZeroSwap, AnomalyHandler, AnomalyTreatment};
+use dex::{AcceptAnyNonZeroSwap, AnomalyCause, AnomalyHandler, AnomalyTreatment};
 use platform::message::Response as MessageResponse;
 use sdk::cosmwasm_std::{Env, QuerierWrapper};
 
@@ -73,7 +73,12 @@ impl<RepayableImpl> AnomalyHandler<SellAsset<RepayableImpl, Calculator>>
 where
     RepayableImpl: Closable + Repayable,
 {
-    fn on_anomaly(self) -> AnomalyTreatment<SellAsset<RepayableImpl, Calculator>> {
+    // Retries on every cause, including a below-floor one: this leg's
+    // calculator accepts any non-zero swap, so it has no floor to be below.
+    fn on_anomaly(
+        self,
+        _cause: AnomalyCause,
+    ) -> AnomalyTreatment<SellAsset<RepayableImpl, Calculator>> {
         AnomalyTreatment::Retry(self)
     }
 }

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/mod.rs
@@ -69,13 +69,23 @@ impl<RepayableImpl> AnomalyHandler<SellAsset<RepayableImpl, Calculator>>
 where
     RepayableImpl: Closable + Repayable,
 {
+    // The only leg with a real output floor, so the only one for which parking
+    // carries information. Slippage protection is claimed solely for a genuine
+    // below-floor rejection; any other cause is a failure of the swap itself,
+    // which the anomaly manager cannot resolve and which must not be reported
+    // to the customer as slippage.
     fn on_anomaly(
         self,
-        _cause: AnomalyCause,
+        cause: AnomalyCause,
     ) -> AnomalyTreatment<SellAsset<RepayableImpl, Calculator>> {
-        let emitter =
-            event::emit_slippage_anomaly(&self.lease.lease, self.slippage_calc.threshold());
-        let next_state = SlippageAnomaly::new(self.lease);
-        AnomalyTreatment::Exit(Ok(Response::from(emitter, next_state)))
+        match cause {
+            AnomalyCause::MinOutputNotFulfilled => {
+                let emitter =
+                    event::emit_slippage_anomaly(&self.lease.lease, self.slippage_calc.threshold());
+                let next_state = SlippageAnomaly::new(self.lease);
+                AnomalyTreatment::Exit(Ok(Response::from(emitter, next_state)))
+            }
+            AnomalyCause::Other => AnomalyTreatment::Retry(self),
+        }
     }
 }

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/mod.rs
@@ -69,11 +69,6 @@ impl<RepayableImpl> AnomalyHandler<SellAsset<RepayableImpl, Calculator>>
 where
     RepayableImpl: Closable + Repayable,
 {
-    // The only leg with a real output floor, so the only one for which parking
-    // carries information. Slippage protection is claimed solely for a genuine
-    // below-floor rejection; any other cause is a failure of the swap itself,
-    // which the anomaly manager cannot resolve and which must not be reported
-    // to the customer as slippage.
     fn on_anomaly(
         self,
         cause: AnomalyCause,

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/liquidation/mod.rs
@@ -1,4 +1,4 @@
-use dex::{AcceptUpToMaxSlippage, AnomalyHandler, AnomalyTreatment};
+use dex::{AcceptUpToMaxSlippage, AnomalyCause, AnomalyHandler, AnomalyTreatment};
 use platform::message::Response as MessageResponse;
 use sdk::cosmwasm_std::{Env, QuerierWrapper};
 
@@ -69,7 +69,10 @@ impl<RepayableImpl> AnomalyHandler<SellAsset<RepayableImpl, Calculator>>
 where
     RepayableImpl: Closable + Repayable,
 {
-    fn on_anomaly(self) -> AnomalyTreatment<SellAsset<RepayableImpl, Calculator>> {
+    fn on_anomaly(
+        self,
+        _cause: AnomalyCause,
+    ) -> AnomalyTreatment<SellAsset<RepayableImpl, Calculator>> {
         let emitter =
             event::emit_slippage_anomaly(&self.lease.lease, self.slippage_calc.threshold());
         let next_state = SlippageAnomaly::new(self.lease);

--- a/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/close/sell_asset/mod.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use dex::{
-    Account, AnomalyTreatment, ContractInSwap, Error as DexError, SlippageCalculator, Stage,
-    SwapCoins, SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
+    Account, AnomalyCause, AnomalyTreatment, ContractInSwap, Error as DexError, SlippageCalculator,
+    Stage, SwapCoins, SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
 };
 use finance::instant::Instant;
 use finance::{coin::Coin, duration::Duration};
@@ -159,11 +159,11 @@ where
         self
     }
 
-    fn on_anomaly(self) -> AnomalyTreatment<Self>
+    fn on_anomaly(self, cause: AnomalyCause) -> AnomalyTreatment<Self>
     where
         Self: Sized,
     {
-        <Self as AnomalyHandler<Self>>::on_anomaly(self)
+        <Self as AnomalyHandler<Self>>::on_anomaly(self, cause)
     }
 
     fn finish(

--- a/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
+++ b/protocol/contracts/lease/src/contract/state/opened/repay/buy_lpn.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 use dex::{
-    AcceptAnyNonZeroSwap, Account, AnomalyTreatment, ContractInSwap, Error as DexError, Stage,
-    StartLocalLocalState, SwapCoins, SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
+    AcceptAnyNonZeroSwap, Account, AnomalyCause, AnomalyTreatment, ContractInSwap,
+    Error as DexError, Stage, StartLocalLocalState, SwapCoins, SwapOutputTask, SwapTask,
+    WithCalculator, WithOutputTask,
 };
 use finance::instant::Instant;
 use finance::{coin::Coin, duration::Duration};
@@ -141,7 +142,9 @@ impl SwapOutputTask<Self> for BuyLpn {
         self
     }
 
-    fn on_anomaly(self) -> AnomalyTreatment<Self>
+    // Retries on every cause, including a below-floor one: this leg's
+    // calculator accepts any non-zero swap, so it has no floor to be below.
+    fn on_anomaly(self, _cause: AnomalyCause) -> AnomalyTreatment<Self>
     where
         Self: Sized,
     {

--- a/protocol/contracts/lease/src/contract/state/opening/buy_asset/finish.rs
+++ b/protocol/contracts/lease/src/contract/state/opening/buy_asset/finish.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use currency::{CurrencyDef, Group, MemberOf};
 use profit::stub::ProfitRef;
 
-use dex::{AnomalyTreatment, SwapOutputTask, SwapTask};
+use dex::{AnomalyCause, AnomalyTreatment, SwapOutputTask, SwapTask};
 use finance::coin::Coin;
 use platform::{
     message::Response as MessageResponse, state_machine::Response as StateMachineResponse,
@@ -54,7 +54,9 @@ where
         self.swap_task
     }
 
-    fn on_anomaly(self) -> AnomalyTreatment<BuyAsset>
+    // Retries on every cause, including a below-floor one: this leg's
+    // calculator accepts any non-zero swap, so it has no floor to be below.
+    fn on_anomaly(self, _cause: AnomalyCause) -> AnomalyTreatment<BuyAsset>
     where
         Self: Sized,
     {

--- a/protocol/contracts/lease/src/contract/state/paid/transfer_in.rs
+++ b/protocol/contracts/lease/src/contract/state/paid/transfer_in.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use currency::{CurrencyDef, Group, MemberOf};
 use dex::{
-    Account, AnomalyTreatment, ContractInSwap, Error as DexError, Stage, StartTransferInState,
-    SwapCoins, SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
+    Account, AnomalyCause, AnomalyTreatment, ContractInSwap, Error as DexError, Stage,
+    StartTransferInState, SwapCoins, SwapOutputTask, SwapTask, WithCalculator, WithOutputTask,
 };
 use finance::instant::Instant;
 use finance::{
@@ -210,7 +210,7 @@ where
         self.swap_task
     }
 
-    fn on_anomaly(self) -> AnomalyTreatment<TransferIn>
+    fn on_anomaly(self, _cause: AnomalyCause) -> AnomalyTreatment<TransferIn>
     where
         Self: Sized,
     {

--- a/protocol/contracts/leaser/Cargo.toml
+++ b/protocol/contracts/leaser/Cargo.toml
@@ -2,7 +2,7 @@ lints = { workspace = true }
 
 [package]
 name = "leaser"
-version = "0.13.1"
+version = "0.13.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/protocol/contracts/lpp/Cargo.toml
+++ b/protocol/contracts/lpp/Cargo.toml
@@ -2,7 +2,7 @@ lints = { workspace = true }
 
 [package]
 name = "lpp"
-version = "0.7.3"
+version = "0.7.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/protocol/contracts/remote_lease/Cargo.toml
+++ b/protocol/contracts/remote_lease/Cargo.toml
@@ -2,7 +2,7 @@ lints = { workspace = true }
 
 [package]
 name = "remote_lease_controller"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/protocol/contracts/reserve/Cargo.toml
+++ b/protocol/contracts/reserve/Cargo.toml
@@ -2,7 +2,7 @@ lints = { workspace = true }
 
 [package]
 name = "reserve"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/protocol/contracts/void/Cargo.toml
+++ b/protocol/contracts/void/Cargo.toml
@@ -2,7 +2,7 @@ lints = { workspace = true }
 
 [package]
 name = "void"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/protocol/packages/dex/Cargo.toml
+++ b/protocol/packages/dex/Cargo.toml
@@ -2,7 +2,7 @@ lints = { workspace = true }
 
 [package]
 name = "dex"
-version = "0.5.1"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/protocol/packages/dex/src/anomaly.rs
+++ b/protocol/packages/dex/src/anomaly.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use platform::remote::ErrorResponse as ICAErrorResponse;
+use platform::remote::ErrorDetails as RemoteErrorDetails;
 
 use crate::SwapTask;
 
@@ -31,11 +31,11 @@ pub enum Cause {
 /// value crosses no message boundary and adds nothing to any persisted layout.
 pub struct ErrorAck {
     cause: Cause,
-    details: ICAErrorResponse,
+    details: RemoteErrorDetails,
 }
 
 impl ErrorAck {
-    pub const fn new(cause: Cause, details: ICAErrorResponse) -> Self {
+    pub const fn new(cause: Cause, details: RemoteErrorDetails) -> Self {
         Self { cause, details }
     }
 
@@ -75,7 +75,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use platform::remote::ErrorResponse as ICAErrorResponse;
+    use platform::remote::ErrorDetails as RemoteErrorDetails;
 
     use super::{Cause, ErrorAck};
 
@@ -102,7 +102,7 @@ mod test {
         );
     }
 
-    fn details() -> ICAErrorResponse {
-        ICAErrorResponse::from("dex pool drained".to_owned())
+    fn details() -> RemoteErrorDetails {
+        RemoteErrorDetails::from("dex pool drained".to_owned())
     }
 }

--- a/protocol/packages/dex/src/anomaly.rs
+++ b/protocol/packages/dex/src/anomaly.rs
@@ -72,3 +72,37 @@ where
     /// alike, which is what a leg without a meaningful output floor does.
     fn on_anomaly(self, cause: Cause) -> Treatment<SwapTaskT>;
 }
+
+#[cfg(test)]
+mod test {
+    use platform::remote::ErrorResponse as ICAErrorResponse;
+
+    use super::{Cause, ErrorAck};
+
+    #[test]
+    fn cause_survives_the_wrapper() {
+        assert!(matches!(
+            ErrorAck::new(Cause::MinOutputNotFulfilled, details()).cause(),
+            Cause::MinOutputNotFulfilled
+        ));
+        assert!(matches!(
+            ErrorAck::new(Cause::Other, details()).cause(),
+            Cause::Other
+        ));
+    }
+
+    // Threading `ErrorAck` through `on_error` left every existing error message
+    // untouched only because the rendering stays the bare response. Pin it, so a
+    // later urge to prepend the cause has to break this test first.
+    #[test]
+    fn display_renders_the_response_alone() {
+        assert_eq!(
+            details().to_string(),
+            ErrorAck::new(Cause::MinOutputNotFulfilled, details()).to_string(),
+        );
+    }
+
+    fn details() -> ICAErrorResponse {
+        ICAErrorResponse::from("dex pool drained".to_owned())
+    }
+}

--- a/protocol/packages/dex/src/anomaly.rs
+++ b/protocol/packages/dex/src/anomaly.rs
@@ -1,4 +1,54 @@
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+use platform::remote::ErrorResponse as ICAErrorResponse;
+
 use crate::SwapTask;
+
+/// Why a swap was refused, as coarsely as the workflow needs to know
+///
+/// Deliberately coarser than any counterparty's own error taxonomy: this crate
+/// has exactly two treatments to choose between, so a finer split would name no
+/// distinct behaviour. Owning the type here rather than re-exporting the
+/// transport's keeps `dex` independent of a particular counterparty's error
+/// vocabulary.
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "testing", derive(Debug, PartialEq, Eq))]
+pub enum Cause {
+    /// The swap executed but could not reach the requested minimum output.
+    MinOutputNotFulfilled,
+    /// Any other refusal the counterparty reported.
+    Other,
+}
+
+/// A refused swap: why it was refused, and the counterparty's own account of it
+///
+/// The workflow branches on [`Self::cause`]; the details are carried for
+/// operator-facing troubleshooting and reach the reader through [`Display`],
+/// which renders exactly what the bare counterparty response used to.
+///
+/// Intentionally not serialisable. The error path runs synchronously inside a
+/// single message execution and never hops through `ResponseDelivery`, so this
+/// value crosses no message boundary and adds nothing to any persisted layout.
+pub struct ErrorAck {
+    cause: Cause,
+    details: ICAErrorResponse,
+}
+
+impl ErrorAck {
+    pub const fn new(cause: Cause, details: ICAErrorResponse) -> Self {
+        Self { cause, details }
+    }
+
+    pub const fn cause(&self) -> Cause {
+        self.cause
+    }
+}
+
+impl Display for ErrorAck {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        self.details.fmt(f)
+    }
+}
 
 /// The options how a detected anomaly should be treated
 ///

--- a/protocol/packages/dex/src/anomaly.rs
+++ b/protocol/packages/dex/src/anomaly.rs
@@ -68,5 +68,7 @@ pub trait Handler<SwapTaskT>
 where
     SwapTaskT: SwapTask,
 {
-    fn on_anomaly(self) -> Treatment<SwapTaskT>;
+    /// `cause` is advisory: a leg is free to ignore it and treat every anomaly
+    /// alike, which is what a leg without a meaningful output floor does.
+    fn on_anomaly(self, cause: Cause) -> Treatment<SwapTaskT>;
 }

--- a/protocol/packages/dex/src/impl_/out_local.rs
+++ b/protocol/packages/dex/src/impl_/out_local.rs
@@ -258,7 +258,7 @@ mod impl_into {
 mod impl_handler {
     use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply};
 
-    use platform::remote::ErrorResponse as ICAErrorResponse;
+    use crate::ErrorAck;
 
     use currency::Group;
 
@@ -335,33 +335,28 @@ mod impl_handler {
             }
         }
 
-        fn on_error(
-            self,
-            response: ICAErrorResponse,
-            querier: QuerierWrapper<'_>,
-            env: Env,
-        ) -> Result<Self> {
+        fn on_error(self, error: ErrorAck, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
             match self {
                 State::TransferOut(inner) => {
-                    Handler::on_error(inner, response, querier, env).map_into()
+                    Handler::on_error(inner, error, querier, env).map_into()
                 }
                 State::TransferOutRespDelivery(inner) => {
-                    Handler::on_error(inner, response, querier, env).map_into()
+                    Handler::on_error(inner, error, querier, env).map_into()
                 }
                 State::SwapExactIn(inner) => {
-                    Handler::on_error(inner, response, querier, env).map_into()
+                    Handler::on_error(inner, error, querier, env).map_into()
                 }
                 State::SwapExactInRespDelivery(inner) => {
-                    Handler::on_error(inner, response, querier, env).map_into()
+                    Handler::on_error(inner, error, querier, env).map_into()
                 }
                 State::TransferInInit(inner) => {
-                    Handler::on_error(inner, response, querier, env).map_into()
+                    Handler::on_error(inner, error, querier, env).map_into()
                 }
                 State::TransferInInitRespDelivery(inner) => {
-                    Handler::on_error(inner, response, querier, env).map_into()
+                    Handler::on_error(inner, error, querier, env).map_into()
                 }
                 State::TransferInFinish(inner) => {
-                    Handler::on_error(inner, response, querier, env).map_into()
+                    Handler::on_error(inner, error, querier, env).map_into()
                 }
             }
         }

--- a/protocol/packages/dex/src/impl_/out_remote.rs
+++ b/protocol/packages/dex/src/impl_/out_remote.rs
@@ -161,8 +161,9 @@ mod impl_into {
 }
 
 mod impl_handler {
-    use platform::remote::ErrorResponse as ICAErrorResponse;
     use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply};
+
+    use crate::ErrorAck;
 
     use currency::Group;
 
@@ -225,24 +226,19 @@ mod impl_handler {
             }
         }
 
-        fn on_error(
-            self,
-            response: ICAErrorResponse,
-            querier: QuerierWrapper<'_>,
-            env: Env,
-        ) -> Result<Self> {
+        fn on_error(self, error: ErrorAck, querier: QuerierWrapper<'_>, env: Env) -> Result<Self> {
             match self {
                 State::TransferOut(inner) => {
-                    Handler::on_error(inner, response, querier, env).map_into()
+                    Handler::on_error(inner, error, querier, env).map_into()
                 }
                 State::TransferOutRespDelivery(inner) => {
-                    Handler::on_error(inner, response, querier, env).map_into()
+                    Handler::on_error(inner, error, querier, env).map_into()
                 }
                 State::SwapExactIn(inner) => {
-                    Handler::on_error(inner, response, querier, env).map_into()
+                    Handler::on_error(inner, error, querier, env).map_into()
                 }
                 State::SwapExactInRespDelivery(inner) => {
-                    Handler::on_error(inner, response, querier, env).map_into()
+                    Handler::on_error(inner, error, querier, env).map_into()
                 }
             }
         }

--- a/protocol/packages/dex/src/impl_/swap_exact_in/mod.rs
+++ b/protocol/packages/dex/src/impl_/swap_exact_in/mod.rs
@@ -9,12 +9,12 @@ use currency::{CurrencyDTO, Group, MemberOf};
 use decode_resp::{DecodeThenFinish, DecodeThenTransferIn};
 use encode_req::EncodeRequest;
 use finance::{coin::CoinDTO, duration::Duration, instant::Instant};
-use platform::{batch::Batch, remote::ErrorResponse as ICAErrorResponse};
+use platform::batch::Batch;
 use report_anomaly::ReportAnomalyCmd;
 use sdk::cosmwasm_std::{Binary, Env, QuerierWrapper};
 
 use crate::{
-    AnomalyTreatment, Contract, ContractInSwap, Enterable,
+    AnomalyCause, AnomalyTreatment, Contract, ContractInSwap, Enterable, ErrorAck,
     RemoteLeaseTransportFactory as RemoteLeaseTransportFactoryT, Stage, SwapTask as SwapTaskT,
     TimeAlarm, TransportOutFactory as TransportOutFactoryT,
     error::Result,
@@ -87,8 +87,13 @@ where
         RemoteLeaseTransportFactoryT<TopG = <SwapTask::InG as Group>::TopG>,
     Self: Handler<Response = SEnum, SwapResult = SwapTask::Result> + Into<SEnum>,
 {
-    fn handle_error(self, querier: QuerierWrapper<'_>, env: Env) -> HandlerResult<Self> {
-        match self.spec.into_output_task(ReportAnomalyCmd::default()) {
+    fn handle_error(
+        self,
+        cause: AnomalyCause,
+        querier: QuerierWrapper<'_>,
+        env: Env,
+    ) -> HandlerResult<Self> {
+        match self.spec.into_output_task(ReportAnomalyCmd::new(cause)) {
             AnomalyTreatment::Retry(spec) => {
                 let swap_exact_in = SwapExactIn::new(spec, self.transport_factory);
                 swap_exact_in
@@ -170,11 +175,11 @@ where
 
     fn on_error(
         self,
-        _response: ICAErrorResponse,
+        error: ErrorAck,
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> HandlerResult<Self> {
-        self.handle_error(querier, env)
+        self.handle_error(error.cause(), querier, env)
     }
 
     fn on_timeout(self, querier: QuerierWrapper<'_>, env: Env) -> ContinueResult<Self> {
@@ -233,11 +238,11 @@ where
 
     fn on_error(
         self,
-        _response: ICAErrorResponse,
+        error: ErrorAck,
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> HandlerResult<Self> {
-        self.handle_error(querier, env)
+        self.handle_error(error.cause(), querier, env)
     }
 
     fn on_timeout(self, querier: QuerierWrapper<'_>, env: Env) -> ContinueResult<Self> {

--- a/protocol/packages/dex/src/impl_/swap_exact_in/report_anomaly.rs
+++ b/protocol/packages/dex/src/impl_/swap_exact_in/report_anomaly.rs
@@ -2,16 +2,22 @@ use std::marker::PhantomData;
 
 use currency::{CurrencyDef, Group, MemberOf};
 
-use crate::{AnomalyTreatment, SwapOutputTask, SwapTask as SwapTaskT, WithOutputTask};
+use crate::{
+    AnomalyCause, AnomalyTreatment, SwapOutputTask, SwapTask as SwapTaskT, WithOutputTask,
+};
 
+// No `Default`: the cause is the whole point of this command, so a causeless
+// report must not be constructible.
 pub struct ReportAnomalyCmd<SwapTask> {
+    cause: AnomalyCause,
     _spec: PhantomData<SwapTask>,
 }
 
-impl<SwapTask> Default for ReportAnomalyCmd<SwapTask> {
-    fn default() -> Self {
+impl<SwapTask> ReportAnomalyCmd<SwapTask> {
+    pub const fn new(cause: AnomalyCause) -> Self {
         Self {
-            _spec: Default::default(),
+            cause,
+            _spec: PhantomData,
         }
     }
 }
@@ -28,6 +34,6 @@ where
         OutC::Group: MemberOf<<SwapTask::OutG as Group>::TopG>,
         OutputTaskT: SwapOutputTask<SwapTask, OutC = OutC>,
     {
-        task.on_anomaly()
+        task.on_anomaly(self.cause)
     }
 }

--- a/protocol/packages/dex/src/impl_/transfer_out/mod.rs
+++ b/protocol/packages/dex/src/impl_/transfer_out/mod.rs
@@ -11,12 +11,11 @@ use finance::instant::Instant;
 use platform::{
     batch::{Batch, Emitter},
     message::Response as MessageResponse,
-    remote::ErrorResponse as ICAErrorResponse,
 };
 use sdk::cosmwasm_std::{Binary, Env, QuerierWrapper};
 
 use crate::{
-    CoinsNb, Contract, ContractInSwap, Enterable,
+    CoinsNb, Contract, ContractInSwap, Enterable, ErrorAck,
     RemoteLeaseTransportFactory as RemoteLeaseTransportFactoryT, Stage, SwapTask as SwapTaskT,
     TimeAlarm, TransportOut as TransportOutT, TransportOutFactory as TransportOutFactoryT,
     error::Result,
@@ -231,7 +230,7 @@ where
     // we cannot do anything else except keep trying to transfer again
     fn on_error(
         self,
-        _response: ICAErrorResponse,
+        _error: ErrorAck,
         querier: QuerierWrapper<'_>,
         env: Env,
     ) -> HandlerResult<Self> {

--- a/protocol/packages/dex/src/lib.rs
+++ b/protocol/packages/dex/src/lib.rs
@@ -3,7 +3,9 @@ pub use self::error::Error;
 
 pub use self::{
     account::Account,
-    anomaly::{Handler as AnomalyHandler, Treatment as AnomalyTreatment},
+    anomaly::{
+        Cause as AnomalyCause, ErrorAck, Handler as AnomalyHandler, Treatment as AnomalyTreatment,
+    },
     coins_in::SwapCoins,
     error::Result as DexResult,
     slippage::{Calculator as SlippageCalculator, WithCalculator},

--- a/protocol/packages/dex/src/response.rs
+++ b/protocol/packages/dex/src/response.rs
@@ -2,12 +2,14 @@ use std::{fmt::Display, result::Result as StdResult};
 
 use platform::{
     message::Response as MessageResponse,
-    remote::ErrorResponse as ICAErrorResponse,
     state_machine::{self, Response as StateMachineResponse},
 };
 use sdk::cosmwasm_std::{Binary, Env, MessageInfo, QuerierWrapper, Reply};
 
-use crate::error::{Error, Result as DexResult};
+use crate::{
+    ErrorAck,
+    error::{Error, Result as DexResult},
+};
 
 pub type Response<H> = StateMachineResponse<<H as Handler>::Response>;
 pub type ContinueResult<H> = DexResult<Response<H>>;
@@ -55,13 +57,8 @@ where
     }
 
     /// The entry point of an error delivery
-    fn on_error(
-        self,
-        response: ICAErrorResponse,
-        _querier: QuerierWrapper<'_>,
-        _env: Env,
-    ) -> Result<Self> {
-        Err(err(self, &format!("handle {response}"))).into()
+    fn on_error(self, error: ErrorAck, _querier: QuerierWrapper<'_>, _env: Env) -> Result<Self> {
+        Err(err(self, &format!("handle {error}"))).into()
     }
 
     /// The entry point of a timeout delivery

--- a/protocol/packages/dex/src/slippage.rs
+++ b/protocol/packages/dex/src/slippage.rs
@@ -35,7 +35,8 @@ where
     /// Determine the minimum output amount of a swap
     ///
     /// An anomaly is triggered if the output amount cannot be satisfied. The
-    /// workflow will continue as per the result of [`Policy::on_anomaly`].
+    /// workflow will continue as per the result of
+    /// [`crate::SwapOutputTask::on_anomaly`].
     fn min_output(
         &self,
         input: &CoinDTO<G>,

--- a/protocol/packages/dex/src/swap_task.rs
+++ b/protocol/packages/dex/src/swap_task.rs
@@ -4,7 +4,8 @@ use sdk::cosmwasm_std::{Env, MessageInfo, QuerierWrapper};
 use timealarms::stub::TimeAlarmsRef;
 
 use crate::{
-    Account, AnomalyTreatment, SwapCoins, error::Result as DexResult, slippage::WithCalculator,
+    Account, AnomalyCause, AnomalyTreatment, SwapCoins, error::Result as DexResult,
+    slippage::WithCalculator,
 };
 
 pub type CoinsNb = u8;
@@ -84,7 +85,7 @@ where
     /// Due to the immaturity of the DEX Swap APIs' the particular error cannot be determined.
     /// If/once the APIs' get more mature we may want to recognize the error cause.
     /// An unsatisfied minimum output amount is always assumed whenever a swap error is received.
-    fn on_anomaly(self) -> AnomalyTreatment<SwapTaskT>
+    fn on_anomaly(self, cause: AnomalyCause) -> AnomalyTreatment<SwapTaskT>
     where
         Self: Sized;
 

--- a/protocol/packages/dex/src/swap_task.rs
+++ b/protocol/packages/dex/src/swap_task.rs
@@ -77,7 +77,7 @@ where
     /// Called when an anomaly is detected
     ///
     /// Determine how the current workflow should procceed.
-    /// Simmilarly to [`SwapTask::finish`], this function may exit the current DEX swap task,
+    /// Simmilarly to [`Self::finish`], this function may exit the current DEX swap task,
     /// a state composed of TransferOut, SwapExactIn, TransferIn, etc., and transition to a next state,
     /// or ask for a retry of the last operation.
     ///
@@ -92,7 +92,7 @@ where
     ///
     /// The states involve TransferOut, SwapExactIn, TransferIn, etc. This transition originates from one of them,
     /// and should point to a next state, sibling to this one in the higher-level state machine.
-    /// For example, the DEX [`Lease::BuyAsset`] state transition to [`Lease::Active`] on finish.
+    /// For example, the DEX `Lease::BuyAsset` state transition to `Lease::Active` on finish.
     ///
     fn finish(
         self,

--- a/protocol/packages/dex/src/swap_task.rs
+++ b/protocol/packages/dex/src/swap_task.rs
@@ -82,9 +82,9 @@ where
     /// a state composed of TransferOut, SwapExactIn, TransferIn, etc., and transition to a next state,
     /// or ask for a retry of the last operation.
     ///
-    /// Due to the immaturity of the DEX Swap APIs' the particular error cannot be determined.
-    /// If/once the APIs' get more mature we may want to recognize the error cause.
-    /// An unsatisfied minimum output amount is always assumed whenever a swap error is received.
+    /// `cause` carries what the counterparty reported, so the decision no longer
+    /// has to assume an unsatisfied minimum output. A leg without a real output
+    /// floor has nothing to distinguish and may ignore it.
     fn on_anomaly(self, cause: AnomalyCause) -> AnomalyTreatment<SwapTaskT>
     where
         Self: Sized;

--- a/protocol/packages/remote_lease/Cargo.toml
+++ b/protocol/packages/remote_lease/Cargo.toml
@@ -2,7 +2,7 @@ lints = { workspace = true }
 
 [package]
 name = "remote_lease"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "admin_contract"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "access-control",
  "cosmwasm-std",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "dex"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "access-control",
  "currency",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "lease"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "access-control",
  "cosmwasm-std",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "leaser"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "access-control",
  "admin_contract",
@@ -1083,7 +1083,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "lpp"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "access-control",
  "cosmwasm-std",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "lpp-platform"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "currency",
  "finance",
@@ -1231,7 +1231,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "platform"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "currency",
  "cw-time",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "remote_lease"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "currency",
  "finance",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "remote_lease_controller"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cw-time",
  "finance",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "reserve"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "access-control",
  "cosmwasm-std",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "timealarms"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "access-control",
  "cosmwasm-std",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "treasury"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "access-control",
  "admin_contract",

--- a/tests/src/lease/close_position.rs
+++ b/tests/src/lease/close_position.rs
@@ -13,6 +13,7 @@ use lease::{
     },
     error::{ContractError, PositionError},
 };
+use remote_lease::callback::{RemoteErrorKind, RemoteLeaseCallback};
 use sdk::{
     cosmwasm_std::{Addr, Event},
     cw_multi_test::AppResponse,
@@ -22,7 +23,7 @@ use sdk::{
 use crate::common::{
     self, ADMIN, USER, lease as common_lease,
     leaser::{self, Instantiator},
-    remote_lease_controller_stub::SwapFill,
+    remote_lease_controller_stub::{self as stub, ResponseMode, SwapFill, op_tag},
     swap,
     test_case::response::ResponseWithInterChainMsgs,
 };
@@ -256,6 +257,64 @@ fn partial_close_min_transaction() {
         &ContractError::PositionError(PositionError::PositionCloseAmountTooSmall(coin
        )) if coin == LpnCoinDTO::from(min_transaction_lpn)
     ));
+}
+
+// Pins decision D7 on the customer-close sell-asset leg. Like the other
+// floorless legs it accepts any non-zero swap, so a `MinOutUnmet` ack must
+// retry rather than park; only liquidation carries a real floor and routes on
+// the cause. Asserted through the swap count and the absent anomaly event,
+// because a re-emitted swap is a `WasmMsg` and so leaves the interchain batch
+// empty either way.
+#[test]
+fn min_out_unmet_still_retries_on_customer_close() {
+    let mut test_case = super::create_test_case::<PaymentCurrency>();
+    let lease = super::open_lease(&mut test_case, DOWNPAYMENT, None);
+    let controller = test_case.address_book.remote_lease_controller().clone();
+
+    swap::set_fill(&mut test_case.app, &controller, SwapFill::InputAmount);
+    // Hold the sell-asset swap so the rejection can be driven by hand.
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+
+    let _ = send_close(
+        &mut test_case,
+        lease.clone(),
+        &ExecuteMsg::ClosePosition(PositionClose::FullClose(FullClose {})),
+    )
+    .unwrap_response();
+
+    let swaps_before = swap::count(&test_case.app, &controller);
+
+    let app_response = test_case
+        .app
+        .execute(
+            controller.clone(),
+            lease,
+            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback::OperationErr(stub::error_ack(
+                RemoteErrorKind::MinOutUnmet,
+                "ibc-solray: post-swap credit below required min",
+            ))),
+            &[],
+        )
+        .expect("a below-floor ack on a floorless leg must retry, not revert")
+        .unwrap_response();
+
+    assert_eq!(
+        swaps_before + 1,
+        swap::count(&test_case.app, &controller),
+        "the sell-asset swap must be re-emitted",
+    );
+    assert!(
+        !app_response
+            .events
+            .iter()
+            .any(|event| event.ty == "wasm-ls-slippage-anomaly"),
+        "the customer-close leg must never claim slippage protection",
+    );
 }
 
 fn do_close(

--- a/tests/src/lease/heal.rs
+++ b/tests/src/lease/heal.rs
@@ -52,6 +52,64 @@ fn active_state() {
     heal_no_inconsistency(&mut test_case.app, lease, testing::user(USER));
 }
 
+// Pins decision D7 on the repay buy-LPN leg. Its calculator accepts any
+// non-zero swap, so there is no floor for an output to fall below and a
+// `MinOutUnmet` ack must be treated exactly like any other cause — retry, never
+// park. The sibling `swap_on_repay` injects `Permanent`, which maps to
+// `AnomalyCause::Other`, so it stays green even if the below-floor cause were
+// wrongly made to park on every leg; only this injection discriminates.
+#[test]
+fn min_out_unmet_still_retries_on_repay() {
+    let mut test_case = super::create_test_case::<LeaseCurrency>();
+    let downpayment = LeaseCoin::new(10_000);
+    let lease = super::open_lease(&mut test_case, downpayment, None);
+
+    let payment = super::create_payment_coin(1_000);
+    test_case.send_funds_from_admin(testing::user(USER), &[common::cwcoin(payment)]);
+
+    let controller = test_case.address_book.remote_lease_controller().clone();
+    stub::set_response_mode(
+        &mut test_case.app,
+        &controller,
+        op_tag::SWAP,
+        ResponseMode::Delayed,
+    );
+    stub::set_swap_fill(&mut test_case.app, &controller, SwapFill::InputAmount);
+
+    () = repay::send_payment_and_transfer(&mut test_case, lease.clone(), payment)
+        .ignore_response()
+        .unwrap_response();
+
+    let swaps_before = test_swap::count(&test_case.app, &controller);
+
+    let app_response = test_case
+        .app
+        .execute(
+            controller.clone(),
+            lease,
+            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback::OperationErr(stub::error_ack(
+                RemoteErrorKind::MinOutUnmet,
+                "ibc-solray: post-swap credit below required min",
+            ))),
+            &[],
+        )
+        .expect("a below-floor ack on a floorless leg must retry, not revert")
+        .unwrap_response();
+
+    assert_eq!(
+        swaps_before + 1,
+        test_swap::count(&test_case.app, &controller),
+        "the buy-LPN swap must be re-emitted",
+    );
+    assert!(
+        !app_response
+            .events
+            .iter()
+            .any(|event| event.ty == "wasm-ls-slippage-anomaly"),
+        "the repay leg must never claim slippage protection",
+    );
+}
+
 #[test]
 fn swap_on_repay() {
     let mut test_case = super::create_test_case::<LeaseCurrency>();

--- a/tests/src/lease/remote_lease_callback.rs
+++ b/tests/src/lease/remote_lease_callback.rs
@@ -121,6 +121,36 @@ fn operation_err_reaches_on_dex_error() {
     );
 }
 
+// Pins decision D7: only the liquidation leg routes on the cause. The opening
+// buy-asset leg accepts any non-zero swap, so it has no floor to be below and a
+// `MinOutUnmet` ack must be treated exactly like any other — retry, never park.
+#[test]
+fn min_out_unmet_still_retries_on_opening() {
+    let (mut test_case, lease) = drive_to_swap_pending();
+    let controller = controller_addr(&test_case);
+
+    let response = test_case
+        .app
+        .execute(
+            controller,
+            lease.clone(),
+            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback::OperationErr(stub::error_ack(
+                RemoteErrorKind::MinOutUnmet,
+                "ibc-solray: post-swap credit below required min",
+            ))),
+            &[],
+        )
+        .expect("a below-floor ack on a floorless leg must retry, not revert");
+    () = response.ignore_response().unwrap_response();
+    assert!(
+        matches!(
+            super::state_query(&test_case, lease),
+            StateResponse::Opening { .. }
+        ),
+        "the opening leg must retry on every cause, keeping the lease opening",
+    );
+}
+
 #[test]
 fn operation_ok_finishes_buy_asset() {
     let (mut test_case, lease) = drive_to_swap_pending();

--- a/tests/src/lease/slippage.rs
+++ b/tests/src/lease/slippage.rs
@@ -167,6 +167,61 @@ fn full_liquidation_heal_full_liquidation() {
     }
 }
 
+// The counterparty rejects the held sell-asset swap for a reason that is not a
+// below-floor outcome. Parking would mislabel the lease as slippage-protected
+// and demand a privileged human for a fault they cannot fix, so the leg
+// re-emits instead and stays in liquidation.
+//
+// `expect_empty()` cannot witness any of this: a re-emitted swap is a `WasmMsg`,
+// not an interchain message, so an empty interchain batch is equally consistent
+// with parking. The swap count and the absence of the anomaly event are what
+// discriminate the two outcomes.
+#[test]
+fn full_liquidation_non_floor_cause_retries() {
+    let mut test_case = lease_mod::create_test_case::<PaymentCurrency>();
+
+    let lease = lease_mod::open_lease(&mut test_case, DOWNPAYMENT, None);
+    let controller = test_case.address_book.remote_lease_controller().clone();
+
+    trigger_full_liquidation(&mut test_case, LEASE_AMOUNT, BORROWED_AMOUNT);
+
+    let swaps_before = swap::count(&test_case.app, &controller);
+
+    let app_response = test_case
+        .app
+        .execute(
+            controller.clone(),
+            lease.clone(),
+            &ExecuteMsg::RemoteLeaseCallback(RemoteLeaseCallback::OperationErr(stub::error_ack(
+                RemoteErrorKind::Permanent,
+                "ibc-solray: jupiter route decode failed",
+            ))),
+            &[],
+        )
+        .expect("a non-floor cause must retry, not revert")
+        .unwrap_response();
+
+    assert_eq!(
+        swaps_before + 1,
+        swap::count(&test_case.app, &controller),
+        "the sell-asset swap must be re-emitted",
+    );
+    assert!(
+        !app_response
+            .events
+            .iter()
+            .any(|event| event.ty == "wasm-ls-slippage-anomaly"),
+        "a non-floor cause must not claim slippage protection",
+    );
+    assert!(matches!(
+        super::state_query(&test_case, lease),
+        StateResponse::Opened {
+            status: Status::InProgress(OngoingTrx::Liquidation { .. }),
+            ..
+        }
+    ));
+}
+
 fn trigger_full_liquidation(
     test_case: &mut LeaseTestCase,
     lease_amount: LeaseCoin,


### PR DESCRIPTION
Routes a remote swap error by **cause** instead of by **leg**. Second of the three PRs on #756; #757 landed the wire kind and the controller-side parse, and this one builds the `dex` seam and flips the liquidation leg.

Closes the ADR 0001 *"Needs on Nolus"* item (`docs/adr/0001-remove-safe-delivery-and-neutron-transport.md:103`) and its §8 Q7 (`:290`).

## The one behaviour change

The liquidation leg used to park in `SlippageAnomaly` on **any** swap error. It now parks only on a genuine below-floor rejection and re-emits on anything else.

A parse failure or an account-wiring bug is not slippage. Parking on one reported the lease as `SlippageProtectionActivated` and demanded an `anomaly_resolution_permission`-gated human for a fault that role cannot fix. Liquidation is the only leg with a real output floor, so it is the only leg where the distinction carries information — the other three use `AcceptAnyNonZeroSwap` (`min_out ≡ 1`) and keep retrying on every cause, which is decision **D7**, deliberate rather than incidental.

Everything else in this PR is plumbing that changes no behaviour.

## Commits

| commit | what |
|---|---|
| `feat(dex): add the anomaly cause seam` | `Cause` + `ErrorAck`, additive; nothing constructs them yet |
| `refactor(dex,lease): thread the anomaly cause to the on_anomaly seam` | behaviour-identical; whole suite green with **zero test edits** |
| `feat(lease): park on a below-floor cause only, retry on the rest` | the flip, one impl body |
| `refactor(platform): rename ErrorResponse to ErrorDetails` | the `ICAErrorResponse` alias stopped being true |
| `chore: bump platform and dex, and propagate up the dependency tree` | release.md rules 1 and 3 |
| `test(lease): pin D7 on the repay and customer-close legs` | the remaining two floorless legs |

## Design points worth reviewing

**`ReportAnomalyCmd::Default` is deleted.** That deletion is the compile-time guarantee: a causeless anomaly report is no longer constructible, so the only way to reach `on_anomaly` is through a classified error.

**`classify` is exhaustive with no wildcard arm** (`contract/state/dex.rs`). A new `RemoteErrorKind` on the wire becomes a compile error at the mapping site rather than a silent `Other`. It sits at the last point where anything typed still exists, before the conversion to the platform error type.

**`ErrorAck` carries no serde, and no storage version moves.** The error path runs synchronously inside one message execution and never hops through `ResponseDelivery`, which defines no `on_error` — so the value crosses no message boundary. `CONTRACT_STORAGE_VERSION` stays 10.

**`dex` stays independent of any counterparty's error vocabulary.** `Cause` is `dex`-owned, not a re-export of the wire type.

**`ErrorAck::Display` renders as the bare wrapped response.** That is what kept every existing error message byte-identical through the threading commit, and it is pinned by a unit test so a later urge to prepend the cause has to break that test first.

## On the rename

`platform::remote::ErrorResponse` was reached everywhere through an `as ICAErrorResponse` alias, which stopped being accurate once the remote-lease controller began reporting through it — that path is not an interchain account. It is now `ErrorDetails`, aliased `as RemoteErrorDetails` at import sites.

`RemoteError` was the obvious candidate and is deliberately **not** used: `remote_lease_wire::callback::RemoteError` already owns that name, and the two types meet in `contract/state/dex.rs` where the wire error is unwrapped and its prose rewrapped — the worst possible place for a collision.

The `Display` text carried the same stale assumption and, unlike a type alias, operators see it: `"ICA error with details"` became `"remote error with details"`. Nothing asserted the old string.

## Versions

Two packages broke their own public API, so each takes a minor per release.md rule 1, and rule 3 pulls every dependent along:

```
platform 0.5.0 -> 0.6.0   ErrorResponse renamed
dex      0.5.1 -> 0.6.0   Handler::on_error and both on_anomaly signatures
```

Patch elsewhere (propagation only): `lease` 0.14.0→0.14.1, `leaser`, `lpp`, `reserve`, `void`, `remote_lease`, `remote_lease_controller`, `admin_contract`, `lpp-platform`, `timealarms`, `treasury`.

`lease` is a **patch** here, unlike #757 where it took a minor: there its `ExecuteMsg` JSON shape changed, here only behaviour does. `oracle`, `profit`, `currencies`, `marketprice` and `remote_lease_wire` are outside the closure and untouched.

## Testing

Suite is 126, up from 122. Both the `protocol` and `tests` workspaces pass build → format → lint → test, and `platform` too since the rename touches it.

The threading commit is the interesting one: it passed the **entire suite with zero test-file edits**, which is the evidence it changed no behaviour.

For the flip, `expect_empty()` cannot discriminate the outcomes — a re-emitted swap is a `WasmMsg`, so the interchain batch is empty whether the leg retried or parked. The guards therefore assert the swap count rose and no `wasm-ls-slippage-anomaly` event was emitted. **Reverting the branch was confirmed to fail `full_liquidation_non_floor_cause_retries` on exactly that assertion**, so it is a real tripwire and not a test that passes either way.

Three D7 guards pin the floorless legs — opening, repay, customer close — each injecting `MinOutUnmet`, the one cause that now changes behaviour on liquidation. The pre-existing tests on those legs inject `Permanent`, which maps to `Other` and retries both before and after, so they would stay green if the below-floor cause were wrongly made to park everywhere; only these new injections discriminate.

Honest limit on those three: I tried to make the customer-close leg park, to watch its guard go red, and it would not compile — the parking machinery is not reachable from that module without new imports. So they are better described as contract pins than as tripwires against a presently-reachable bug. The liquidation test is the one with a demonstrated red state.

## Trade-offs accepted

1. **A deterministic non-floor cause now re-emits forever on the liquidation leg**, where it previously stopped. That is bad-debt exposure, not merely wasted fees. Retry stays unbounded by decision **D3**. The mitigation is structural: the seam makes adding a third arm a one-line `classify` split rather than a redesign.
2. **A `Retry` re-entry on liquidation calls `min_output`, an oracle query.** A failed quote returns `Err` and reverts the ack — newly reachable precisely because liquidation never retried before. No fix exists inside D2/D3; flagged for #660.

## Not in scope

Transfer-in and transfer-out legs, the timeout path (#660), and the counterparty half. PR-3 on `nolus-protocol/ibc-solray` is blocked on a stale pin: its `Cargo.toml:57` points at a commit that is not an ancestor of nolus `main`, which is 103 commits ahead with 4 touching `remote_lease_wire`.

Also pre-existing and untouched: #758, the missing late-ack absorber on the `SlippageAnomaly` terminal. D7 means this PR does not widen it — the terminal stays reachable from liquidation alone.
