### PR TITLE
test(remote_lease): take the error-ack fixtures from counterparty output

### DIFF
--- a/protocol/contracts/remote_lease/src/ibc/tests/packets.rs
+++ b/protocol/contracts/remote_lease/src/ibc/tests/packets.rs
@@ -346,9 +346,22 @@ fn fixture_stdack_success_open_lease_decodes_to_callback() {
     );
 }
 
+// Both error fixtures below are counterparty output, not authored here: the
+// bytes are what `ibc-solray`'s `app::remote_lease::ack::error` emitted at
+// `ec40d50d` for a real `api::Error` value, captured verbatim. That is what makes
+// the byte assertion a cross-repo agreement rather than a restatement of this
+// crate's own rendering — it fails if either end changes how the frame, the
+// provenance prefix or the ICS-26 envelope is composed.
+//
+// To regenerate: for the chosen `Error` variant, print
+// `ack::error(&e, OPERATION_ERR_MAX_BYTES).as_bytes()` from that tree and
+// replace the `.bin` plus the prose below.
 #[test]
 fn fixture_stdack_error_decodes_to_callback() {
-    const FIXTURE_ACK: &str = "[permanent] dex pool drained";
+    // `Error::SwapAmountInMismatch { expected: 1_000, got: 999 }` — a
+    // `Disposition::PermanentInput` variant, so it frames as `permanent`.
+    const FIXTURE_ACK: &str =
+        "[permanent] ibc-solray: Swap amount_in mismatch: expected '1000', got '999'";
     const ACK_BYTES: &[u8] = include_bytes!("../../../tests/fixtures/stdack_error.bin");
 
     let computed = StdAck::error(FIXTURE_ACK).to_binary();
@@ -360,7 +373,7 @@ fn fixture_stdack_error_decodes_to_callback() {
 
     assert_error_ack_dispatches(
         RemoteErrorKind::Permanent,
-        "dex pool drained",
+        "ibc-solray: Swap amount_in mismatch: expected '1000', got '999'",
         "lease-fixture-err",
         FIXTURE_ACK,
     );
@@ -368,7 +381,10 @@ fn fixture_stdack_error_decodes_to_callback() {
 
 #[test]
 fn fixture_stdack_error_min_out_decodes_to_callback() {
-    const FIXTURE_ACK: &str = "[min_out_unmet] ibc-solray: credit below min";
+    // `Error::SwapPostBalanceCreditBelowMin { min_required: 42, got: 41 }` — the
+    // post-CPI floor check, which the counterparty frames as `min_out_unmet`
+    // despite its `Disposition::Stale` class.
+    const FIXTURE_ACK: &str = "[min_out_unmet] ibc-solray: Swap post-balance credit below required min: min_required '42', got '41'";
     const ACK_BYTES: &[u8] = include_bytes!("../../../tests/fixtures/stdack_error_min_out.bin");
 
     let computed = StdAck::error(FIXTURE_ACK).to_binary();
@@ -380,7 +396,7 @@ fn fixture_stdack_error_min_out_decodes_to_callback() {
 
     assert_error_ack_dispatches(
         RemoteErrorKind::MinOutUnmet,
-        "ibc-solray: credit below min",
+        "ibc-solray: Swap post-balance credit below required min: min_required '42', got '41'",
         "lease-fixture-err-min-out",
         FIXTURE_ACK,
     );

--- a/protocol/contracts/remote_lease/tests/fixtures/stdack_error.bin
+++ b/protocol/contracts/remote_lease/tests/fixtures/stdack_error.bin
@@ -1,1 +1,1 @@
-{"error":"[permanent] dex pool drained"}
+{"error":"[permanent] ibc-solray: Swap amount_in mismatch: expected '1000', got '999'"}

--- a/protocol/contracts/remote_lease/tests/fixtures/stdack_error_min_out.bin
+++ b/protocol/contracts/remote_lease/tests/fixtures/stdack_error_min_out.bin
@@ -1,1 +1,1 @@
-{"error":"[min_out_unmet] ibc-solray: credit below min"}
+{"error":"[min_out_unmet] ibc-solray: Swap post-balance credit below required min: min_required '42', got '41'"}


### PR DESCRIPTION
Closes #762.

Both `stdack_error*.bin` fixtures were hand-authored in this repository, so the
byte assertion beside them compared this crate's `StdAck` rendering against bytes
derived from that same rendering. Nothing anywhere proved the two ends of the
protocol agree on what an error acknowledgement looks like.

Now they hold what `ibc-solray`'s `app::remote_lease::ack::error` actually emits
at `ec40d50d`, captured verbatim for two real `api::Error` values:

- `SwapPostBalanceCreditBelowMin { min_required: 42, got: 41 }` — the post-CPI
  floor check, framed `min_out_unmet`
- `SwapAmountInMismatch { expected: 1_000, got: 999 }` — a
  `Disposition::PermanentInput` variant, framed `permanent`

Both parse, classify and dispatch through the real `ibc_packet_ack`, and both
match `StdAck::error(..).to_binary()` byte for byte — which is the result worth
having: cosmwasm's ICS-26 envelope and ibc-rs's `AcknowledgementStatus::error`
render identically, the frame survives at offset zero ahead of the counterparty's
own `ibc-solray: ` provenance prefix, and the prose lands inside the 200-byte cap
once the frame is stripped. The assertion now fails if either repository changes
how it composes any of that.

The provenance and a regeneration recipe sit next to the fixtures, so the next
reader can tell which bytes are real and how to refresh them.

Worth noting for the record: the counterparty caps the **whole** composed string
at `OPERATION_ERR_MAX_BYTES`, while this side applies the cap to the prose after
stripping the frame. The counterparty is therefore strictly the more conservative
of the two — no acknowledgement it can emit is rejected here for length.

## Verification

`cargo fmt --all --check`, `cargo clippy --all-features --all-targets -p
remote_lease_controller` clean, `cargo test -p remote_lease_controller
--all-features` green (77 passed).
