### PR TITLE
docs(lpp): point borrow rate reference at docs.nolus.io

### DIFF
--- a/protocol/contracts/lpp/src/borrow.rs
+++ b/protocol/contracts/lpp/src/borrow.rs
@@ -55,7 +55,7 @@ impl InterestRate {
         self.addon_optimal_interest_rate
     }
 
-    /// For more ref see: https://hub.nolus.io/en/articles/9680324-borrow
+    /// For more ref see: https://docs.nolus.io/docs/protocol/borrowing/opening
     pub fn calculate<Lpn>(&self, total_liability: Coin<Lpn>, balance: Coin<Lpn>) -> Percent100 {
         // TODO migrate to using SimpleFraction once it starts implementing Ord
         let utilization_factor_max = self.utilization_factor_max();


### PR DESCRIPTION
The linked Intercom article (hub.nolus.io/en/articles/9680324-borrow) was removed when the help-center Tech Documentation collection was retired in favor of docs.nolus.io. The interest-rate model this comment references is documented at https://docs.nolus.io/docs/protocol/borrowing/opening (Base Rate + Utilization/Optimal x Add-on Rate), which matches what `calculate` implements. Comment-only change.