### PR TITLE
docs(remote_lease): describe the real error-ack classification seam

### DIFF
--- a/protocol/contracts/remote_lease/src/ibc.rs
+++ b/protocol/contracts/remote_lease/src/ibc.rs
@@ -157,9 +157,8 @@ pub fn ibc_packet_timeout(
 
 // `StdAck::Error` is a bare string, so this is the single point where the
 // counterparty's failure becomes typed: the kind is parsed once here, leaving
-// consumers a value to branch on rather than prose to re-parse. No consumer
-// reads it yet — the lease still routes on the prose alone. Both fallible steps —
-// `parse_ack`'s code frame and its length cap — reject counterparty
+// consumers a value to branch on rather than prose to re-parse. Both fallible
+// steps — `parse_ack`'s code frame and its length cap — reject counterparty
 // non-conformance rather than guessing a kind. That does mean an `Err` here
 // reverts `ibc_packet_ack` (the dispatch below is a plain `add_message`) and
 // leaves the relayer redelivering, which is the intended loud failure: the two

--- a/protocol/docs/remote-lease-callback-flow.md
+++ b/protocol/docs/remote-lease-callback-flow.md
@@ -32,9 +32,12 @@ flowchart TD
         direction TB
         ExecEntry["contract::endpoins::execute → state.on_remote_lease_callback"]:::lease
         Auth["DexState&lt;H&gt;::authz_remote_lease_callback<br/>check_remote_lease_callback(h.remote_lease, info)<br/>← SingleUserPermission ↔ info.sender"]:::lease
-        Classify["classify_callback(cb) → CallbackDispatch::Response(to_json_binary(swap_resp))"]:::lease
+        Classify["inline 3-arm match on the callback<br/>OperationOk → to_json_binary(resp) → on_dex_response<br/>OperationErr → ErrorAck::new(classify(kind), details) → on_dex_error<br/>OperationTimeout → on_dex_timeout"]:::lease
         DispatchResp["on_dex_response(data) → H::on_response → SwapExactIn::on_response"]:::lease
-        ExecEntry --> Auth -->|matches| Classify --> DispatchResp
+        DispatchErr["on_dex_error(ErrorAck) → SwapExactIn::on_error → ReportAnomalyCmd(cause) → on_anomaly<br/>liquidation + MinOutputNotFulfilled → Exit → SlippageAnomaly<br/>every other leg, and every other cause → Retry, re-emitting the swap"]:::lease
+        ExecEntry --> Auth -->|matches| Classify
+        Classify -->|OperationOk| DispatchResp
+        Classify -->|OperationErr| DispatchErr
         Auth -. mismatch / no controller .-> AuthErr["DexError::Unauthorized / UnsupportedOperation<br/>← Err propagates to controller, relayer retries"]:::err
     end
 
@@ -122,13 +125,52 @@ on a permanently-unrecoverable state.
    concern of the lease + `TimeAlarms` contract. The controller is
    never invoked again for the same packet.
 
+## Error acknowledgements — the classification seam
+
+`ExecuteMsg::RemoteLeaseCallback` carries a `RemoteError { kind, message }`,
+already parsed from the acknowledgement's `[<token>] ` frame by the
+controller's `ack_to_callback` (see `docs/remote-lease-wire-contract.md`).
+`DexState<H>::on_remote_lease_callback` is where that typed value stops:
+`classify` projects the three wire kinds onto the two-valued
+`dex::AnomalyCause`, and the pair travels on as `dex::ErrorAck` — the cause
+to branch on plus a `platform::remote::ErrorDetails` for troubleshooting.
+The projection is exhaustive with no wildcard arm, so a fourth wire kind is
+a compile error here rather than a silent `Other`. Below the seam `dex`
+knows nothing of the counterparty's error vocabulary.
+
+`SwapExactIn::on_error` hands the cause to the leg through
+`ReportAnomalyCmd`, and the leg answers with an `AnomalyTreatment`:
+
+- **Liquidation sell-asset** is the only leg that reads the cause, because
+  it is the only one whose calculator quotes a real floor from the oracle.
+  `MinOutputNotFulfilled` exits to the `SlippageAnomaly` terminal, which
+  emits `ls-slippage-anomaly` and is resolvable only through the
+  anomaly-manager-gated `heal`. Any other cause retries.
+- **Opening buy-asset, repay buy-LPN, and customer / auto close** accept any
+  non-zero swap, so no output can be below their floor and every cause —
+  including `MinOutputNotFulfilled` — retries (#756, decisions D4/D6/D7).
+
+Two constraints hold the retry branch in place. It must return `Ok` and
+re-emit: the controller dispatches the callback with a plain `add_message`,
+so an `Err` reverts `ibc_packet_ack` and leaves the relayer redelivering the
+same acknowledgement forever. And it is unbounded — there is no attempt
+counter anywhere, so a deterministic non-floor cause re-emits until an
+operator intervenes.
+
+`ErrorAck` deliberately carries no serde. The error path runs synchronously
+inside one message execution and never hops through `ResponseDelivery`, so
+the cause crosses no message or storage boundary. The remaining ICA path
+(`SudoMsg::Error`, the outbound transfer-out) has no code frame to parse and
+constructs `AnomalyCause::Other`; the only leg reachable through it re-emits
+regardless of the cause.
+
 ## What changed in #141 (vs. today's SudoMsg path)
 
 | Stage | Today (SudoMsg) | After #141 (ExecuteMsg::RemoteLeaseCallback) |
 |-------|-----------------|----------------------------------------------|
 | Outer transport | `SudoMsg::Response` (chain-delivered) | `ExecuteMsg::RemoteLeaseCallback` (controller-delivered via `WasmMsg::Execute`) |
 | Auth gate | Implicit (Sudo privilege) | `info.sender == remote_lease` at `DexState::on_remote_lease_callback` |
-| Classify | `data` enters directly into `on_dex_response` | `classify_callback` projects variant → `CallbackDispatch::Response/Error/Timeout` |
+| Classify | `data` enters directly into `on_dex_response` | an inline 3-arm `match` on the callback variant → `on_dex_response` / `on_dex_error(ErrorAck)` / `on_dex_timeout` |
 | A–D safe-delivery boxes | unchanged | unchanged |
 
 ## Outbound open-side lifecycle (issue #142)


### PR DESCRIPTION
Closes the last open acceptance item of #756: the callback-flow document had to
name the classification seam that actually shipped.

## What was wrong

`protocol/docs/remote-lease-callback-flow.md:35` and `:131` named
`classify_callback` and `CallbackDispatch::{Response,Error,Timeout}`. Neither
symbol has ever existed in the tree — they are fossils of the seam #756 later
built differently — and the document described no error path at all, even though
the error path is where the whole cause-driven decision now lives.

`contracts/remote_lease/src/ibc.rs` carried a matching claim from #757: *"No
consumer reads it yet — the lease still routes on the prose alone."* The lease
has read the parsed kind since #761 landed `classify` at
`contracts/lease/src/contract/state/dex.rs:142`.

## What this changes

- The flowchart's `Classify` box shows the real inline three-arm match, with the
  `OperationErr` arm projecting the wire kind through `classify` into
  `ErrorAck`; a new node spells out the treatment — liquidation plus
  `MinOutputNotFulfilled` exits to `SlippageAnomaly`, everything else retries.
- The `#141` comparison row drops the two fossil names.
- A new *Error acknowledgements — the classification seam* section covers where
  the typed value stops, why the projection carries no wildcard arm, which leg
  reads the cause and why the other three cannot, the `Ok`-and-re-emit
  constraint on the retry branch, that the retry is unbounded, and why
  `ErrorAck` needs no serde.
- The stale sentence in `ack_to_callback`'s comment is removed.

Documentation and one comment only — no code paths touched.

## Verification

`cargo fmt --all --check` and `cargo check -p remote_lease_controller
--all-features` clean. The behaviour the new section describes was re-verified
against `e76bc31c8` before writing it: the four D7 pins, the liquidation park
and the non-floor retry all pass, as do the wire, typed-sibling and controller
byte-level tests; clippy is clean on `dex`, `lease`, `remote_lease`,
`remote_lease_wire` and `remote_lease_controller`. Full walkthrough in
https://github.com/nolus-protocol/nolus-money-market/issues/756#issuecomment-5164255074

## Left alone deliberately

The same flowchart's `Auth` box names `DexState<H>::authz_remote_lease_callback`
/ `check_remote_lease_callback`, while the code calls
`self.handler.authz_remote_callback(querier, &info)`. That drift pre-dates #756
and is out of scope here.
